### PR TITLE
Add support for importing users

### DIFF
--- a/gitlab/resource_gitlab_user.go
+++ b/gitlab/resource_gitlab_user.go
@@ -15,6 +15,9 @@ func resourceGitlabUser() *schema.Resource {
 		Read:   resourceGitlabUserRead,
 		Update: resourceGitlabUserUpdate,
 		Delete: resourceGitlabUserDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"username": {

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -51,3 +51,11 @@ for the user.
 The resource exports the following attributes:
 
 * `id` - The unique id assigned to the user by the GitLab server.
+
+## Importing users
+
+You can import a user to terraform state using `terraform import <resource> <id>`.
+The `id` must be an integer for the id of the user you want to import,
+for example:
+
+    terraform import gitlab_user.example 42


### PR DESCRIPTION
Here we add basic support for importing users to state.   Ideally we
would be able to import by username, as there is an api to find users by
username[1], but this is not currently exposed by go-gitlab[2]

Towards #36

[1] https://docs.gitlab.com/ee/api/users.html#list-users documents
	/users?username=:username which worked well in manual testing.

[2] https://github.com/xanzy/go-gitlab/blob/master/users.go#L97-L99