### PR TITLE
Fix and document importing projects

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -94,6 +94,7 @@ func resourceGitlabProject() *schema.Resource {
 }
 
 func resourceGitlabProjectSetToState(d *schema.ResourceData, project *gitlab.Project) {
+	d.SetId(fmt.Sprintf("%d", project.ID))
 	d.Set("name", project.Name)
 	d.Set("path", project.Path)
 	d.Set("description", project.Description)

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -63,3 +63,13 @@ The following additional attributes are exported:
   repository via HTTP.
 
 * `web_url` - URL that can be used to find the project in a browser.
+
+## Importing projects
+
+You can import a project state using `terraform import <resource> <id>`.  The
+`id` can be whatever the [get single project api](get_single_project) takes for
+its `:id` value, so for example:
+
+    terraform import gitlab_project.example richardc/example
+
+[get_single_project]: https://docs.gitlab.com/ee/api/projects.html#get-single-project


### PR DESCRIPTION
As noted in #35, when importing a project we were not updating the ID to
be the primary key id, so if a project was imported with `terraform
import gitlab_project.foo user/foo` it was kept in the state as
`user/foo` rather than the underlying id.

Here we fix that up, and add some documentation indicating that this
resource is importable (towards #36)