### PR TITLE
gitlab_group: support parent_id field

### DIFF
--- a/gitlab/resource_gitlab_group.go
+++ b/gitlab/resource_gitlab_group.go
@@ -48,6 +48,12 @@ func resourceGitlabGroup() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice([]string{"private", "internal", "public"}, true),
 			},
+			"parent_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  0,
+			},
 		},
 	}
 }
@@ -70,6 +76,10 @@ func resourceGitlabGroupCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("visibility_level"); ok {
 		options.Visibility = stringToVisibilityLevel(v.(string))
+	}
+
+	if v, ok := d.GetOk("parent_id"); ok {
+		options.ParentID = gitlab.Int(v.(int))
 	}
 
 	log.Printf("[DEBUG] create gitlab group %q", options.Name)
@@ -105,6 +115,7 @@ func resourceGitlabGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("lfs_enabled", group.LFSEnabled)
 	d.Set("request_access_enabled", group.RequestAccessEnabled)
 	d.Set("visibility_level", group.Visibility)
+	d.Set("parent_id", group.ParentID)
 
 	return nil
 }

--- a/vendor/github.com/xanzy/go-gitlab/groups.go
+++ b/vendor/github.com/xanzy/go-gitlab/groups.go
@@ -38,15 +38,16 @@ type Group struct {
 	Name                 string             `json:"name"`
 	Path                 string             `json:"path"`
 	Description          string             `json:"description"`
+	Visibility           *VisibilityValue   `json:"visibility"`
+	LFSEnabled           bool               `json:"lfs_enabled"`
 	AvatarURL            string             `json:"avatar_url"`
+	WebURL               string             `json:"web_url"`
+	RequestAccessEnabled bool               `json:"request_access_enabled"`
 	FullName             string             `json:"full_name"`
 	FullPath             string             `json:"full_path"`
-	LFSEnabled           bool               `json:"lfs_enabled"`
+	ParentID             int                `json:"parent_id"`
 	Projects             []*Project         `json:"projects"`
 	Statistics           *StorageStatistics `json:"statistics"`
-	RequestAccessEnabled bool               `json:"request_access_enabled"`
-	Visibility           *VisibilityValue   `json:"visibility"`
-	WebURL               string             `json:"web_url"`
 }
 
 // ListGroupsOptions represents the available ListGroups() options.

