### PR TITLE
Meatball fix of gitlab_project_hook tests.

### DIFF
--- a/gitlab/resource_gitlab_project_hook.go
+++ b/gitlab/resource_gitlab_project_hook.go
@@ -89,10 +89,13 @@ func resourceGitlabProjectHookCreate(d *schema.ResourceData, meta interface{}) e
 		MergeRequestsEvents:   gitlab.Bool(d.Get("merge_requests_events").(bool)),
 		TagPushEvents:         gitlab.Bool(d.Get("tag_push_events").(bool)),
 		NoteEvents:            gitlab.Bool(d.Get("note_events").(bool)),
-		BuildEvents:           gitlab.Bool(d.Get("build_events").(bool)),
 		PipelineEvents:        gitlab.Bool(d.Get("pipeline_events").(bool)),
 		WikiPageEvents:        gitlab.Bool(d.Get("wiki_page_events").(bool)),
 		EnableSSLVerification: gitlab.Bool(d.Get("enable_ssl_verification").(bool)),
+	}
+
+	if v, ok := d.GetOk("build_events"); ok {
+		options.BuildEvents = gitlab.Bool(v.(bool))
 	}
 
 	if v, ok := d.GetOk("token"); ok {
@@ -158,10 +161,13 @@ func resourceGitlabProjectHookUpdate(d *schema.ResourceData, meta interface{}) e
 		MergeRequestsEvents:   gitlab.Bool(d.Get("merge_requests_events").(bool)),
 		TagPushEvents:         gitlab.Bool(d.Get("tag_push_events").(bool)),
 		NoteEvents:            gitlab.Bool(d.Get("note_events").(bool)),
-		BuildEvents:           gitlab.Bool(d.Get("build_events").(bool)),
 		PipelineEvents:        gitlab.Bool(d.Get("pipeline_events").(bool)),
 		WikiPageEvents:        gitlab.Bool(d.Get("wiki_page_events").(bool)),
 		EnableSSLVerification: gitlab.Bool(d.Get("enable_ssl_verification").(bool)),
+	}
+
+	if d.HasChange("build_events") {
+		options.BuildEvents = gitlab.Bool(d.Get("build_events").(bool))
 	}
 
 	if d.HasChange("token") {

--- a/gitlab/resource_gitlab_project_hook_test.go
+++ b/gitlab/resource_gitlab_project_hook_test.go
@@ -44,7 +44,6 @@ func TestAccGitlabProjectHook_basic(t *testing.T) {
 						MergeRequestsEvents:   true,
 						TagPushEvents:         true,
 						NoteEvents:            true,
-						BuildEvents:           true,
 						PipelineEvents:        true,
 						WikiPageEvents:        true,
 						EnableSSLVerification: false,
@@ -212,7 +211,6 @@ resource "gitlab_project_hook" "foo" {
   merge_requests_events = true
   tag_push_events = true
   note_events = true
-  build_events = true
   pipeline_events = true
   wiki_page_events = true
 }


### PR DESCRIPTION
Here we treat gitlab_project_hook#build_events as optional, which they
were before, it was just more succinct in the code to act as though they
weren't, as it's a simple boolean attribute..

Also we stop testing for it so it won't 500 the gitlab API between 9.3.0
and release containing
https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/12673

This won't fix the underlying issue that the gitlab 9.3.0 broke the
handling of the build_events attribute of project hooks, but it will
allow the CI to run green again.