### PR TITLE
Fix and document importing groups

### DIFF
--- a/gitlab/resource_gitlab_group.go
+++ b/gitlab/resource_gitlab_group.go
@@ -109,6 +109,7 @@ func resourceGitlabGroupRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	d.SetId(fmt.Sprintf("%d", group.ID))
 	d.Set("name", group.Name)
 	d.Set("path", group.Path)
 	d.Set("description", group.Description)

--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -56,3 +56,13 @@ The resource exports the following attributes:
 
 * `id` - The unique id assigned to the group by the GitLab server.  Serves as a
   namespace id where one is needed.
+
+## Importing groups
+
+You can import a group state using `terraform import <resource> <id>`.  The
+`id` can be whatever the [details of a group](details_of_a_group) api takes for
+its `:id` value, so for example:
+
+    terraform import gitlab_group.example example
+
+[details_of_a_group]: https://docs.gitlab.com/ee/api/groups.html#details-of-a-group


### PR DESCRIPTION
As noted in #35, when importing a group we were not updating the ID to
be the primary key id, so if a group was imported with `terraform
import gitlab_group.foo foo` it was kept in the state as
`foo` rather than the underlying id.

Here we fix that up, and add some documentation indicating that this
resource is importable (towards #36)

Closes #35, basically a copy of #37 