### PR TITLE
Fixes error when updating default branch

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -183,7 +183,7 @@ func resourceGitlabProjectUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("default_branch") {
-		options.DefaultBranch = gitlab.String(d.Get("description").(string))
+		options.DefaultBranch = gitlab.String(d.Get("default_branch").(string))
 	}
 
 	if d.HasChange("visibility_level") {
@@ -235,10 +235,9 @@ func resourceGitlabProjectDelete(d *schema.ResourceData, meta interface{}) error
 			if err != nil {
 				if response.StatusCode == 404 {
 					return out, "Deleted", nil
-				} else {
-					log.Printf("[ERROR] Received error: %#v", err)
-					return out, "Error", err
 				}
+				log.Printf("[ERROR] Received error: %#v", err)
+				return out, "Error", err
 			}
 			return out, "Deleting", nil
 		},


### PR DESCRIPTION
Updating the default branch caused the build to fail because it was inadvertently set to update the branch to the project description.

I attempted to write some tests for this case, but it's quite difficult. Gitlab returns `null` for the default branch until the first commit is pushed up to a repo, and the default branch can't be changed to another branch until that branch exists in Gitlab. However, by default, the `master` branch is the default branch when creating a new project. All makes sense, but, writing a test case means that a project needs to be created, the repo needs to exist and it needs to have multiple branches. I can help try and write it, but it's hard to fit it all into a single test step.