--- a/vendor/github.com/xanzy/go-gitlab/merge_requests.go
+++ b/vendor/github.com/xanzy/go-gitlab/merge_requests.go
@@ -333,8 +333,8 @@ func (s *MergeRequestsService) GetMergeRequestChanges(pid interface{}, mergeRequ
 type CreateMergeRequestOptions struct {
 	Title           *string `url:"title,omitempty" json:"title,omitempty"`
 	Description     *string `url:"description,omitempty" json:"description,omitempty"`
-	SourceBranch    *string `url:"source_branch,omitemtpy" json:"source_branch,omitemtpy"`
-	TargetBranch    *string `url:"target_branch,omitemtpy" json:"target_branch,omitemtpy"`
+	SourceBranch    *string `url:"source_branch,omitempty" json:"source_branch,omitempty"`
+	TargetBranch    *string `url:"target_branch,omitempty" json:"target_branch,omitempty"`
 	AssigneeID      *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
 	TargetProjectID *int    `url:"target_project_id,omitempty" json:"target_project_id,omitempty"`
 }
@@ -372,7 +372,7 @@ func (s *MergeRequestsService) CreateMergeRequest(pid interface{}, opt *CreateMe
 type UpdateMergeRequestOptions struct {
 	Title        *string `url:"title,omitempty" json:"title,omitempty"`
 	Description  *string `url:"description,omitempty" json:"description,omitempty"`
-	TargetBranch *string `url:"target_branch,omitemtpy" json:"target_branch,omitemtpy"`
+	TargetBranch *string `url:"target_branch,omitempty" json:"target_branch,omitempty"`
 	AssigneeID   *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
 	Labels       Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
 	MilestoneID  *int    `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -585,10 +585,10 @@
 			"revisionTime": "2016-09-27T10:08:44Z"
 		},
 		{
-			"checksumSHA1": "NGUUV3ypJQQXQMy+grgMxuTyC/Y=",
+			"checksumSHA1": "rBRMciteJAFVf9xWMXbMbXbJrzM=",
 			"path": "github.com/xanzy/go-gitlab",
-			"revision": "b3ac6922c154579c76836ccd3ab66f377986202c",
-			"revisionTime": "2017-09-22T13:45:23Z"
+			"revision": "d11d546f58c67430417f975b453f44f280474a4d",
+			"revisionTime": "2017-09-24T15:03:35Z"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",

--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -48,6 +48,8 @@ enable users to request access to the group.
   Valid values are `private`, `internal`, `public`.
   Groups are created as private by default.
 
+* `parent_id` - (Optional) Integer, id of the parent group (creates a nested group).
+
 ## Attributes Reference
 
 The resource exports the following attributes:


### PR DESCRIPTION
Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-gitlab	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccGitlabDeployKey_basic
--- PASS: TestAccGitlabDeployKey_basic (6.06s)
=== RUN   TestAccGitlabGroup_basic
--- PASS: TestAccGitlabGroup_basic (0.59s)
=== RUN   TestAccGitlabGroup_nested
--- FAIL: TestAccGitlabGroup_nested (0.93s)
	testing.go:435: Step 2 error: Error applying: 1 error(s) occurred:
		
		* gitlab_group.nested_foo: gitlab_group.nested_foo: diffs didn't match during apply. This is a bug with Terraform and should be reported as a GitHub Issue.
		
		Please include the following information in your report:
		
		    Terraform Version: 0.10.0
		    Resource ID: gitlab_group.nested_foo
		    Mismatch reason: diff RequiresNew; old: true, new: false
		    Diff One (usually from plan): *terraform.InstanceDiff{mu:sync.Mutex{state:0, sema:0x0}, Attributes:map[string]*terraform.ResourceAttrDiff{"path":*terraform.ResourceAttrDiff{Old:"nfoo-path-4455425876977035609", New:"nfoo-path-4455425876977035609", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}, "description":*terraform.ResourceAttrDiff{Old:"Terraform acceptance tests - new parent", New:"Terraform acceptance tests - updated", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}, "lfs_enabled":*terraform.ResourceAttrDiff{Old:"true", New:"true", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}, "parent_id":*terraform.ResourceAttrDiff{Old:"129", New:"0", NewComputed:false, NewRemoved:true, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "request_access_enabled":*terraform.ResourceAttrDiff{Old:"false", New:"false", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}, "visibility_level":*terraform.ResourceAttrDiff{Old:"public", New:"public", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}, "name":*terraform.ResourceAttrDiff{Old:"nfoo-name-4455425876977035609", New:"nfoo-name-4455425876977035609", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}}, Destroy:false, DestroyDeposed:false, DestroyTainted:false, Meta:map[string]interface {}(nil)}
		    Diff Two (usually from apply): *terraform.InstanceDiff{mu:sync.Mutex{state:0, sema:0x0}, Attributes:map[string]*terraform.ResourceAttrDiff{"lfs_enabled":*terraform.ResourceAttrDiff{Old:"", New:"true", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}, "request_access_enabled":*terraform.ResourceAttrDiff{Old:"", New:"false", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}, "visibility_level":*terraform.ResourceAttrDiff{Old:"", New:"public", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}, "name":*terraform.ResourceAttrDiff{Old:"", New:"nfoo-name-4455425876977035609", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}, "path":*terraform.ResourceAttrDiff{Old:"", New:"nfoo-path-4455425876977035609", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}, "description":*terraform.ResourceAttrDiff{Old:"", New:"Terraform acceptance tests - updated", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}}, Destroy:false, DestroyDeposed:false, DestroyTainted:false, Meta:map[string]interface {}(nil)}
		
		Also include as much context as you can about your config, state, and the steps you performed to trigger this error.
		
=== RUN   TestAccGitlabProjectHook_basic
--- PASS: TestAccGitlabProjectHook_basic (5.96s)
=== RUN   TestAccGitlabProject_basic
--- PASS: TestAccGitlabProject_basic (5.94s)
=== RUN   TestGitlab_validation
--- PASS: TestGitlab_validation (0.00s)
=== RUN   TestGitlab_visbilityHelpers
--- PASS: TestGitlab_visbilityHelpers (0.00s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-gitlab/gitlab	19.489s
make: *** [GNUmakefile:15: testacc] Error 1
```