### PR TITLE
Add `cacert_file` and `insecure` options to the provider.

### DIFF
--- a/gitlab/config.go
+++ b/gitlab/config.go
@@ -1,18 +1,49 @@
 package gitlab
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/xanzy/go-gitlab"
 )
 
 // Config is per-provider, specifies where to connect to gitlab
 type Config struct {
-	Token   string
-	BaseURL string
+	Token      string
+	BaseURL    string
+	Insecure   bool
+	CACertFile string
 }
 
 // Client returns a *gitlab.Client to interact with the configured gitlab instance
 func (c *Config) Client() (interface{}, error) {
-	client := gitlab.NewClient(nil, c.Token)
+	// Configure TLS/SSL
+	tlsConfig := &tls.Config{}
+
+	// If a CACertFile has been specified, use that for cert validation
+	if c.CACertFile != "" {
+		caCert, err := ioutil.ReadFile(c.CACertFile)
+		if err != nil {
+			return nil, err
+		}
+
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	// If configured as insecure, turn off SSL verification
+	if c.Insecure {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
+
+	httpClient := &http.Client{Transport: transport}
+
+	client := gitlab.NewClient(httpClient, c.Token)
 	if c.BaseURL != "" {
 		err := client.SetBaseURL(c.BaseURL)
 		if err != nil {

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -23,6 +23,18 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("GITLAB_BASE_URL", ""),
 				Description: descriptions["base_url"],
 			},
+			"cacert_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: descriptions["cacert_file"],
+			},
+			"insecure": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["insecure"],
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"gitlab_group":        resourceGitlabGroup(),
@@ -42,13 +54,19 @@ func init() {
 		"token": "The OAuth token used to connect to GitLab.",
 
 		"base_url": "The GitLab Base API URL",
+
+		"cacert_file": "A file containing the ca certificate to use in case ssl certificate is not from a standard chain",
+
+		"insecure": "Disable SSL verification of API calls",
 	}
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		Token:   d.Get("token").(string),
-		BaseURL: d.Get("base_url").(string),
+		Token:      d.Get("token").(string),
+		BaseURL:    d.Get("base_url").(string),
+		CACertFile: d.Get("cacert_file").(string),
+		Insecure:   d.Get("insecure").(bool),
 	}
 
 	return config.Client()

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -65,3 +65,9 @@ The following arguments are supported in the `provider` block:
   requirement when working with GitLab CE or GitLab Enterprise e.g. https://my.gitlab.server/api/v3/.
   It is optional to provide this value and it can also be sourced from the `GITLAB_BASE_URL` environment variable.
   The value must end with a slash.
+
+* `cacert_file` - (Optional) This is a file containing the ca cert to verify the gitlab instance.  This is available
+  for use when working with GitLab CE or Gitlab Enterprise with a locally-issued or self-signed certificate chain.
+
+* `insecure` - (Optional; boolean, defaults to false) When set to true this disables SSL verification of the connection to the
+  GitLab instance.


### PR DESCRIPTION
These settings can be used to configure the level of SSL verification
performed by the provider.

* `cacert_file` allows for the provision of an alternate ca cert, for
locally-signed or self-signed operations.
* `insecure` allows SSL verification to be turned off completely.  It is
not suggested as a first option.

Targets https://github.com/terraform-providers/terraform-provider-gitlab/issues/4