### PR TITLE
Add gitlab_users datasource

### DIFF
--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -1,0 +1,103 @@
+package gitlab
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func dataSourceGitlabUsers() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGitlabUsersRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "all_users",
+			},
+			"users": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"username": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"email": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_admin": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"can_create_group": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"can_create_project": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"projects_limit": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGitlabUsersRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	users, _, err := client.Users.ListUsers(nil)
+	if err != nil {
+		return err
+	}
+
+	d.Set("users", flattenGitlabUsers(users))
+	d.SetId(d.Get("name").(string))
+
+	return nil
+}
+
+func flattenGitlabUsers(users []*gitlab.User) []interface{} {
+	usersList := []interface{}{}
+
+	for _, user := range users {
+		values := map[string]interface{}{
+			"username":           user.Username,
+			"email":              user.Email,
+			"name":               user.Name,
+			"is_admin":           user.IsAdmin,
+			"can_create_group":   user.CanCreateGroup,
+			"can_create_project": user.CanCreateProject,
+			"projects_limit":     user.ProjectsLimit,
+			"state":              user.State,
+		}
+
+		if user.CreatedAt != nil {
+			values["created_at"] = user.CreatedAt.String()
+		}
+
+		usersList = append(usersList, values)
+	}
+
+	return usersList
+}

--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -1,6 +1,11 @@
 package gitlab
 
 import (
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -11,25 +16,62 @@ func dataSourceGitlabUsers() *schema.Resource {
 		Read: dataSourceGitlabUsersRead,
 
 		Schema: map[string]*schema.Schema{
-			"order_by": {
-				Type:     schema.TypeString,
+			"options": {
+				Type:     schema.TypeList,
 				Optional: true,
-				Default:  "id",
-				ValidateFunc: validation.StringInSlice([]string{"id", "name",
-					"username", "created_at"}, true),
-			},
-			"sort": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "desc",
-				ValidateFunc: validation.StringInSlice([]string{"desc", "asc"}, true),
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"order_by": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "id",
+							ValidateFunc: validation.StringInSlice([]string{"id", "name",
+								"username", "created_at"}, true),
+						},
+						"sort": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "desc",
+							ValidateFunc: validation.StringInSlice([]string{"desc", "asc"}, true),
+						},
+						"search": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"active": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"blocked": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"extern_uid": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"provider": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"created_before": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"created_after": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
 			},
 			"users": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": {
+						"user_id": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
@@ -73,6 +115,18 @@ func dataSourceGitlabUsers() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"extern_uid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"organization": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"two_factor_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -83,21 +137,20 @@ func dataSourceGitlabUsers() *schema.Resource {
 func dataSourceGitlabUsersRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
-	orderBy := d.Get("order_by").(string)
-	sort := d.Get("sort").(string)
-	listUsersOptions := &gitlab.ListUsersOptions{
-		OrderBy: &orderBy,
-		Sort:    &sort,
+	listUsersOptions, id, err := expandGitlabUsersOptions(d.Get("options").([]interface{}))
+	if err != nil {
+		return err
 	}
-
+	log.Printf("\n\n\nListOptions\n%v\n\n\n", listUsersOptions)
 	users, _, err := client.Users.ListUsers(listUsersOptions)
+	log.Printf("\n\n\nListUsers\n%v\n\n\n", users)
+
 	if err != nil {
 		return err
 	}
 
 	d.Set("users", flattenGitlabUsers(users))
-	id := "all_users_" + orderBy + "_" + sort
-	d.SetId(id)
+	d.SetId(fmt.Sprintf("%d", id))
 
 	return nil
 }
@@ -107,7 +160,7 @@ func flattenGitlabUsers(users []*gitlab.User) []interface{} {
 
 	for _, user := range users {
 		values := map[string]interface{}{
-			"id":                 user.ID,
+			"user_id":            user.ID,
 			"username":           user.Username,
 			"email":              user.Email,
 			"name":               user.Name,
@@ -117,14 +170,76 @@ func flattenGitlabUsers(users []*gitlab.User) []interface{} {
 			"projects_limit":     user.ProjectsLimit,
 			"state":              user.State,
 			"external":           user.External,
+			"extern_uid":         user.ExternUID,
+			"organization":       user.Organization,
+			"two_factor_enabled": user.TwoFactorEnabled,
 		}
 
 		if user.CreatedAt != nil {
-			values["created_at"] = user.CreatedAt.String()
+			values["created_at"] = user.CreatedAt
 		}
 
 		usersList = append(usersList, values)
 	}
 
 	return usersList
+}
+
+func expandGitlabUsersOptions(d []interface{}) (*gitlab.ListUsersOptions, int, error) {
+	if len(d) == 0 {
+		return nil, 0, nil
+	}
+
+	data := d[0].(map[string]interface{})
+	listUsersOptions := &gitlab.ListUsersOptions{}
+	options := ""
+
+	if orderBy := data["order_by"].(string); orderBy != "" {
+		listUsersOptions.OrderBy = &orderBy
+		options += orderBy
+	}
+	if sort := data["sort"].(string); sort != "" {
+		listUsersOptions.Sort = &sort
+		options += sort
+	}
+	if search := data["search"].(string); search != "" {
+		listUsersOptions.Search = &search
+		options += search
+	}
+	if active := data["active"].(bool); active != false {
+		listUsersOptions.Active = &active
+		options += strconv.FormatBool(active)
+	}
+	if blocked := data["blocked"].(bool); blocked != false {
+		listUsersOptions.Blocked = &blocked
+		options += strconv.FormatBool(blocked)
+	}
+	if externalUID := data["extern_uid"].(string); externalUID != "" {
+		listUsersOptions.ExternalUID = &externalUID
+		options += externalUID
+	}
+	if provider := data["provider"].(string); provider != "" {
+		// listUsersOptions.Provider = &provider
+		options += provider
+	}
+	if createdBefore := data["created_before"].(string); createdBefore != "" {
+		date, err := time.Parse("2006-01-02", createdBefore)
+		if err != nil {
+			return nil, 0, fmt.Errorf("created_before must be in yyyy-mm-dd format")
+		}
+		listUsersOptions.CreatedBefore = &date
+		options += createdBefore
+	}
+	if createdAfter := data["created_after"].(string); createdAfter != "" {
+		// date, err := time.Parse("2006-01-02", createdAfter)
+		// if err != nil {
+		// 	return nil, 0, fmt.Errorf("created_after must be in yyyy-mm-dd format")
+		// }
+		// listUsersOptions.CreatedAfter = &date
+		options += createdAfter
+	}
+
+	id := schema.HashString(options)
+
+	return listUsersOptions, id, nil
 }

--- a/gitlab/data_source_gitlab_users_test.go
+++ b/gitlab/data_source_gitlab_users_test.go
@@ -1,0 +1,27 @@
+package gitlab
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceGitlabUsers_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeLbIpRangesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.gitlab_users.test",
+						"users.#", regexp.MustCompile("^[1-9]*$"))),
+			},
+		},
+	})
+}
+
+const testAccComputeLbIpRangesConfig = `
+data "gitlab_users" "test" {}
+`

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -48,6 +48,9 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_deploy_key":   resourceGitlabDeployKey(),
 			"gitlab_user":         resourceGitlabUser(),
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"gitlab_users": dataSourceGitlabUsers(),
+		},
 
 		ConfigureFunc: providerConfigure,
 	}

--- a/gitlab/resource_gitlab_label.go
+++ b/gitlab/resource_gitlab_label.go
@@ -66,7 +66,7 @@ func resourceGitlabLabelRead(d *schema.ResourceData, meta interface{}) error {
 	labelName := d.Id()
 	log.Printf("[DEBUG] read gitlab label %s/%s", project, labelName)
 
-	labels, response, err := client.Labels.ListLabels(project)
+	labels, response, err := client.Labels.ListLabels(project, nil)
 	if err != nil {
 		if response.StatusCode == 404 {
 			log.Printf("[WARN] removing label %s from state because it no longer exists in gitlab", labelName)

--- a/gitlab/resource_gitlab_label_test.go
+++ b/gitlab/resource_gitlab_label_test.go
@@ -73,7 +73,7 @@ func testAccCheckGitlabLabelExists(n string, label *gitlab.Label) resource.TestC
 		}
 		conn := testAccProvider.Meta().(*gitlab.Client)
 
-		labels, _, err := conn.Labels.ListLabels(repoName)
+		labels, _, err := conn.Labels.ListLabels(repoName, nil)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/claranet/terraform-provider-gitlab/gitlab"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/terraform-providers/terraform-provider-gitlab/gitlab"
 )
 
 func main() {

--- a/vendor/github.com/xanzy/go-gitlab/README.md
+++ b/vendor/github.com/xanzy/go-gitlab/README.md
@@ -2,8 +2,12 @@
 
 A GitLab API client enabling Go programs to interact with GitLab in a simple and uniform way
 
-**Documentation:** [![GoDoc](https://godoc.org/github.com/xanzy/go-gitlab?status.svg)](https://godoc.org/github.com/xanzy/go-gitlab)
-**Build Status:** [![Build Status](https://travis-ci.org/xanzy/go-gitlab.svg?branch=master)](https://travis-ci.org/xanzy/go-gitlab)
+[![Build Status](https://travis-ci.org/xanzy/go-gitlab.svg?branch=master)](https://travis-ci.org/xanzy/go-gitlab)
+[![GitHub license](https://img.shields.io/github/license/xanzy/go-gitlab.svg)](https://github.com/xanzy/go-gitlab/blob/master/LICENSE)
+[![Sourcegraph](https://sourcegraph.com/github.com/xanzy/go-gitlab/-/badge.svg)](https://sourcegraph.com/github.com/xanzy/go-gitlab?badge)
+[![GoDoc](https://godoc.org/github.com/xanzy/go-gitlab?status.svg)](https://godoc.org/github.com/xanzy/go-gitlab)
+[![Go Report Card](https://goreportcard.com/badge/github.com/xanzy/go-gitlab)](https://goreportcard.com/report/github.com/xanzy/go-gitlab)
+[![GitHub issues](https://img.shields.io/github/issues/xanzy/go-gitlab.svg)](https://github.com/xanzy/go-gitlab/issues)
 
 ## NOTE
 
@@ -13,30 +17,62 @@ incompatible changes that were needed to fully support the V4 Gitlab API.
 
 ## Coverage
 
-This API client package covers **100%** of the existing GitLab API calls! So this
-includes all calls to the following services:
+This API client package covers most of the existing Gitlab API calls and is updated regularly
+to add new and/or missing endpoints. Currently the following services are supported:
 
-- [x] Users
-- [x] Session
+- [x] Award Emojis
+- [x] Branches
+- [x] Broadcast Messages
+- [ ] Project-level Variables
+- [ ] Group-level Variables
+- [x] Commits
+- [ ] Custom Attributes
+- [x] Deployments
+- [x] Deploy Keys
+- [x] Environments
+- [x] Events
+- [x] Feature flags
+- [x] Gitignores templates
+- [ ] GitLab CI Config templates
+- [x] Groups
+- [ ] Group Access Requests
+- [ ] Group Members
+- [x] Issues
+- [x] Issue Boards
+- [x] Jobs
+- [ ] Keys
+- [x] Labels
+- [x] Merge Requests
+- [x] Project Milestones
+- [ ] Group Milestones
+- [x] Namespaces
+- [x] Notes (comments)
+- [x] Notification settings
+- [ ] Open source license templates
+- [x] Page Domains
+- [x] Pipelines
+- [x] Pipeline Triggers
+- [x] Pipeline Schedules
 - [x] Projects (including setting Webhooks)
+- [ ] Project Access Requests
+- [x] Project Members
 - [x] Project Snippets
-- [x] Services
+- [x] Protected Branches
 - [x] Repositories
 - [x] Repository Files
-- [x] Commits
-- [x] Branches
-- [x] Merge Requests
-- [x] Issues
-- [x] Labels
-- [x] Milestones
-- [x] Notes (comments)
-- [x] Deploy Keys
-- [x] System Hooks
-- [x] Groups
-- [x] Namespaces
+- [x] Runners
+- [ ] Search
+- [x] Services
 - [x] Settings
-- [x] Pipelines
+- [x] Sidekiq metrics
+- [x] Session
+- [x] System Hooks
+- [x] Tags
+- [x] Todos
+- [x] Users
+- [x] Validate CI configuration
 - [x] Version
+- [x] Wikis
 
 ## Usage
 

--- a/vendor/github.com/xanzy/go-gitlab/award_emojis.go
+++ b/vendor/github.com/xanzy/go-gitlab/award_emojis.go
@@ -1,0 +1,460 @@
+//
+// Copyright 2017, Arkbriar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// AwardEmojiService handles communication with the emoji awards related methods
+// of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/award_emoji.html
+type AwardEmojiService struct {
+	client *Client
+}
+
+// AwardEmoji represents a GitLab Award Emoji.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/award_emoji.html
+type AwardEmoji struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+	User struct {
+		Name      string `json:"name"`
+		Username  string `json:"username"`
+		ID        int    `json:"id"`
+		State     string `json:"state"`
+		AvatarURL string `json:"avatar_url"`
+		WebURL    string `json:"web_url"`
+	} `json:"user"`
+	CreatedAt     *time.Time `json:"created_at"`
+	UpdatedAt     *time.Time `json:"updated_at"`
+	AwardableID   int        `json:"awardable_id"`
+	AwardableType string     `json:"awardable_type"`
+}
+
+const (
+	awardMergeRequest = "merge_requests"
+	awardIssue        = "issues"
+	awardSnippets     = "snippets"
+)
+
+// ListEmojiAwardsOptions represents the available options for listing emoji
+// for each resources
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html
+type ListEmojiAwardsOptions ListOptions
+
+// ListMergeRequestAwardEmoji gets a list of all award emoji on the merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+func (s *AwardEmojiService) ListMergeRequestAwardEmoji(pid interface{}, mergeRequestIID int, opt *ListEmojiAwardsOptions, options ...OptionFunc) ([]*AwardEmoji, *Response, error) {
+	return s.listAwardEmoji(pid, awardMergeRequest, mergeRequestIID, opt, options...)
+}
+
+// ListIssueAwardEmoji gets a list of all award emoji on the issue.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+func (s *AwardEmojiService) ListIssueAwardEmoji(pid interface{}, issueIID int, opt *ListEmojiAwardsOptions, options ...OptionFunc) ([]*AwardEmoji, *Response, error) {
+	return s.listAwardEmoji(pid, awardIssue, issueIID, opt, options...)
+}
+
+// ListSnippetAwardEmoji gets a list of all award emoji on the snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+func (s *AwardEmojiService) ListSnippetAwardEmoji(pid interface{}, snippetID int, opt *ListEmojiAwardsOptions, options ...OptionFunc) ([]*AwardEmoji, *Response, error) {
+	return s.listAwardEmoji(pid, awardSnippets, snippetID, opt, options...)
+}
+
+func (s *AwardEmojiService) listAwardEmoji(pid interface{}, resource string, resourceID int, opt *ListEmojiAwardsOptions, options ...OptionFunc) ([]*AwardEmoji, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/%s/%d/award_emoji",
+		url.QueryEscape(project),
+		resource,
+		resourceID,
+	)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var as []*AwardEmoji
+	resp, err := s.client.Do(req, &as)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return as, resp, err
+}
+
+// GetMergeRequestAwardEmoji get an award emoji from merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+func (s *AwardEmojiService) GetMergeRequestAwardEmoji(pid interface{}, mergeRequestIID, awardID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	return s.getAwardEmoji(pid, awardMergeRequest, mergeRequestIID, awardID, options...)
+}
+
+// GetIssueAwardEmoji get an award emoji from issue.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+func (s *AwardEmojiService) GetIssueAwardEmoji(pid interface{}, issueIID, awardID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	return s.getAwardEmoji(pid, awardIssue, issueIID, awardID, options...)
+}
+
+// GetSnippetAwardEmoji get an award emoji from snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+func (s *AwardEmojiService) GetSnippetAwardEmoji(pid interface{}, snippetID, awardID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	return s.getAwardEmoji(pid, awardSnippets, snippetID, awardID, options...)
+}
+
+func (s *AwardEmojiService) getAwardEmoji(pid interface{}, resource string, resourceID, awardID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/%s/%d/award_emoji/%d",
+		url.QueryEscape(project),
+		resource,
+		resourceID,
+		awardID,
+	)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(AwardEmoji)
+	resp, err := s.client.Do(req, &a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}
+
+// CreateMergeRequestAwardEmoji get an award emoji from merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji
+func (s *AwardEmojiService) CreateMergeRequestAwardEmoji(pid interface{}, mergeRequestIID, awardID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	return s.createAwardEmoji(pid, awardMergeRequest, mergeRequestIID, awardID, options...)
+}
+
+// CreateIssueAwardEmoji get an award emoji from issue.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji
+func (s *AwardEmojiService) CreateIssueAwardEmoji(pid interface{}, issueIID, awardID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	return s.createAwardEmoji(pid, awardIssue, issueIID, awardID, options...)
+}
+
+// CreateSnippetAwardEmoji get an award emoji from snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji
+func (s *AwardEmojiService) CreateSnippetAwardEmoji(pid interface{}, snippetID, awardID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	return s.createAwardEmoji(pid, awardSnippets, snippetID, awardID, options...)
+}
+
+func (s *AwardEmojiService) createAwardEmoji(pid interface{}, resource string, resourceID, awardID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/%s/%d/award_emoji/%d",
+		url.QueryEscape(project),
+		resource,
+		resourceID,
+		awardID,
+	)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(AwardEmoji)
+	resp, err := s.client.Do(req, &a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}
+
+// DeleteIssueAwardEmoji delete award emoji on an issue.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji-on-a-note
+func (s *AwardEmojiService) DeleteIssueAwardEmoji(pid interface{}, issueIID, awardID int, options ...OptionFunc) (*Response, error) {
+	return s.deleteAwardEmoji(pid, awardMergeRequest, issueIID, awardID, options...)
+}
+
+// DeleteMergeRequestAwardEmoji delete award emoji on a merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji-on-a-note
+func (s *AwardEmojiService) DeleteMergeRequestAwardEmoji(pid interface{}, mergeRequestIID, awardID int, options ...OptionFunc) (*Response, error) {
+	return s.deleteAwardEmoji(pid, awardMergeRequest, mergeRequestIID, awardID, options...)
+}
+
+// DeleteSnippetAwardEmoji delete award emoji on a snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji-on-a-note
+func (s *AwardEmojiService) DeleteSnippetAwardEmoji(pid interface{}, snippetID, awardID int, options ...OptionFunc) (*Response, error) {
+	return s.deleteAwardEmoji(pid, awardMergeRequest, snippetID, awardID, options...)
+}
+
+// DeleteAwardEmoji Delete an award emoji on the specified resource.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#delete-an-award-emoji
+func (s *AwardEmojiService) deleteAwardEmoji(pid interface{}, resource string, resourceID, awardID int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/%s/%d/award_emoji/%d", url.QueryEscape(project), resource,
+		resourceID, awardID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// ListIssuesAwardEmojiOnNote gets a list of all award emoji on a note from the
+// issue.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+func (s *AwardEmojiService) ListIssuesAwardEmojiOnNote(pid interface{}, issueID, noteID int, opt *ListEmojiAwardsOptions, options ...OptionFunc) ([]*AwardEmoji, *Response, error) {
+	return s.listAwardEmojiOnNote(pid, awardIssue, issueID, noteID, opt, options...)
+}
+
+// ListMergeRequestAwardEmojiOnNote gets a list of all award emoji on a note
+// from the merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+func (s *AwardEmojiService) ListMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID, noteID int, opt *ListEmojiAwardsOptions, options ...OptionFunc) ([]*AwardEmoji, *Response, error) {
+	return s.listAwardEmojiOnNote(pid, awardMergeRequest, mergeRequestIID, noteID, opt, options...)
+}
+
+// ListSnippetAwardEmojiOnNote gets a list of all award emoji on a note from the
+// snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+func (s *AwardEmojiService) ListSnippetAwardEmojiOnNote(pid interface{}, snippetIID, noteID int, opt *ListEmojiAwardsOptions, options ...OptionFunc) ([]*AwardEmoji, *Response, error) {
+	return s.listAwardEmojiOnNote(pid, awardSnippets, snippetIID, noteID, opt, options...)
+}
+
+func (s *AwardEmojiService) listAwardEmojiOnNote(pid interface{}, resources string, ressourceID, noteID int, opt *ListEmojiAwardsOptions, options ...OptionFunc) ([]*AwardEmoji, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/%s/%d/notes/%d/award_emoji", url.QueryEscape(project), resources,
+		ressourceID, noteID)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var as []*AwardEmoji
+	resp, err := s.client.Do(req, &as)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return as, resp, err
+}
+
+// GetIssuesAwardEmojiOnNote gets an award emoji on a note from an issue.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+func (s *AwardEmojiService) GetIssuesAwardEmojiOnNote(pid interface{}, issueID, noteID, awardID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	return s.getSingleNoteAwardEmoji(pid, awardIssue, issueID, noteID, awardID, options...)
+}
+
+// GetMergeRequestAwardEmojiOnNote gets an award emoji on a note from a
+// merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+func (s *AwardEmojiService) GetMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID, noteID, awardID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	return s.getSingleNoteAwardEmoji(pid, awardMergeRequest, mergeRequestIID, noteID, awardID,
+		options...)
+}
+
+// GetSnippetAwardEmojiOnNote gets an award emoji on a note from a snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+func (s *AwardEmojiService) GetSnippetAwardEmojiOnNote(pid interface{}, snippetIID, noteID, awardID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	return s.getSingleNoteAwardEmoji(pid, awardSnippets, snippetIID, noteID, awardID, options...)
+}
+
+func (s *AwardEmojiService) getSingleNoteAwardEmoji(pid interface{}, ressource string, resourceID, noteID, awardID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/%s/%d/notes/%d/award_emoji/%d",
+		url.QueryEscape(project),
+		ressource,
+		resourceID,
+		noteID,
+		awardID,
+	)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(AwardEmoji)
+	resp, err := s.client.Do(req, &a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}
+
+// CreateIssuesAwardEmojiOnNote gets an award emoji on a note from an issue.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+func (s *AwardEmojiService) CreateIssuesAwardEmojiOnNote(pid interface{}, issueID, noteID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	return s.createAwardEmojiOnNote(pid, awardIssue, issueID, noteID, options...)
+}
+
+// CreateMergeRequestAwardEmojiOnNote gets an award emoji on a note from a
+// merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+func (s *AwardEmojiService) CreateMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID, noteID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	return s.createAwardEmojiOnNote(pid, awardMergeRequest, mergeRequestIID, noteID, options...)
+}
+
+// CreateSnippetAwardEmojiOnNote gets an award emoji on a note from a snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+func (s *AwardEmojiService) CreateSnippetAwardEmojiOnNote(pid interface{}, snippetIID, noteID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	return s.createAwardEmojiOnNote(pid, awardSnippets, snippetIID, noteID, options...)
+}
+
+// CreateAwardEmojiOnNote award emoji on a note.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji-on-a-note
+func (s *AwardEmojiService) createAwardEmojiOnNote(pid interface{}, resource string, resourceID, noteID int, options ...OptionFunc) (*AwardEmoji, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/%s/%d/notes/%d/award_emoji",
+		url.QueryEscape(project),
+		resource,
+		resourceID,
+		noteID,
+	)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(AwardEmoji)
+	resp, err := s.client.Do(req, &a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}
+
+// DeleteIssuesAwardEmojiOnNote deletes an award emoji on a note from an issue.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+func (s *AwardEmojiService) DeleteIssuesAwardEmojiOnNote(pid interface{}, issueID, noteID, awardID int, options ...OptionFunc) (*Response, error) {
+	return s.deleteAwardEmojiOnNote(pid, awardIssue, issueID, noteID, awardID, options...)
+}
+
+// DeleteMergeRequestAwardEmojiOnNote deletes an award emoji on a note from a
+// merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+func (s *AwardEmojiService) DeleteMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID, noteID, awardID int, options ...OptionFunc) (*Response, error) {
+	return s.deleteAwardEmojiOnNote(pid, awardMergeRequest, mergeRequestIID, noteID, awardID,
+		options...)
+}
+
+// DeleteSnippetAwardEmojiOnNote deletes an award emoji on a note from a snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+func (s *AwardEmojiService) DeleteSnippetAwardEmojiOnNote(pid interface{}, snippetIID, noteID, awardID int, options ...OptionFunc) (*Response, error) {
+	return s.deleteAwardEmojiOnNote(pid, awardSnippets, snippetIID, noteID, awardID, options...)
+}
+
+func (s *AwardEmojiService) deleteAwardEmojiOnNote(pid interface{}, resource string, resourceID, noteID, awardID int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/%s/%d/notes/%d/award_emoji/%d",
+		url.QueryEscape(project),
+		resource,
+		resourceID,
+		noteID,
+		awardID,
+	)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/xanzy/go-gitlab/boards.go
+++ b/vendor/github.com/xanzy/go-gitlab/boards.go
@@ -1,0 +1,261 @@
+//
+// Copyright 2015, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// IssueBoardsService handles communication with the issue board related
+// methods of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html
+type IssueBoardsService struct {
+	client *Client
+}
+
+// IssueBoard represents a GitLab issue board.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html
+type IssueBoard struct {
+	ID        int          `json:"id"`
+	Name      string       `json:"name"`
+	Project   *Project     `json:"project"`
+	Milestone *Milestone   `json:"milestone"`
+	Lists     []*BoardList `json:"lists"`
+}
+
+func (b IssueBoard) String() string {
+	return Stringify(b)
+}
+
+// BoardList represents a GitLab board list.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html
+type BoardList struct {
+	ID       int      `json:"id"`
+	Labels   []*Label `json:"labels"`
+	Position int      `json:"position"`
+}
+
+func (b BoardList) String() string {
+	return Stringify(b)
+}
+
+// ListIssueBoardsOptions represents the available ListIssueBoards() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#project-board
+type ListIssueBoardsOptions ListOptions
+
+// ListIssueBoards gets a list of all issue boards in a project.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#project-board
+func (s *IssueBoardsService) ListIssueBoards(pid interface{}, opt *ListIssueBoardsOptions, options ...OptionFunc) ([]*IssueBoard, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/boards", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var is []*IssueBoard
+	resp, err := s.client.Do(req, &is)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return is, resp, err
+}
+
+// GetIssueBoard gets a single issue board of a project.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#single-board
+func (s *IssueBoardsService) GetIssueBoard(pid interface{}, board int, options ...OptionFunc) (*IssueBoard, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/boards/%d", url.QueryEscape(project), board)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ib := new(IssueBoard)
+	resp, err := s.client.Do(req, ib)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ib, resp, err
+}
+
+// GetIssueBoardListsOptions represents the available GetIssueBoardLists() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#list-board-lists
+type GetIssueBoardListsOptions ListOptions
+
+// GetIssueBoardLists gets a list of the issue board's lists. Does not include
+// backlog and closed lists.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#list-board-lists
+func (s *IssueBoardsService) GetIssueBoardLists(pid interface{}, board int, opt *GetIssueBoardListsOptions, options ...OptionFunc) ([]*BoardList, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/boards/%d/lists", url.QueryEscape(project), board)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var bl []*BoardList
+	resp, err := s.client.Do(req, &bl)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return bl, resp, err
+}
+
+// GetIssueBoardList gets a single issue board list.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#single-board-list
+func (s *IssueBoardsService) GetIssueBoardList(pid interface{}, board, list int, options ...OptionFunc) (*BoardList, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/boards/%d/lists/%d",
+		url.QueryEscape(project),
+		board,
+		list,
+	)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bl := new(BoardList)
+	resp, err := s.client.Do(req, bl)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return bl, resp, err
+}
+
+// CreateIssueBoardListOptions represents the available CreateIssueBoardList()
+// options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#new-board-list
+type CreateIssueBoardListOptions struct {
+	LabelID *int `url:"label_id" json:"label_id"`
+}
+
+// CreateIssueBoardList creates a new issue board list.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#new-board-list
+func (s *IssueBoardsService) CreateIssueBoardList(pid interface{}, board int, opt *CreateIssueBoardListOptions, options ...OptionFunc) (*BoardList, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/boards/%d/lists", url.QueryEscape(project), board)
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bl := new(BoardList)
+	resp, err := s.client.Do(req, bl)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return bl, resp, err
+}
+
+// UpdateIssueBoardListOptions represents the available UpdateIssueBoardList()
+// options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#edit-board-list
+type UpdateIssueBoardListOptions struct {
+	Position *int `url:"position" json:"position"`
+}
+
+// UpdateIssueBoardList updates the position of an existing issue board list.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#edit-board-list
+func (s *IssueBoardsService) UpdateIssueBoardList(pid interface{}, board, list int, opt *UpdateIssueBoardListOptions, options ...OptionFunc) (*BoardList, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/boards/%d/lists/%d",
+		url.QueryEscape(project),
+		board,
+		list,
+	)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bl := new(BoardList)
+	resp, err := s.client.Do(req, bl)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return bl, resp, err
+}
+
+// DeleteIssueBoardList soft deletes an issue board list. Only for admins and
+// project owners.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/boards.html#delete-a-board-list
+func (s *IssueBoardsService) DeleteIssueBoardList(pid interface{}, board, list int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/boards/%d/lists/%d",
+		url.QueryEscape(project),
+		board,
+		list,
+	)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/xanzy/go-gitlab/branches.go
+++ b/vendor/github.com/xanzy/go-gitlab/branches.go
@@ -49,9 +49,7 @@ func (b Branch) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/branches.html#list-repository-branches
-type ListBranchesOptions struct {
-	ListOptions
-}
+type ListBranchesOptions ListOptions
 
 // ListBranches gets a list of repository branches from a project, sorted by
 // name alphabetically.
@@ -88,7 +86,7 @@ func (s *BranchesService) GetBranch(pid interface{}, branch string, options ...O
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/branches/%s", url.QueryEscape(project), branch)
+	u := fmt.Sprintf("projects/%s/repository/branches/%s", url.QueryEscape(project), url.QueryEscape(branch))
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -124,7 +122,7 @@ func (s *BranchesService) ProtectBranch(pid interface{}, branch string, opts *Pr
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/branches/%s/protect", url.QueryEscape(project), branch)
+	u := fmt.Sprintf("projects/%s/repository/branches/%s/protect", url.QueryEscape(project), url.QueryEscape(branch))
 
 	req, err := s.client.NewRequest("PUT", u, opts, options)
 	if err != nil {
@@ -151,7 +149,7 @@ func (s *BranchesService) UnprotectBranch(pid interface{}, branch string, option
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/branches/%s/unprotect", url.QueryEscape(project), branch)
+	u := fmt.Sprintf("projects/%s/repository/branches/%s/unprotect", url.QueryEscape(project), url.QueryEscape(branch))
 
 	req, err := s.client.NewRequest("PUT", u, nil, options)
 	if err != nil {
@@ -210,7 +208,7 @@ func (s *BranchesService) DeleteBranch(pid interface{}, branch string, options .
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/branches/%s", url.QueryEscape(project), branch)
+	u := fmt.Sprintf("projects/%s/repository/branches/%s", url.QueryEscape(project), url.QueryEscape(branch))
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/broadcast_messages.go
+++ b/vendor/github.com/xanzy/go-gitlab/broadcast_messages.go
@@ -1,0 +1,172 @@
+//
+// Copyright 2018, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"time"
+)
+
+// BroadcastMessagesService handles communication with the broadcast
+// messages methods of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/broadcast_messages.html
+type BroadcastMessagesService struct {
+	client *Client
+}
+
+// BroadcastMessage represents a GitLab issue board.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/broadcast_messages.html#get-all-broadcast-messages
+type BroadcastMessage struct {
+	Message  string     `json:"message"`
+	StartsAt *time.Time `json:"starts_at"`
+	EndsAt   *time.Time `json:"ends_at"`
+	Color    string     `json:"color"`
+	Font     string     `json:"font"`
+	ID       int        `json:"id"`
+	Active   bool       `json:"active"`
+}
+
+// ListBroadcastMessagesOptions represents the available ListBroadcastMessages()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/broadcast_messages.html#get-all-broadcast-messages
+type ListBroadcastMessagesOptions ListOptions
+
+// ListBroadcastMessages gets a list of all broadcasted messages.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/broadcast_messages.html#get-all-broadcast-messages
+func (s *BroadcastMessagesService) ListBroadcastMessages(opt *ListBroadcastMessagesOptions, options ...OptionFunc) ([]*BroadcastMessage, *Response, error) {
+	req, err := s.client.NewRequest("GET", "broadcast_messages", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var bs []*BroadcastMessage
+	resp, err := s.client.Do(req, &bs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return bs, resp, err
+}
+
+// GetBroadcastMessage gets a single broadcast message.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/broadcast_messages.html#get-a-specific-broadcast-message
+func (s *BroadcastMessagesService) GetBroadcastMessage(broadcast int, options ...OptionFunc) (*BroadcastMessage, *Response, error) {
+	u := fmt.Sprintf("broadcast_messages/%d", broadcast)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	b := new(BroadcastMessage)
+	resp, err := s.client.Do(req, &b)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return b, resp, err
+}
+
+// CreateBroadcastMessageOptions represents the available CreateBroadcastMessage()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/broadcast_messages.html#create-a-broadcast-message
+type CreateBroadcastMessageOptions struct {
+	Message  *string    `url:"message" json:"message"`
+	StartsAt *time.Time `url:"starts_at,omitempty" json:"starts_at,omitempty"`
+	EndsAt   *time.Time `url:"ends_at,omitempty" json:"ends_at,omitempty"`
+	Color    *string    `url:"color,omitempty" json:"color,omitempty"`
+	Font     *string    `url:"font,omitempty" json:"font,omitempty"`
+}
+
+// CreateBroadcastMessage creates a message to broadcast.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/broadcast_messages.html#create-a-broadcast-message
+func (s *BroadcastMessagesService) CreateBroadcastMessage(opt *CreateBroadcastMessageOptions, options ...OptionFunc) (*BroadcastMessage, *Response, error) {
+	req, err := s.client.NewRequest("POST", "broadcast_messages", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	b := new(BroadcastMessage)
+	resp, err := s.client.Do(req, &b)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return b, resp, err
+}
+
+// UpdateBroadcastMessageOptions represents the available CreateBroadcastMessage()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/broadcast_messages.html#update-a-broadcast-message
+type UpdateBroadcastMessageOptions struct {
+	Message  *string    `url:"message,omitempty" json:"message,omitempty"`
+	StartsAt *time.Time `url:"starts_at,omitempty" json:"starts_at,omitempty"`
+	EndsAt   *time.Time `url:"ends_at,omitempty" json:"ends_at,omitempty"`
+	Color    *string    `url:"color,omitempty" json:"color,omitempty"`
+	Font     *string    `url:"font,omitempty" json:"font,omitempty"`
+}
+
+// UpdateBroadcastMessage update a broadcasted message.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/broadcast_messages.html#update-a-broadcast-message
+func (s *BroadcastMessagesService) UpdateBroadcastMessage(broadcast int, opt *UpdateBroadcastMessageOptions, options ...OptionFunc) (*BroadcastMessage, *Response, error) {
+	u := fmt.Sprintf("broadcast_messages/%d", broadcast)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	b := new(BroadcastMessage)
+	resp, err := s.client.Do(req, &b)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return b, resp, err
+}
+
+// DeleteBroadcastMessage deletes a broadcasted message.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/broadcast_messages.html#delete-a-broadcast-message
+func (s *BroadcastMessagesService) DeleteBroadcastMessage(broadcast int, options ...OptionFunc) (*Response, error) {
+	u := fmt.Sprintf("broadcast_messages/%d", broadcast)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/xanzy/go-gitlab/build_variables.go
+++ b/vendor/github.com/xanzy/go-gitlab/build_variables.go
@@ -30,9 +30,7 @@ func (v BuildVariable) String() string {
 //
 // Gitlab API Docs:
 // https://docs.gitlab.com/ce/api/build_variables.html#list-project-variables
-type ListBuildVariablesOptions struct {
-	ListOptions
-}
+type ListBuildVariablesOptions ListOptions
 
 // ListBuildVariables gets the a list of project variables in a project
 //

--- a/vendor/github.com/xanzy/go-gitlab/commits.go
+++ b/vendor/github.com/xanzy/go-gitlab/commits.go
@@ -34,20 +34,20 @@ type CommitsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html
 type Commit struct {
-	ID             string       `json:"id"`
-	ShortID        string       `json:"short_id"`
-	Title          string       `json:"title"`
-	AuthorName     string       `json:"author_name"`
-	AuthorEmail    string       `json:"author_email"`
-	AuthoredDate   *time.Time   `json:"authored_date"`
-	CommitterName  string       `json:"committer_name"`
-	CommitterEmail string       `json:"committer_email"`
-	CommittedDate  *time.Time   `json:"committed_date"`
-	CreatedAt      *time.Time   `json:"created_at"`
-	Message        string       `json:"message"`
-	ParentIDs      []string     `json:"parent_ids"`
-	Stats          *CommitStats `json:"stats"`
-	Status         *BuildState  `json:"status"`
+	ID             string           `json:"id"`
+	ShortID        string           `json:"short_id"`
+	Title          string           `json:"title"`
+	AuthorName     string           `json:"author_name"`
+	AuthorEmail    string           `json:"author_email"`
+	AuthoredDate   *time.Time       `json:"authored_date"`
+	CommitterName  string           `json:"committer_name"`
+	CommitterEmail string           `json:"committer_email"`
+	CommittedDate  *time.Time       `json:"committed_date"`
+	CreatedAt      *time.Time       `json:"created_at"`
+	Message        string           `json:"message"`
+	ParentIDs      []string         `json:"parent_ids"`
+	Stats          *CommitStats     `json:"stats"`
+	Status         *BuildStateValue `json:"status"`
 }
 
 // CommitStats represents the number of added and deleted files in a commit.
@@ -150,6 +150,7 @@ func (s *CommitsService) GetCommit(pid interface{}, sha string, options ...Optio
 type CreateCommitOptions struct {
 	Branch        *string         `url:"branch" json:"branch"`
 	CommitMessage *string         `url:"commit_message" json:"commit_message"`
+	StartBranch   *string         `url:"start_branch,omitempty" json:"start_branch,omitempty"`
 	Actions       []*CommitAction `url:"actions" json:"actions"`
 	AuthorEmail   *string         `url:"author_email,omitempty" json:"author_email,omitempty"`
 	AuthorName    *string         `url:"author_name,omitempty" json:"author_name,omitempty"`
@@ -197,18 +198,24 @@ func (d Diff) String() string {
 	return Stringify(d)
 }
 
+// GetCommitDiffOptions represents the available GetCommitDiff() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/commits.html#get-the-diff-of-a-commit
+type GetCommitDiffOptions ListOptions
+
 // GetCommitDiff gets the diff of a commit in a project..
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/commits.html#get-the-diff-of-a-commit
-func (s *CommitsService) GetCommitDiff(pid interface{}, sha string, options ...OptionFunc) ([]*Diff, *Response, error) {
+func (s *CommitsService) GetCommitDiff(pid interface{}, sha string, opt *GetCommitDiffOptions, options ...OptionFunc) ([]*Diff, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/commits/%s/diff", url.QueryEscape(project), sha)
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -248,18 +255,24 @@ func (c CommitComment) String() string {
 	return Stringify(c)
 }
 
+// GetCommitCommentsOptions represents the available GetCommitComments() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/commits.html#get-the-comments-of-a-commit
+type GetCommitCommentsOptions ListOptions
+
 // GetCommitComments gets the comments of a commit in a project.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/commits.html#get-the-comments-of-a-commit
-func (s *CommitsService) GetCommitComments(pid interface{}, sha string, options ...OptionFunc) ([]*CommitComment, *Response, error) {
+func (s *CommitsService) GetCommitComments(pid interface{}, sha string, opt *GetCommitCommentsOptions, options ...OptionFunc) ([]*CommitComment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/commits/%s/comments", url.QueryEscape(project), sha)
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -316,6 +329,7 @@ func (s *CommitsService) PostCommitComment(pid interface{}, sha string, opt *Pos
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-the-status-of-a-commit
 type GetCommitStatusesOptions struct {
+	ListOptions
 	Ref   *string `url:"ref,omitempty" json:"ref,omitempty"`
 	Stage *string `url:"stage,omitempty" json:"stage,omitempty"`
 	Name  *string `url:"name,omitempty" json:"name,omitempty"`
@@ -367,25 +381,13 @@ func (s *CommitsService) GetCommitStatuses(pid interface{}, sha string, opt *Get
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#post-the-status-to-commit
 type SetCommitStatusOptions struct {
-	State       BuildState `url:"state" json:"state"`
-	Ref         *string    `url:"ref,omitempty" json:"ref,omitempty"`
-	Name        *string    `url:"name,omitempty" json:"name,omitempty"`
-	Context     *string    `url:"context,omitempty" json:"context,omitempty"`
-	TargetURL   *string    `url:"target_url,omitempty" json:"target_url,omitempty"`
-	Description *string    `url:"description,omitempty" json:"description,omitempty"`
+	State       BuildStateValue `url:"state" json:"state"`
+	Ref         *string         `url:"ref,omitempty" json:"ref,omitempty"`
+	Name        *string         `url:"name,omitempty" json:"name,omitempty"`
+	Context     *string         `url:"context,omitempty" json:"context,omitempty"`
+	TargetURL   *string         `url:"target_url,omitempty" json:"target_url,omitempty"`
+	Description *string         `url:"description,omitempty" json:"description,omitempty"`
 }
-
-// BuildState represents a GitLab build state.
-type BuildState string
-
-// These constants represent all valid build states.
-const (
-	Pending  BuildState = "pending"
-	Running  BuildState = "running"
-	Success  BuildState = "success"
-	Failed   BuildState = "failed"
-	Canceled BuildState = "canceled"
-)
 
 // SetCommitStatus sets the status of a commit in a project.
 //

--- a/vendor/github.com/xanzy/go-gitlab/deploy_keys.go
+++ b/vendor/github.com/xanzy/go-gitlab/deploy_keys.go
@@ -62,18 +62,25 @@ func (s *DeployKeysService) ListAllDeployKeys(options ...OptionFunc) ([]*DeployK
 	return ks, resp, err
 }
 
+// ListProjectDeployKeysOptions represents the available ListProjectDeployKeys()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deploy_keys.html#list-project-deploy-keys
+type ListProjectDeployKeysOptions ListOptions
+
 // ListProjectDeployKeys gets a list of a project's deploy keys
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/deploy_keys.html#list-project-deploy-keys
-func (s *DeployKeysService) ListProjectDeployKeys(pid interface{}, options ...OptionFunc) ([]*DeployKey, *Response, error) {
+func (s *DeployKeysService) ListProjectDeployKeys(pid interface{}, opt *ListProjectDeployKeysOptions, options ...OptionFunc) ([]*DeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/deploy_keys", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/xanzy/go-gitlab/deployments.go
+++ b/vendor/github.com/xanzy/go-gitlab/deployments.go
@@ -1,0 +1,121 @@
+//
+// Copyright 2018, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// DeploymentsService handles communication with the deployment related methods
+// of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/deployments.html
+type DeploymentsService struct {
+	client *Client
+}
+
+// Deployment represents the Gitlab deployment
+type Deployment struct {
+	ID          int          `json:"id"`
+	IID         int          `json:"iid"`
+	Ref         string       `json:"ref"`
+	Sha         string       `json:"sha"`
+	CreatedAt   *time.Time   `json:"created_at"`
+	User        *ProjectUser `json:"user"`
+	Environment *Environment `json:"environment"`
+	Deployable  struct {
+		ID         int        `json:"id"`
+		Status     string     `json:"status"`
+		Stage      string     `json:"stage"`
+		Name       string     `json:"name"`
+		Ref        string     `json:"ref"`
+		Tag        bool       `json:"tag"`
+		Coverage   float64    `json:"coverage"`
+		CreatedAt  *time.Time `json:"created_at"`
+		StartedAt  *time.Time `json:"started_at"`
+		FinishedAt *time.Time `json:"finished_at"`
+		Duration   float64    `json:"duration"`
+		User       *User      `json:"user"`
+		Commit     *Commit    `json:"commit"`
+		Pipeline   struct {
+			ID     int    `json:"id"`
+			Sha    string `json:"sha"`
+			Ref    string `json:"ref"`
+			Status string `json:"status"`
+		} `json:"pipeline"`
+		Runner *Runner `json:"runner"`
+	} `json:"deployable"`
+}
+
+// ListProjectDeploymentsOptions represents the available ListProjectDeployments() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deployments.html#list-project-deployments
+type ListProjectDeploymentsOptions struct {
+	ListOptions
+	OrderBy *OrderByValue `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort    *string       `url:"sort,omitempty" json:"sort,omitempty"`
+}
+
+// ListProjectDeployments gets a list of deployments in a project.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/deployments.html#list-project-deployments
+func (s *DeploymentsService) ListProjectDeployments(pid interface{}, opts *ListProjectDeploymentsOptions, options ...OptionFunc) ([]*Deployment, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/deployments", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opts, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ds []*Deployment
+	resp, err := s.client.Do(req, &ds)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ds, resp, err
+}
+
+// GetProjectDeployment get a deployment for a project.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/deployments.html#get-a-specific-deployment
+func (s *DeploymentsService) GetProjectDeployment(pid interface{}, deployment int, options ...OptionFunc) (*Deployment, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/deployments/%d", url.QueryEscape(project), deployment)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	d := new(Deployment)
+	resp, err := s.client.Do(req, d)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return d, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/environments.go
+++ b/vendor/github.com/xanzy/go-gitlab/environments.go
@@ -1,0 +1,166 @@
+//
+// Copyright 2017, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// EnvironmentsService handles communication with the environment related methods
+// of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/environments.html
+type EnvironmentsService struct {
+	client *Client
+}
+
+// Environment represents a GitLab environment.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/environments.html
+type Environment struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Slug        string `json:"slug"`
+	ExternalURL string `json:"external_url"`
+}
+
+func (env Environment) String() string {
+	return Stringify(env)
+}
+
+// ListEnvironmentsOptions represents the available ListEnvironments() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/environments.html#list-environments
+type ListEnvironmentsOptions ListOptions
+
+// ListEnvironments gets a list of environments from a project, sorted by name
+// alphabetically.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/environments.html#list-environments
+func (s *EnvironmentsService) ListEnvironments(pid interface{}, opts *ListEnvironmentsOptions, options ...OptionFunc) ([]*Environment, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/environments", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opts, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var envs []*Environment
+	resp, err := s.client.Do(req, &envs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return envs, resp, err
+}
+
+// CreateEnvironmentOptions represents the available CreateEnvironment() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/environments.html#create-a-new-environment
+type CreateEnvironmentOptions struct {
+	Name        *string `url:"name,omitempty" json:"name,omitempty"`
+	ExternalURL *string `url:"external_url,omitempty" json:"external_url,omitempty"`
+}
+
+// CreateEnvironment adds a environment to a project. This is an idempotent
+// method and can be called multiple times with the same parameters. Createing
+// an environment that is already a environment does not affect the
+// existing environmentship.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/environments.html#create-a-new-environment
+func (s *EnvironmentsService) CreateEnvironment(pid interface{}, opt *CreateEnvironmentOptions, options ...OptionFunc) (*Environment, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/environments", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	env := new(Environment)
+	resp, err := s.client.Do(req, env)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return env, resp, err
+}
+
+// EditEnvironmentOptions represents the available EditEnvironment() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/environments.html#edit-an-existing-environment
+type EditEnvironmentOptions struct {
+	Name        *string `url:"name,omitempty" json:"name,omitempty"`
+	ExternalURL *string `url:"external_url,omitempty" json:"external_url,omitempty"`
+}
+
+// EditEnvironment updates a project team environment to a specified access level..
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/environments.html#edit-an-existing-environment
+func (s *EnvironmentsService) EditEnvironment(pid interface{}, environment int, opt *EditEnvironmentOptions, options ...OptionFunc) (*Environment, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/environments/%d", url.QueryEscape(project), environment)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	env := new(Environment)
+	resp, err := s.client.Do(req, env)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return env, resp, err
+}
+
+// DeleteEnvironment removes a environment from a project team.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/environments.html#remove-a-environment-from-a-group-or-project
+func (s *EnvironmentsService) DeleteEnvironment(pid interface{}, environment int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/environments/%d", url.QueryEscape(project), environment)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/xanzy/go-gitlab/event_types.go
+++ b/vendor/github.com/xanzy/go-gitlab/event_types.go
@@ -1,0 +1,649 @@
+//
+// Copyright 2017, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"time"
+)
+
+// PushEvent represents a push event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#push-events
+type PushEvent struct {
+	ObjectKind  string `json:"object_kind"`
+	Before      string `json:"before"`
+	After       string `json:"after"`
+	Ref         string `json:"ref"`
+	CheckoutSha string `json:"checkout_sha"`
+	UserID      int    `json:"user_id"`
+	UserName    string `json:"user_name"`
+	UserEmail   string `json:"user_email"`
+	UserAvatar  string `json:"user_avatar"`
+	ProjectID   int    `json:"project_id"`
+	Project     struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	Repository *Repository `json:"repository"`
+	Commits    []*struct {
+		ID        string     `json:"id"`
+		Message   string     `json:"message"`
+		Timestamp *time.Time `json:"timestamp"`
+		URL       string     `json:"url"`
+		Author    struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"author"`
+		Added    []string `json:"added"`
+		Modified []string `json:"modified"`
+		Removed  []string `json:"removed"`
+	} `json:"commits"`
+	TotalCommitsCount int `json:"total_commits_count"`
+}
+
+// TagEvent represents a tag event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#tag-events
+type TagEvent struct {
+	ObjectKind  string `json:"object_kind"`
+	Before      string `json:"before"`
+	After       string `json:"after"`
+	Ref         string `json:"ref"`
+	CheckoutSha string `json:"checkout_sha"`
+	UserID      int    `json:"user_id"`
+	UserName    string `json:"user_name"`
+	UserAvatar  string `json:"user_avatar"`
+	ProjectID   int    `json:"project_id"`
+	Project     struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	Repository *Repository `json:"repository"`
+	Commits    []*struct {
+		ID        string     `json:"id"`
+		Message   string     `json:"message"`
+		Timestamp *time.Time `json:"timestamp"`
+		URL       string     `json:"url"`
+		Author    struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"author"`
+		Added    []string `json:"added"`
+		Modified []string `json:"modified"`
+		Removed  []string `json:"removed"`
+	} `json:"commits"`
+	TotalCommitsCount int `json:"total_commits_count"`
+}
+
+// IssueEvent represents a issue event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#issues-events
+type IssueEvent struct {
+	ObjectKind string `json:"object_kind"`
+	User       *User  `json:"user"`
+	Project    struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	Repository       *Repository `json:"repository"`
+	ObjectAttributes struct {
+		ID          int    `json:"id"`
+		Title       string `json:"title"`
+		AssigneeID  int    `json:"assignee_id"`
+		AuthorID    int    `json:"author_id"`
+		ProjectID   int    `json:"project_id"`
+		CreatedAt   string `json:"created_at"` // Should be *time.Time (see Gitlab issue #21468)
+		UpdatedAt   string `json:"updated_at"` // Should be *time.Time (see Gitlab issue #21468)
+		Position    int    `json:"position"`
+		BranchName  string `json:"branch_name"`
+		Description string `json:"description"`
+		MilestoneID int    `json:"milestone_id"`
+		State       string `json:"state"`
+		IID         int    `json:"iid"`
+		URL         string `json:"url"`
+		Action      string `json:"action"`
+	} `json:"object_attributes"`
+	Assignee struct {
+		Name      string `json:"name"`
+		Username  string `json:"username"`
+		AvatarURL string `json:"avatar_url"`
+	} `json:"assignee"`
+}
+
+// CommitCommentEvent represents a comment on a commit event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#comment-on-commit
+type CommitCommentEvent struct {
+	ObjectKind string `json:"object_kind"`
+	User       *User  `json:"user"`
+	ProjectID  int    `json:"project_id"`
+	Project    struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	Repository       *Repository `json:"repository"`
+	ObjectAttributes struct {
+		ID           int    `json:"id"`
+		Note         string `json:"note"`
+		NoteableType string `json:"noteable_type"`
+		AuthorID     int    `json:"author_id"`
+		CreatedAt    string `json:"created_at"`
+		UpdatedAt    string `json:"updated_at"`
+		ProjectID    int    `json:"project_id"`
+		Attachment   string `json:"attachment"`
+		LineCode     string `json:"line_code"`
+		CommitID     string `json:"commit_id"`
+		NoteableID   int    `json:"noteable_id"`
+		System       bool   `json:"system"`
+		StDiff       struct {
+			Diff        string `json:"diff"`
+			NewPath     string `json:"new_path"`
+			OldPath     string `json:"old_path"`
+			AMode       string `json:"a_mode"`
+			BMode       string `json:"b_mode"`
+			NewFile     bool   `json:"new_file"`
+			RenamedFile bool   `json:"renamed_file"`
+			DeletedFile bool   `json:"deleted_file"`
+		} `json:"st_diff"`
+	} `json:"object_attributes"`
+	Commit *struct {
+		ID        string     `json:"id"`
+		Message   string     `json:"message"`
+		Timestamp *time.Time `json:"timestamp"`
+		URL       string     `json:"url"`
+		Author    struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"author"`
+	} `json:"commit"`
+}
+
+// MergeCommentEvent represents a comment on a merge event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#comment-on-merge-request
+type MergeCommentEvent struct {
+	ObjectKind string `json:"object_kind"`
+	User       *User  `json:"user"`
+	ProjectID  int    `json:"project_id"`
+	Project    struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	ObjectAttributes struct {
+		ID           int    `json:"id"`
+		Note         string `json:"note"`
+		NoteableType string `json:"noteable_type"`
+		AuthorID     int    `json:"author_id"`
+		CreatedAt    string `json:"created_at"`
+		UpdatedAt    string `json:"updated_at"`
+		ProjectID    int    `json:"project_id"`
+		Attachment   string `json:"attachment"`
+		LineCode     string `json:"line_code"`
+		CommitID     string `json:"commit_id"`
+		NoteableID   int    `json:"noteable_id"`
+		System       bool   `json:"system"`
+		StDiff       *Diff  `json:"st_diff"`
+		URL          string `json:"url"`
+	} `json:"object_attributes"`
+	Repository   *Repository `json:"repository"`
+	MergeRequest struct {
+		ID              int    `json:"id"`
+		TargetBranch    string `json:"target_branch"`
+		SourceBranch    string `json:"source_branch"`
+		SourceProjectID int    `json:"source_project_id"`
+		AuthorID        int    `json:"author_id"`
+		AssigneeID      int    `json:"assignee_id"`
+		Title           string `json:"title"`
+		CreatedAt       string `json:"created_at"`
+		UpdatedAt       string `json:"updated_at"`
+		MilestoneID     int    `json:"milestone_id"`
+		State           string `json:"state"`
+		MergeStatus     string `json:"merge_status"`
+		TargetProjectID int    `json:"target_project_id"`
+		IID             int    `json:"iid"`
+		Description     string `json:"description"`
+		Position        int    `json:"position"`
+		LockedAt        string `json:"locked_at"`
+		UpdatedByID     int    `json:"updated_by_id"`
+		MergeError      string `json:"merge_error"`
+		MergeParams     struct {
+			ForceRemoveSourceBranch string `json:"force_remove_source_branch"`
+		} `json:"merge_params"`
+		MergeWhenPipelineSucceeds bool        `json:"merge_when_pipeline_succeeds"`
+		MergeUserID               int         `json:"merge_user_id"`
+		MergeCommitSha            string      `json:"merge_commit_sha"`
+		DeletedAt                 string      `json:"deleted_at"`
+		InProgressMergeCommitSha  string      `json:"in_progress_merge_commit_sha"`
+		LockVersion               int         `json:"lock_version"`
+		ApprovalsBeforeMerge      string      `json:"approvals_before_merge"`
+		RebaseCommitSha           string      `json:"rebase_commit_sha"`
+		TimeEstimate              int         `json:"time_estimate"`
+		Squash                    bool        `json:"squash"`
+		LastEditedAt              string      `json:"last_edited_at"`
+		LastEditedByID            int         `json:"last_edited_by_id"`
+		Source                    *Repository `json:"source"`
+		Target                    *Repository `json:"target"`
+		LastCommit                struct {
+			ID        string     `json:"id"`
+			Message   string     `json:"message"`
+			Timestamp *time.Time `json:"timestamp"`
+			URL       string     `json:"url"`
+			Author    struct {
+				Name  string `json:"name"`
+				Email string `json:"email"`
+			} `json:"author"`
+		} `json:"last_commit"`
+		WorkInProgress bool `json:"work_in_progress"`
+		TotalTimeSpent int  `json:"total_time_spent"`
+	} `json:"merge_request"`
+}
+
+// IssueCommentEvent represents a comment on an issue event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#comment-on-issue
+type IssueCommentEvent struct {
+	ObjectKind string `json:"object_kind"`
+	User       *User  `json:"user"`
+	ProjectID  int    `json:"project_id"`
+	Project    struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	Repository       *Repository `json:"repository"`
+	ObjectAttributes struct {
+		ID           int     `json:"id"`
+		Note         string  `json:"note"`
+		NoteableType string  `json:"noteable_type"`
+		AuthorID     int     `json:"author_id"`
+		CreatedAt    string  `json:"created_at"`
+		UpdatedAt    string  `json:"updated_at"`
+		ProjectID    int     `json:"project_id"`
+		Attachment   string  `json:"attachment"`
+		LineCode     string  `json:"line_code"`
+		CommitID     string  `json:"commit_id"`
+		NoteableID   int     `json:"noteable_id"`
+		System       bool    `json:"system"`
+		StDiff       []*Diff `json:"st_diff"`
+		URL          string  `json:"url"`
+	} `json:"object_attributes"`
+	Issue *Issue `json:"issue"`
+}
+
+// SnippetCommentEvent represents a comment on a snippet event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#comment-on-code-snippet
+type SnippetCommentEvent struct {
+	ObjectKind string `json:"object_kind"`
+	User       *User  `json:"user"`
+	ProjectID  int    `json:"project_id"`
+	Project    struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	Repository       *Repository `json:"repository"`
+	ObjectAttributes struct {
+		ID           int    `json:"id"`
+		Note         string `json:"note"`
+		NoteableType string `json:"noteable_type"`
+		AuthorID     int    `json:"author_id"`
+		CreatedAt    string `json:"created_at"`
+		UpdatedAt    string `json:"updated_at"`
+		ProjectID    int    `json:"project_id"`
+		Attachment   string `json:"attachment"`
+		LineCode     string `json:"line_code"`
+		CommitID     string `json:"commit_id"`
+		NoteableID   int    `json:"noteable_id"`
+		System       bool   `json:"system"`
+		StDiff       *Diff  `json:"st_diff"`
+		URL          string `json:"url"`
+	} `json:"object_attributes"`
+	Snippet *Snippet `json:"snippet"`
+}
+
+// MergeEvent represents a merge event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#merge-request-events
+type MergeEvent struct {
+	ObjectKind string `json:"object_kind"`
+	User       *User  `json:"user"`
+	Project    struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	ObjectAttributes struct {
+		ID              int       `json:"id"`
+		TargetBranch    string    `json:"target_branch"`
+		SourceBranch    string    `json:"source_branch"`
+		SourceProjectID int       `json:"source_project_id"`
+		AuthorID        int       `json:"author_id"`
+		AssigneeID      int       `json:"assignee_id"`
+		Title           string    `json:"title"`
+		CreatedAt       string    `json:"created_at"` // Should be *time.Time (see Gitlab issue #21468)
+		UpdatedAt       string    `json:"updated_at"` // Should be *time.Time (see Gitlab issue #21468)
+		StCommits       []*Commit `json:"st_commits"`
+		StDiffs         []*Diff   `json:"st_diffs"`
+		MilestoneID     int       `json:"milestone_id"`
+		State           string    `json:"state"`
+		MergeStatus     string    `json:"merge_status"`
+		TargetProjectID int       `json:"target_project_id"`
+		IID             int       `json:"iid"`
+		Description     string    `json:"description"`
+		Position        int       `json:"position"`
+		LockedAt        string    `json:"locked_at"`
+		UpdatedByID     int       `json:"updated_by_id"`
+		MergeError      string    `json:"merge_error"`
+		MergeParams     struct {
+			ForceRemoveSourceBranch string `json:"force_remove_source_branch"`
+		} `json:"merge_params"`
+		MergeWhenBuildSucceeds   bool        `json:"merge_when_build_succeeds"`
+		MergeUserID              int         `json:"merge_user_id"`
+		MergeCommitSha           string      `json:"merge_commit_sha"`
+		DeletedAt                string      `json:"deleted_at"`
+		ApprovalsBeforeMerge     string      `json:"approvals_before_merge"`
+		RebaseCommitSha          string      `json:"rebase_commit_sha"`
+		InProgressMergeCommitSha string      `json:"in_progress_merge_commit_sha"`
+		LockVersion              int         `json:"lock_version"`
+		TimeEstimate             int         `json:"time_estimate"`
+		Source                   *Repository `json:"source"`
+		Target                   *Repository `json:"target"`
+		LastCommit               struct {
+			ID        string     `json:"id"`
+			Message   string     `json:"message"`
+			Timestamp *time.Time `json:"timestamp"`
+			URL       string     `json:"url"`
+			Author    struct {
+				Name  string `json:"name"`
+				Email string `json:"email"`
+			} `json:"author"`
+		} `json:"last_commit"`
+		WorkInProgress bool   `json:"work_in_progress"`
+		URL            string `json:"url"`
+		Action         string `json:"action"`
+		Assignee       struct {
+			Name      string `json:"name"`
+			Username  string `json:"username"`
+			AvatarURL string `json:"avatar_url"`
+		} `json:"assignee"`
+	} `json:"object_attributes"`
+	Repository *Repository `json:"repository"`
+	Assignee   struct {
+		Name      string `json:"name"`
+		Username  string `json:"username"`
+		AvatarURL string `json:"avatar_url"`
+	} `json:"assignee"`
+}
+
+// WikiPageEvent represents a wiki page event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#wiki-page-events
+type WikiPageEvent struct {
+	ObjectKind string `json:"object_kind"`
+	User       *User  `json:"user"`
+	Project    struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	Wiki struct {
+		WebURL            string `json:"web_url"`
+		GitSSHURL         string `json:"git_ssh_url"`
+		GitHTTPURL        string `json:"git_http_url"`
+		PathWithNamespace string `json:"path_with_namespace"`
+		DefaultBranch     string `json:"default_branch"`
+	} `json:"wiki"`
+	ObjectAttributes struct {
+		Title   string `json:"title"`
+		Content string `json:"content"`
+		Format  string `json:"format"`
+		Message string `json:"message"`
+		Slug    string `json:"slug"`
+		URL     string `json:"url"`
+		Action  string `json:"action"`
+	} `json:"object_attributes"`
+}
+
+// PipelineEvent represents a pipeline event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#pipeline-events
+type PipelineEvent struct {
+	ObjectKind       string `json:"object_kind"`
+	ObjectAttributes struct {
+		ID         int      `json:"id"`
+		Ref        string   `json:"ref"`
+		Tag        bool     `json:"tag"`
+		Sha        string   `json:"sha"`
+		BeforeSha  string   `json:"before_sha"`
+		Status     string   `json:"status"`
+		Stages     []string `json:"stages"`
+		CreatedAt  string   `json:"created_at"`
+		FinishedAt string   `json:"finished_at"`
+		Duration   int      `json:"duration"`
+	} `json:"object_attributes"`
+	User struct {
+		Name      string `json:"name"`
+		Username  string `json:"username"`
+		AvatarURL string `json:"avatar_url"`
+	} `json:"user"`
+	Project struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	Commit struct {
+		ID        string     `json:"id"`
+		Message   string     `json:"message"`
+		Timestamp *time.Time `json:"timestamp"`
+		URL       string     `json:"url"`
+		Author    struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"author"`
+	} `json:"commit"`
+	Builds []struct {
+		ID         int    `json:"id"`
+		Stage      string `json:"stage"`
+		Name       string `json:"name"`
+		Status     string `json:"status"`
+		CreatedAt  string `json:"created_at"`
+		StartedAt  string `json:"started_at"`
+		FinishedAt string `json:"finished_at"`
+		When       string `json:"when"`
+		Manual     bool   `json:"manual"`
+		User       struct {
+			Name      string `json:"name"`
+			Username  string `json:"username"`
+			AvatarURL string `json:"avatar_url"`
+		} `json:"user"`
+		Runner struct {
+			ID          int    `json:"id"`
+			Description string `json:"description"`
+			Active      bool   `json:"active"`
+			IsShared    bool   `json:"is_shared"`
+		} `json:"runner"`
+		ArtifactsFile struct {
+			Filename string `json:"filename"`
+			Size     int    `json:"size"`
+		} `json:"artifacts_file"`
+	} `json:"builds"`
+}
+
+//BuildEvent represents a build event
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#build-events
+type BuildEvent struct {
+	ObjectKind        string  `json:"object_kind"`
+	Ref               string  `json:"ref"`
+	Tag               bool    `json:"tag"`
+	BeforeSha         string  `json:"before_sha"`
+	Sha               string  `json:"sha"`
+	BuildID           int     `json:"build_id"`
+	BuildName         string  `json:"build_name"`
+	BuildStage        string  `json:"build_stage"`
+	BuildStatus       string  `json:"build_status"`
+	BuildStartedAt    string  `json:"build_started_at"`
+	BuildFinishedAt   string  `json:"build_finished_at"`
+	BuildDuration     float64 `json:"build_duration"`
+	BuildAllowFailure bool    `json:"build_allow_failure"`
+	ProjectID         int     `json:"project_id"`
+	ProjectName       string  `json:"project_name"`
+	User              struct {
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	} `json:"user"`
+	Commit struct {
+		ID          int    `json:"id"`
+		Sha         string `json:"sha"`
+		Message     string `json:"message"`
+		AuthorName  string `json:"author_name"`
+		AuthorEmail string `json:"author_email"`
+		Status      string `json:"status"`
+		Duration    int    `json:"duration"`
+		StartedAt   string `json:"started_at"`
+		FinishedAt  string `json:"finished_at"`
+	} `json:"commit"`
+	Repository *Repository `json:"repository"`
+}

--- a/vendor/github.com/xanzy/go-gitlab/events.go
+++ b/vendor/github.com/xanzy/go-gitlab/events.go
@@ -16,547 +16,132 @@
 
 package gitlab
 
-import "time"
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
 
-// PushEvent represents a push event.
+// EventsService handles communication with the event related methods of
+// the GitLab API.
 //
-// GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#push-events
-type PushEvent struct {
-	ObjectKind  string `json:"object_kind"`
-	Before      string `json:"before"`
-	After       string `json:"after"`
-	Ref         string `json:"ref"`
-	CheckoutSha string `json:"checkout_sha"`
-	UserID      int    `json:"user_id"`
-	UserName    string `json:"user_name"`
-	UserEmail   string `json:"user_email"`
-	UserAvatar  string `json:"user_avatar"`
-	ProjectID   int    `json:"project_id"`
-	Project     struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Repository        *Repository `json:"repository"`
-	Commits           []*Commit   `json:"commits"`
-	TotalCommitsCount int         `json:"total_commits_count"`
+// GitLab API docs: https://docs.gitlab.com/ce/api/events.html
+type EventsService struct {
+	client *Client
 }
 
-// TagEvent represents a tag event.
+// ContributionEvent represents a user's contribution
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#tag-events
-type TagEvent struct {
-	ObjectKind  string `json:"object_kind"`
-	Before      string `json:"before"`
-	After       string `json:"after"`
-	Ref         string `json:"ref"`
-	CheckoutSha string `json:"checkout_sha"`
-	UserID      int    `json:"user_id"`
-	UserName    string `json:"user_name"`
-	UserAvatar  string `json:"user_avatar"`
-	ProjectID   int    `json:"project_id"`
-	Project     struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Repository        *Repository `json:"repository"`
-	Commits           []*Commit   `json:"commits"`
-	TotalCommitsCount int         `json:"total_commits_count"`
-}
-
-// IssueEvent represents a issue event.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#issues-events
-type IssueEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	Project    struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Repository       *Repository `json:"repository"`
-	ObjectAttributes struct {
-		ID          int    `json:"id"`
-		Title       string `json:"title"`
-		AssigneeID  int    `json:"assignee_id"`
-		AuthorID    int    `json:"author_id"`
-		ProjectID   int    `json:"project_id"`
-		CreatedAt   string `json:"created_at"` // Should be *time.Time (see Gitlab issue #21468)
-		UpdatedAt   string `json:"updated_at"` // Should be *time.Time (see Gitlab issue #21468)
-		Position    int    `json:"position"`
-		BranchName  string `json:"branch_name"`
-		Description string `json:"description"`
-		MilestoneID int    `json:"milestone_id"`
-		State       string `json:"state"`
-		Iid         int    `json:"iid"`
-		URL         string `json:"url"`
+// https://docs.gitlab.com/ce/api/events.html#get-user-contribution-events
+type ContributionEvent struct {
+	Title       string    `json:"title"`
+	ProjectID   int       `json:"project_id"`
+	ActionName  string    `json:"action_name"`
+	TargetID    int       `json:"target_id"`
+	TargetIID   int       `json:"target_iid"`
+	TargetType  string    `json:"target_type"`
+	AuthorID    int       `json:"author_id"`
+	TargetTitle string    `json:"target_title"`
+	CreatedAt   time.Time `json:"created_at"`
+	PushData    struct {
+		CommitCount int    `json:"commit_count"`
 		Action      string `json:"action"`
-	} `json:"object_attributes"`
-	Assignee struct {
+		RefType     string `json:"ref_type"`
+		CommitFrom  string `json:"commit_from"`
+		CommitTo    string `json:"commit_to"`
+		Ref         string `json:"ref"`
+		CommitTitle string `json:"commit_title"`
+	} `json:"push_data"`
+	Note   *Note `json:"note"`
+	Author struct {
 		Name      string `json:"name"`
 		Username  string `json:"username"`
+		ID        int    `json:"id"`
+		State     string `json:"state"`
 		AvatarURL string `json:"avatar_url"`
-	} `json:"assignee"`
+		WebURL    string `json:"web_url"`
+	} `json:"author"`
+	AuthorUsername string `json:"author_username"`
 }
 
-// CommitCommentEvent represents a comment on a commit event.
+// ListContributionEventsOptions represents the options for GetUserContributionEvents
 //
-// GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#comment-on-commit
-type CommitCommentEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	ProjectID  int    `json:"project_id"`
-	Project    struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Repository       *Repository `json:"repository"`
-	ObjectAttributes struct {
-		ID           int    `json:"id"`
-		Note         string `json:"note"`
-		NoteableType string `json:"noteable_type"`
-		AuthorID     int    `json:"author_id"`
-		CreatedAt    string `json:"created_at"`
-		UpdatedAt    string `json:"updated_at"`
-		ProjectID    int    `json:"project_id"`
-		Attachment   string `json:"attachment"`
-		LineCode     string `json:"line_code"`
-		CommitID     string `json:"commit_id"`
-		NoteableID   int    `json:"noteable_id"`
-		System       bool   `json:"system"`
-		StDiff       struct {
-			Diff        string `json:"diff"`
-			NewPath     string `json:"new_path"`
-			OldPath     string `json:"old_path"`
-			AMode       string `json:"a_mode"`
-			BMode       string `json:"b_mode"`
-			NewFile     bool   `json:"new_file"`
-			RenamedFile bool   `json:"renamed_file"`
-			DeletedFile bool   `json:"deleted_file"`
-		} `json:"st_diff"`
-	} `json:"object_attributes"`
-	Commit *Commit `json:"commit"`
+// GitLap API docs:
+// https://docs.gitlab.com/ce/api/events.html#get-user-contribution-events
+type ListContributionEventsOptions struct {
+	ListOptions
+	Action     *EventTypeValue       `json:"action,omitempty"`
+	TargetType *EventTargetTypeValue `json:"target_type,omitempty"`
+	Before     *ISOTime              `json:"before,omitempty"`
+	After      *ISOTime              `json:"after,omitempty"`
+	Sort       *string               `json:"sort,omitempty"`
 }
 
-// MergeCommentEvent represents a comment on a merge event.
+// ListUserContributionEvents retrieves user contribution events
+// for the specified user, sorted from newest to oldest.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#comment-on-merge-request
-type MergeCommentEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	ProjectID  int    `json:"project_id"`
-	Project    struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Repository       *Repository `json:"repository"`
-	ObjectAttributes struct {
-		ID           int    `json:"id"`
-		Note         string `json:"note"`
-		NoteableType string `json:"noteable_type"`
-		AuthorID     int    `json:"author_id"`
-		CreatedAt    string `json:"created_at"`
-		UpdatedAt    string `json:"updated_at"`
-		ProjectID    int    `json:"project_id"`
-		Attachment   string `json:"attachment"`
-		LineCode     string `json:"line_code"`
-		CommitID     string `json:"commit_id"`
-		NoteableID   int    `json:"noteable_id"`
-		System       bool   `json:"system"`
-		StDiff       *Diff  `json:"st_diff"`
-		URL          string `json:"url"`
-	} `json:"object_attributes"`
-	MergeRequest *MergeRequest `json:"merge_request"`
+// https://docs.gitlab.com/ce/api/events.html#get-user-contribution-events
+func (s *UsersService) ListUserContributionEvents(uid interface{}, opt *ListContributionEventsOptions, options ...OptionFunc) ([]*ContributionEvent, *Response, error) {
+	user, err := parseID(uid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("users/%s/events", user)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var cs []*ContributionEvent
+	resp, err := s.client.Do(req, &cs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return cs, resp, err
 }
 
-// IssueCommentEvent represents a comment on an issue event.
+// ListCurrentUserContributionEvents gets a list currently authenticated user's events
 //
-// GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#comment-on-issue
-type IssueCommentEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	ProjectID  int    `json:"project_id"`
-	Project    struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Repository       *Repository `json:"repository"`
-	ObjectAttributes struct {
-		ID           int     `json:"id"`
-		Note         string  `json:"note"`
-		NoteableType string  `json:"noteable_type"`
-		AuthorID     int     `json:"author_id"`
-		CreatedAt    string  `json:"created_at"`
-		UpdatedAt    string  `json:"updated_at"`
-		ProjectID    int     `json:"project_id"`
-		Attachment   string  `json:"attachment"`
-		LineCode     string  `json:"line_code"`
-		CommitID     string  `json:"commit_id"`
-		NoteableID   int     `json:"noteable_id"`
-		System       bool    `json:"system"`
-		StDiff       []*Diff `json:"st_diff"`
-		URL          string  `json:"url"`
-	} `json:"object_attributes"`
-	Issue *Issue `json:"issue"`
+// GitLab API docs: https://docs.gitlab.com/ce/api/events.html#list-currently-authenticated-user-39-s-events
+func (s *EventsService) ListCurrentUserContributionEvents(opt *ListContributionEventsOptions, options ...OptionFunc) ([]*ContributionEvent, *Response, error) {
+	req, err := s.client.NewRequest("GET", "events", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var cs []*ContributionEvent
+	resp, err := s.client.Do(req, &cs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return cs, resp, err
 }
 
-// SnippetCommentEvent represents a comment on a snippet event.
+// ListProjectContributionEvents gets a list currently authenticated user's events
 //
-// GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#comment-on-code-snippet
-type SnippetCommentEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	ProjectID  int    `json:"project_id"`
-	Project    struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Repository       *Repository `json:"repository"`
-	ObjectAttributes struct {
-		ID           int    `json:"id"`
-		Note         string `json:"note"`
-		NoteableType string `json:"noteable_type"`
-		AuthorID     int    `json:"author_id"`
-		CreatedAt    string `json:"created_at"`
-		UpdatedAt    string `json:"updated_at"`
-		ProjectID    int    `json:"project_id"`
-		Attachment   string `json:"attachment"`
-		LineCode     string `json:"line_code"`
-		CommitID     string `json:"commit_id"`
-		NoteableID   int    `json:"noteable_id"`
-		System       bool   `json:"system"`
-		StDiff       *Diff  `json:"st_diff"`
-		URL          string `json:"url"`
-	} `json:"object_attributes"`
-	Snippet *Snippet `json:"snippet"`
-}
+// GitLab API docs: https://docs.gitlab.com/ce/api/events.html#list-a-project-39-s-visible-events
+func (s *EventsService) ListProjectContributionEvents(pid interface{}, opt *ListContributionEventsOptions, options ...OptionFunc) ([]*ContributionEvent, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("%s/events", url.QueryEscape(project))
 
-// MergeEvent represents a merge event.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#merge-request-events
-type MergeEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	Project    struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	ObjectAttributes struct {
-		ID              int       `json:"id"`
-		TargetBranch    string    `json:"target_branch"`
-		SourceBranch    string    `json:"source_branch"`
-		SourceProjectID int       `json:"source_project_id"`
-		AuthorID        int       `json:"author_id"`
-		AssigneeID      int       `json:"assignee_id"`
-		Title           string    `json:"title"`
-		CreatedAt       string    `json:"created_at"` // Should be *time.Time (see Gitlab issue #21468)
-		UpdatedAt       string    `json:"updated_at"` // Should be *time.Time (see Gitlab issue #21468)
-		StCommits       []*Commit `json:"st_commits"`
-		StDiffs         []*Diff   `json:"st_diffs"`
-		MilestoneID     int       `json:"milestone_id"`
-		State           string    `json:"state"`
-		MergeStatus     string    `json:"merge_status"`
-		TargetProjectID int       `json:"target_project_id"`
-		Iid             int       `json:"iid"`
-		Description     string    `json:"description"`
-		Position        int       `json:"position"`
-		LockedAt        string    `json:"locked_at"`
-		UpdatedByID     int       `json:"updated_by_id"`
-		MergeError      string    `json:"merge_error"`
-		MergeParams     struct {
-			ForceRemoveSourceBranch string `json:"force_remove_source_branch"`
-		} `json:"merge_params"`
-		MergeWhenBuildSucceeds   bool        `json:"merge_when_build_succeeds"`
-		MergeUserID              int         `json:"merge_user_id"`
-		MergeCommitSha           string      `json:"merge_commit_sha"`
-		DeletedAt                string      `json:"deleted_at"`
-		ApprovalsBeforeMerge     string      `json:"approvals_before_merge"`
-		RebaseCommitSha          string      `json:"rebase_commit_sha"`
-		InProgressMergeCommitSha string      `json:"in_progress_merge_commit_sha"`
-		LockVersion              int         `json:"lock_version"`
-		TimeEstimate             int         `json:"time_estimate"`
-		Source                   *Repository `json:"source"`
-		Target                   *Repository `json:"target"`
-		LastCommit               struct {
-			ID        string     `json:"id"`
-			Message   string     `json:"message"`
-			Timestamp *time.Time `json:"timestamp"`
-			URL       string     `json:"url"`
-			Author    *Author    `json:"author"`
-		} `json:"last_commit"`
-		WorkInProgress bool   `json:"work_in_progress"`
-		URL            string `json:"url"`
-		Action         string `json:"action"`
-		Assignee       struct {
-			Name      string `json:"name"`
-			Username  string `json:"username"`
-			AvatarURL string `json:"avatar_url"`
-		} `json:"assignee"`
-	} `json:"object_attributes"`
-	Repository *Repository `json:"repository"`
-	Assignee   struct {
-		Name      string `json:"name"`
-		Username  string `json:"username"`
-		AvatarURL string `json:"avatar_url"`
-	} `json:"assignee"`
-}
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
 
-// WikiPageEvent represents a wiki page event.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#wiki-page-events
-type WikiPageEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	Project    struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Wiki struct {
-		WebURL            string `json:"web_url"`
-		GitSSHURL         string `json:"git_ssh_url"`
-		GitHTTPURL        string `json:"git_http_url"`
-		PathWithNamespace string `json:"path_with_namespace"`
-		DefaultBranch     string `json:"default_branch"`
-	} `json:"wiki"`
-	ObjectAttributes struct {
-		Title   string `json:"title"`
-		Content string `json:"content"`
-		Format  string `json:"format"`
-		Message string `json:"message"`
-		Slug    string `json:"slug"`
-		URL     string `json:"url"`
-		Action  string `json:"action"`
-	} `json:"object_attributes"`
-}
+	var cs []*ContributionEvent
+	resp, err := s.client.Do(req, &cs)
+	if err != nil {
+		return nil, resp, err
+	}
 
-// PipelineEvent represents a pipeline event.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#pipeline-events
-type PipelineEvent struct {
-	ObjectKind       string `json:"object_kind"`
-	ObjectAttributes struct {
-		ID         int      `json:"id"`
-		Ref        string   `json:"ref"`
-		Tag        bool     `json:"tag"`
-		Sha        string   `json:"sha"`
-		BeforeSha  string   `json:"before_sha"`
-		Status     string   `json:"status"`
-		Stages     []string `json:"stages"`
-		CreatedAt  string   `json:"created_at"`
-		FinishedAt string   `json:"finished_at"`
-		Duration   int      `json:"duration"`
-	} `json:"object_attributes"`
-	User struct {
-		Name      string `json:"name"`
-		Username  string `json:"username"`
-		AvatarURL string `json:"avatar_url"`
-	} `json:"user"`
-	Project struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Commit struct {
-		ID        string    `json:"id"`
-		Message   string    `json:"message"`
-		Timestamp time.Time `json:"timestamp"`
-		URL       string    `json:"url"`
-		Author    struct {
-			Name  string `json:"name"`
-			Email string `json:"email"`
-		} `json:"author"`
-	} `json:"commit"`
-	Builds []struct {
-		ID         int    `json:"id"`
-		Stage      string `json:"stage"`
-		Name       string `json:"name"`
-		Status     string `json:"status"`
-		CreatedAt  string `json:"created_at"`
-		StartedAt  string `json:"started_at"`
-		FinishedAt string `json:"finished_at"`
-		When       string `json:"when"`
-		Manual     bool   `json:"manual"`
-		User       struct {
-			Name      string `json:"name"`
-			Username  string `json:"username"`
-			AvatarURL string `json:"avatar_url"`
-		} `json:"user"`
-		Runner struct {
-			ID          int    `json:"id"`
-			Description string `json:"description"`
-			Active      bool   `json:"active"`
-			IsShared    bool   `json:"is_shared"`
-		} `json:"runner"`
-		ArtifactsFile struct {
-			Filename string `json:"filename"`
-			Size     int    `json:"size"`
-		} `json:"artifacts_file"`
-	} `json:"builds"`
-}
-
-//BuildEvent represents a build event
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#build-events
-type BuildEvent struct {
-	ObjectKind        string  `json:"object_kind"`
-	Ref               string  `json:"ref"`
-	Tag               bool    `json:"tag"`
-	BeforeSha         string  `json:"before_sha"`
-	Sha               string  `json:"sha"`
-	BuildID           int     `json:"build_id"`
-	BuildName         string  `json:"build_name"`
-	BuildStage        string  `json:"build_stage"`
-	BuildStatus       string  `json:"build_status"`
-	BuildStartedAt    string  `json:"build_started_at"`
-	BuildFinishedAt   string  `json:"build_finished_at"`
-	BuildDuration     float64 `json:"build_duration"`
-	BuildAllowFailure bool    `json:"build_allow_failure"`
-	ProjectID         int     `json:"project_id"`
-	ProjectName       string  `json:"project_name"`
-	User              struct {
-		ID    int    `json:"id"`
-		Name  string `json:"name"`
-		Email string `json:"email"`
-	} `json:"user"`
-	Commit struct {
-		ID          int    `json:"id"`
-		Sha         string `json:"sha"`
-		Message     string `json:"message"`
-		AuthorName  string `json:"author_name"`
-		AuthorEmail string `json:"author_email"`
-		Status      string `json:"status"`
-		Duration    string `json:"duration"`
-		StartedAt   string `json:"started_at"`
-		FinishedAt  string `json:"finished_at"`
-	} `json:"commit"`
-	Repository *Repository `json:"repository"`
+	return cs, resp, err
 }

--- a/vendor/github.com/xanzy/go-gitlab/gitignore_templates.go
+++ b/vendor/github.com/xanzy/go-gitlab/gitignore_templates.go
@@ -1,0 +1,84 @@
+//
+// Copyright 2018, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// GitIgnoreTemplatesService handles communication with the gitignore
+// templates related methods of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/templates/gitignores.html
+type GitIgnoreTemplatesService struct {
+	client *Client
+}
+
+// GitIgnoreTemplate represents a GitLab gitignore template.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/templates/gitignores.html
+type GitIgnoreTemplate struct {
+	Name    string `json:"name"`
+	Content string `json:"content"`
+}
+
+// ListTemplatesOptions represents the available ListAllTemplates() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/templates/gitignores.html#list-gitignore-templates
+type ListTemplatesOptions ListOptions
+
+// ListTemplates get a list of available git ignore templates
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/templates/gitignores.html#list-gitignore-templates
+func (s *GitIgnoreTemplatesService) ListTemplates(opt *ListTemplatesOptions, options ...OptionFunc) ([]*GitIgnoreTemplate, *Response, error) {
+	req, err := s.client.NewRequest("GET", "templates/gitignores", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var gs []*GitIgnoreTemplate
+	resp, err := s.client.Do(req, &gs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gs, resp, err
+}
+
+// GetTemplate get a git ignore template
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/templates/gitignores.html#single-gitignore-template
+func (s *GitIgnoreTemplatesService) GetTemplate(key string, options ...OptionFunc) (*GitIgnoreTemplate, *Response, error) {
+	u := fmt.Sprintf("templates/gitignores/%s", url.QueryEscape(key))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	g := new(GitIgnoreTemplate)
+	resp, err := s.client.Do(req, g)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return g, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/gitlab.go
+++ b/vendor/github.com/xanzy/go-gitlab/gitlab.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -28,6 +29,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-querystring/query"
 )
@@ -60,12 +62,65 @@ type AccessLevelValue int
 //
 // GitLab API docs: https://docs.gitlab.com/ce/permissions/permissions.html
 const (
+	NoPermissions        AccessLevelValue = 0
 	GuestPermissions     AccessLevelValue = 10
 	ReporterPermissions  AccessLevelValue = 20
 	DeveloperPermissions AccessLevelValue = 30
 	MasterPermissions    AccessLevelValue = 40
 	OwnerPermission      AccessLevelValue = 50
 )
+
+// BuildStateValue represents a GitLab build state.
+type BuildStateValue string
+
+// These constants represent all valid build states.
+const (
+	Pending  BuildStateValue = "pending"
+	Running  BuildStateValue = "running"
+	Success  BuildStateValue = "success"
+	Failed   BuildStateValue = "failed"
+	Canceled BuildStateValue = "canceled"
+	Skipped  BuildStateValue = "skipped"
+)
+
+// ISOTime represents an ISO 8601 formatted date
+type ISOTime time.Time
+
+// ISO 8601 date format
+const iso8601 = "2006-01-02"
+
+// MarshalJSON implements the json.Marshaler interface
+func (t ISOTime) MarshalJSON() ([]byte, error) {
+	if y := time.Time(t).Year(); y < 0 || y >= 10000 {
+		// ISO 8901 uses 4 digits for the years
+		return nil, errors.New("ISOTime.MarshalJSON: year outside of range [0,9999]")
+	}
+
+	b := make([]byte, 0, len(iso8601)+2)
+	b = append(b, '"')
+	b = time.Time(t).AppendFormat(b, iso8601)
+	b = append(b, '"')
+
+	return b, nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (t *ISOTime) UnmarshalJSON(data []byte) error {
+	// Ignore null, like in the main JSON package
+	if string(data) == "null" {
+		return nil
+	}
+
+	isotime, err := time.Parse(`"`+iso8601+`"`, string(data))
+	*t = ISOTime(isotime)
+
+	return err
+}
+
+// String implements the Stringer interface
+func (t ISOTime) String() string {
+	return time.Time(t).Format(iso8601)
+}
 
 // NotificationLevelValue represents a notification level.
 type NotificationLevelValue int
@@ -92,6 +147,8 @@ func (l *NotificationLevelValue) UnmarshalJSON(data []byte) error {
 		*l = NotificationLevelValue(raw)
 	case string:
 		*l = notificationLevelTypes[raw]
+	case nil:
+		// No action needed.
 	default:
 		return fmt.Errorf("json: cannot unmarshal %T into Go value of type %T", raw, *l)
 	}
@@ -127,6 +184,19 @@ var notificationLevelTypes = map[string]NotificationLevelValue{
 	"custom":        CustomNotificationLevel,
 }
 
+// OrderByValue represent in which order to sort the item
+type OrderByValue string
+
+// These constants represent all valid order by values.
+const (
+	OrderByCreatedAt OrderByValue = "created_at"
+	OrderByID        OrderByValue = "id"
+	OrderByIID       OrderByValue = "iid"
+	OrderByRef       OrderByValue = "ref"
+	OrderByStatus    OrderByValue = "status"
+	OrderByUserID    OrderByValue = "user_id"
+)
+
 // VisibilityValue represents a visibility level within GitLab.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/
@@ -141,13 +211,49 @@ const (
 	PublicVisibility   VisibilityValue = "public"
 )
 
+// EventTypeValue represents actions type for contribution events
+type EventTypeValue string
+
+// List of available action type
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/events.html#action-types
+const (
+	CreatedEventType   EventTypeValue = "created"
+	UpdatedEventType   EventTypeValue = "updated"
+	ClosedEventType    EventTypeValue = "closed"
+	ReopenedEventType  EventTypeValue = "reopened"
+	PushedEventType    EventTypeValue = "pushed"
+	CommentedEventType EventTypeValue = "commented"
+	MergedEventType    EventTypeValue = "merged"
+	JoinedEventType    EventTypeValue = "joined"
+	LeftEventType      EventTypeValue = "left"
+	DestroyedEventType EventTypeValue = "destroyed"
+	ExpiredEventType   EventTypeValue = "expired"
+)
+
+// EventTargetTypeValue represents actions type value for contribution events
+type EventTargetTypeValue string
+
+// List of available action type
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/events.html#target-types
+const (
+	IssueEventTargetType        EventTargetTypeValue = "issue"
+	MilestoneEventTargetType    EventTargetTypeValue = "milestone"
+	MergeRequestEventTargetType EventTargetTypeValue = "merge_request"
+	NoteEventTargetType         EventTargetTypeValue = "note"
+	ProjectEventTargetType      EventTargetTypeValue = "project"
+	SnippetEventTargetType      EventTargetTypeValue = "snippet"
+	UserEventTargetType         EventTargetTypeValue = "user"
+)
+
 // A Client manages communication with the GitLab API.
 type Client struct {
 	// HTTP client used to communicate with the API.
 	client *http.Client
 
 	// Base URL for API requests. Defaults to the public GitLab API, but can be
-	// set to a domain endpoint to use with aself hosted GitLab server. baseURL
+	// set to a domain endpoint to use with a self hosted GitLab server. baseURL
 	// should always be specified with a trailing slash.
 	baseURL *url.URL
 
@@ -161,35 +267,54 @@ type Client struct {
 	UserAgent string
 
 	// Services used for talking to different parts of the GitLab API.
+	AwardEmoji           *AwardEmojiService
 	Branches             *BranchesService
 	BuildVariables       *BuildVariablesService
+	BroadcastMessage     *BroadcastMessagesService
 	Commits              *CommitsService
 	DeployKeys           *DeployKeysService
+	Deployments          *DeploymentsService
+	Environments         *EnvironmentsService
+	Events               *EventsService
 	Features             *FeaturesService
+	GitIgnoreTemplates   *GitIgnoreTemplatesService
 	Groups               *GroupsService
+	GroupMembers         *GroupMembersService
+	GroupMilestones      *GroupMilestonesService
 	Issues               *IssuesService
+	IssueLinks           *IssueLinksService
 	Jobs                 *JobsService
+	Boards               *IssueBoardsService
 	Labels               *LabelsService
 	MergeRequests        *MergeRequestsService
 	Milestones           *MilestonesService
 	Namespaces           *NamespacesService
 	Notes                *NotesService
 	NotificationSettings *NotificationSettingsService
+	PagesDomains         *PagesDomainsService
+	Pipelines            *PipelinesService
+	PipelineSchedules    *PipelineSchedulesService
+	PipelineTriggers     *PipelineTriggersService
 	Projects             *ProjectsService
 	ProjectMembers       *ProjectMembersService
 	ProjectSnippets      *ProjectSnippetsService
-	Pipelines            *PipelinesService
-	PipelineTriggers     *PipelineTriggersService
+	ProtectedBranches    *ProtectedBranchesService
 	Repositories         *RepositoriesService
 	RepositoryFiles      *RepositoryFilesService
+	Runners              *RunnersService
+	Search               *SearchService
 	Services             *ServicesService
 	Session              *SessionService
 	Settings             *SettingsService
+	Sidekiq              *SidekiqService
+	Snippets             *SnippetsService
 	SystemHooks          *SystemHooksService
 	Tags                 *TagsService
 	Todos                *TodosService
 	Users                *UsersService
+	Validate             *ValidateService
 	Version              *VersionService
+	Wikis                *WikisService
 }
 
 // ListOptions specifies the optional parameters to various List methods that
@@ -231,35 +356,54 @@ func newClient(httpClient *http.Client, tokenType tokenType, token string) *Clie
 	timeStats := &timeStatsService{client: c}
 
 	// Create all the public services.
+	c.AwardEmoji = &AwardEmojiService{client: c}
 	c.Branches = &BranchesService{client: c}
 	c.BuildVariables = &BuildVariablesService{client: c}
+	c.BroadcastMessage = &BroadcastMessagesService{client: c}
 	c.Commits = &CommitsService{client: c}
 	c.DeployKeys = &DeployKeysService{client: c}
+	c.Deployments = &DeploymentsService{client: c}
+	c.Environments = &EnvironmentsService{client: c}
+	c.Events = &EventsService{client: c}
 	c.Features = &FeaturesService{client: c}
+	c.GitIgnoreTemplates = &GitIgnoreTemplatesService{client: c}
 	c.Groups = &GroupsService{client: c}
+	c.GroupMembers = &GroupMembersService{client: c}
+	c.GroupMilestones = &GroupMilestonesService{client: c}
 	c.Issues = &IssuesService{client: c, timeStats: timeStats}
+	c.IssueLinks = &IssueLinksService{client: c}
 	c.Jobs = &JobsService{client: c}
+	c.Boards = &IssueBoardsService{client: c}
 	c.Labels = &LabelsService{client: c}
 	c.MergeRequests = &MergeRequestsService{client: c, timeStats: timeStats}
 	c.Milestones = &MilestonesService{client: c}
 	c.Namespaces = &NamespacesService{client: c}
 	c.Notes = &NotesService{client: c}
 	c.NotificationSettings = &NotificationSettingsService{client: c}
+	c.PagesDomains = &PagesDomainsService{client: c}
+	c.Pipelines = &PipelinesService{client: c}
+	c.PipelineSchedules = &PipelineSchedulesService{client: c}
+	c.PipelineTriggers = &PipelineTriggersService{client: c}
 	c.Projects = &ProjectsService{client: c}
 	c.ProjectMembers = &ProjectMembersService{client: c}
 	c.ProjectSnippets = &ProjectSnippetsService{client: c}
-	c.Pipelines = &PipelinesService{client: c}
-	c.PipelineTriggers = &PipelineTriggersService{client: c}
+	c.ProtectedBranches = &ProtectedBranchesService{client: c}
 	c.Repositories = &RepositoriesService{client: c}
 	c.RepositoryFiles = &RepositoryFilesService{client: c}
+	c.Runners = &RunnersService{client: c}
 	c.Services = &ServicesService{client: c}
+	c.Search = &SearchService{client: c}
 	c.Session = &SessionService{client: c}
 	c.Settings = &SettingsService{client: c}
+	c.Sidekiq = &SidekiqService{client: c}
+	c.Snippets = &SnippetsService{client: c}
 	c.SystemHooks = &SystemHooksService{client: c}
 	c.Tags = &TagsService{client: c}
 	c.Todos = &TodosService{client: c}
 	c.Users = &UsersService{client: c}
+	c.Validate = &ValidateService{client: c}
 	c.Version = &VersionService{client: c}
+	c.Wikis = &WikisService{client: c}
 
 	return c
 }
@@ -312,6 +456,10 @@ func (c *Client) NewRequest(method, path string, opt interface{}, options []Opti
 	}
 
 	for _, fn := range options {
+		if fn == nil {
+			continue
+		}
+
 		if err := fn(req); err != nil {
 			return nil, err
 		}
@@ -356,61 +504,50 @@ type Response struct {
 	// results. Any or all of these may be set to the zero value for
 	// responses that are not part of a paginated set, or for which there
 	// are no additional pages.
-
-	NextPage  int
-	PrevPage  int
-	FirstPage int
-	LastPage  int
+	TotalItems   int
+	TotalPages   int
+	ItemsPerPage int
+	CurrentPage  int
+	NextPage     int
+	PreviousPage int
 }
 
-// newResponse creats a new Response for the provided http.Response.
+// newResponse creates a new Response for the provided http.Response.
 func newResponse(r *http.Response) *Response {
 	response := &Response{Response: r}
 	response.populatePageValues()
 	return response
 }
 
+const (
+	xTotal      = "X-Total"
+	xTotalPages = "X-Total-Pages"
+	xPerPage    = "X-Per-Page"
+	xPage       = "X-Page"
+	xNextPage   = "X-Next-Page"
+	xPrevPage   = "X-Prev-Page"
+)
+
 // populatePageValues parses the HTTP Link response headers and populates the
-// various pagination link values in the Reponse.
+// various pagination link values in the Response.
 func (r *Response) populatePageValues() {
-	if links, ok := r.Response.Header["Link"]; ok && len(links) > 0 {
-		for _, link := range strings.Split(links[0], ",") {
-			segments := strings.Split(strings.TrimSpace(link), ";")
-
-			// link must at least have href and rel
-			if len(segments) < 2 {
-				continue
-			}
-
-			// ensure href is properly formatted
-			if !strings.HasPrefix(segments[0], "<") || !strings.HasSuffix(segments[0], ">") {
-				continue
-			}
-
-			// try to pull out page parameter
-			url, err := url.Parse(segments[0][1 : len(segments[0])-1])
-			if err != nil {
-				continue
-			}
-			page := url.Query().Get("page")
-			if page == "" {
-				continue
-			}
-
-			for _, segment := range segments[1:] {
-				switch strings.TrimSpace(segment) {
-				case `rel="next"`:
-					r.NextPage, _ = strconv.Atoi(page)
-				case `rel="prev"`:
-					r.PrevPage, _ = strconv.Atoi(page)
-				case `rel="first"`:
-					r.FirstPage, _ = strconv.Atoi(page)
-				case `rel="last"`:
-					r.LastPage, _ = strconv.Atoi(page)
-				}
-
-			}
-		}
+	if totalItems := r.Response.Header.Get(xTotal); totalItems != "" {
+		r.TotalItems, _ = strconv.Atoi(totalItems)
+	}
+	if totalPages := r.Response.Header.Get(xTotalPages); totalPages != "" {
+		r.TotalPages, _ = strconv.Atoi(totalPages)
+	}
+	if itemsPerPage := r.Response.Header.Get(xPerPage); itemsPerPage != "" {
+		r.ItemsPerPage, _ = strconv.Atoi(itemsPerPage)
+	}
+	if currentPage := r.Response.Header.Get(xPage); currentPage != "" {
+		r.CurrentPage, _ = strconv.Atoi(currentPage)
+	}
+	if nextPage := r.Response.Header.Get(xNextPage); nextPage != "" {
+		r.NextPage, _ = strconv.Atoi(nextPage)
+	}
+	if previousPage := r.Response.Header.Get(xPrevPage); previousPage != "" {
+		r.PreviousPage, _ = strconv.Atoi(previousPage)
 	}
 }
 
@@ -547,16 +684,12 @@ type OptionFunc func(*http.Request) error
 // WithSudo takes either a username or user ID and sets the SUDO request header
 func WithSudo(uid interface{}) OptionFunc {
 	return func(req *http.Request) error {
-		switch uid := uid.(type) {
-		case int:
-			req.Header.Set("SUDO", strconv.Itoa(uid))
-			return nil
-		case string:
-			req.Header.Set("SUDO", uid)
-			return nil
-		default:
-			return fmt.Errorf("uid must be either a username or user ID")
+		user, err := parseID(uid)
+		if err != nil {
+			return err
 		}
+		req.Header.Set("SUDO", user)
+		return nil
 	}
 }
 
@@ -601,10 +734,26 @@ func AccessLevel(v AccessLevelValue) *AccessLevelValue {
 	return p
 }
 
+// BuildState is a helper routine that allocates a new BuildStateValue
+// to store v and returns a pointer to it.
+func BuildState(v BuildStateValue) *BuildStateValue {
+	p := new(BuildStateValue)
+	*p = v
+	return p
+}
+
 // NotificationLevel is a helper routine that allocates a new NotificationLevelValue
 // to store v and returns a pointer to it.
 func NotificationLevel(v NotificationLevelValue) *NotificationLevelValue {
 	p := new(NotificationLevelValue)
+	*p = v
+	return p
+}
+
+// OrderBy is a helper routine that allocates a new OrderByValue
+// to store v and returns a pointer to it.
+func OrderBy(v OrderByValue) *OrderByValue {
+	p := new(OrderByValue)
 	*p = v
 	return p
 }

--- a/vendor/github.com/xanzy/go-gitlab/group_members.go
+++ b/vendor/github.com/xanzy/go-gitlab/group_members.go
@@ -1,0 +1,192 @@
+//
+// Copyright 2017, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// GroupMembersService handles communication with the group members
+// related methods of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/members.html
+type GroupMembersService struct {
+	client *Client
+}
+
+// GroupMember represents a GitLab group member.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/members.html
+type GroupMember struct {
+	ID          int              `json:"id"`
+	Username    string           `json:"username"`
+	Email       string           `json:"email"`
+	Name        string           `json:"name"`
+	State       string           `json:"state"`
+	CreatedAt   *time.Time       `json:"created_at"`
+	AccessLevel AccessLevelValue `json:"access_level"`
+	ExpiresAt   *ISOTime         `json:"expires_at"`
+}
+
+// ListGroupMembersOptions represents the available ListGroupMembers()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
+type ListGroupMembersOptions ListOptions
+
+// ListGroupMembers get a list of group members viewable by the authenticated
+// user.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
+func (s *GroupsService) ListGroupMembers(gid interface{}, opt *ListGroupMembersOptions, options ...OptionFunc) ([]*GroupMember, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/members", url.QueryEscape(group))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var gm []*GroupMember
+	resp, err := s.client.Do(req, &gm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gm, resp, err
+}
+
+// AddGroupMemberOptions represents the available AddGroupMember() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/members.html#add-a-member-to-a-group-or-project
+type AddGroupMemberOptions struct {
+	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
+	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
+	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at"`
+}
+
+// GetGroupMember gets a member of a group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/members.html#get-a-member-of-a-group-or-project
+func (s *GroupMembersService) GetGroupMember(gid interface{}, user int, options ...OptionFunc) (*GroupMember, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/members/%d", url.QueryEscape(group), user)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gm := new(GroupMember)
+	resp, err := s.client.Do(req, gm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gm, resp, err
+}
+
+// AddGroupMember adds a user to the list of group members.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/members.html#add-a-member-to-a-group-or-project
+func (s *GroupMembersService) AddGroupMember(gid interface{}, opt *AddGroupMemberOptions, options ...OptionFunc) (*GroupMember, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/members", url.QueryEscape(group))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gm := new(GroupMember)
+	resp, err := s.client.Do(req, gm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gm, resp, err
+}
+
+// EditGroupMemberOptions represents the available EditGroupMember()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/members.html#edit-a-member-of-a-group-or-project
+type EditGroupMemberOptions struct {
+	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
+	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at"`
+}
+
+// EditGroupMember updates a member of a group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/members.html#edit-a-member-of-a-group-or-project
+func (s *GroupMembersService) EditGroupMember(gid interface{}, user int, opt *EditGroupMemberOptions, options ...OptionFunc) (*GroupMember, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/members/%d", url.QueryEscape(group), user)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gm := new(GroupMember)
+	resp, err := s.client.Do(req, gm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gm, resp, err
+}
+
+// RemoveGroupMember removes user from user team.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/members.html#remove-a-member-from-a-group-or-project
+func (s *GroupMembersService) RemoveGroupMember(gid interface{}, user int, options ...OptionFunc) (*Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/members/%d", url.QueryEscape(group), user)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/xanzy/go-gitlab/group_milestones.go
+++ b/vendor/github.com/xanzy/go-gitlab/group_milestones.go
@@ -1,0 +1,250 @@
+//
+// Copyright 2018, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// GroupMilestonesService handles communication with the milestone related
+// methods of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/group_milestones.html
+type GroupMilestonesService struct {
+	client *Client
+}
+
+// GroupMilestone represents a GitLab milestone.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/group_milestones.html
+type GroupMilestone struct {
+	ID          int        `json:"id"`
+	IID         int        `json:"iid"`
+	GroupID     int        `json:"group_id"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	StartDate   *ISOTime   `json:"start_date"`
+	DueDate     *ISOTime   `json:"due_date"`
+	State       string     `json:"state"`
+	UpdatedAt   *time.Time `json:"updated_at"`
+	CreatedAt   *time.Time `json:"created_at"`
+}
+
+func (m GroupMilestone) String() string {
+	return Stringify(m)
+}
+
+// ListGroupMilestonesOptions represents the available
+// ListGroupMilestones() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#list-group-milestones
+type ListGroupMilestonesOptions struct {
+	ListOptions
+	IIDs   []int  `url:"iids,omitempty" json:"iids,omitempty"`
+	State  string `url:"state,omitempty" json:"state,omitempty"`
+	Search string `url:"search,omitempty" json:"search,omitempty"`
+}
+
+// ListGroupMilestones returns a list of group milestones.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#list-group-milestones
+func (s *GroupMilestonesService) ListGroupMilestones(gid interface{}, opt *ListGroupMilestonesOptions, options ...OptionFunc) ([]*GroupMilestone, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones", url.QueryEscape(group))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var m []*GroupMilestone
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// GetGroupMilestone gets a single group milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#get-single-milestone
+func (s *GroupMilestonesService) GetGroupMilestone(gid interface{}, milestone int, options ...OptionFunc) (*GroupMilestone, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones/%d", url.QueryEscape(group), milestone)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(GroupMilestone)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// CreateGroupMilestoneOptions represents the available CreateGroupMilestone() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#create-new-milestone
+type CreateGroupMilestoneOptions struct {
+	Title       *string  `url:"title,omitempty" json:"title,omitempty"`
+	Description *string  `url:"description,omitempty" json:"description,omitempty"`
+	StartDate   *ISOTime `url:"start_date,omitempty" json:"start_date,omitempty"`
+	DueDate     *ISOTime `url:"due_date,omitempty" json:"due_date,omitempty"`
+}
+
+// CreateGroupMilestone creates a new group milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#create-new-milestone
+func (s *GroupMilestonesService) CreateGroupMilestone(gid interface{}, opt *CreateGroupMilestoneOptions, options ...OptionFunc) (*GroupMilestone, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones", url.QueryEscape(group))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(GroupMilestone)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// UpdateGroupMilestoneOptions represents the available UpdateGroupMilestone() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#edit-milestone
+type UpdateGroupMilestoneOptions struct {
+	Title       *string  `url:"title,omitempty" json:"title,omitempty"`
+	Description *string  `url:"description,omitempty" json:"description,omitempty"`
+	StartDate   *ISOTime `url:"start_date,omitempty" json:"start_date,omitempty"`
+	DueDate     *ISOTime `url:"due_date,omitempty" json:"due_date,omitempty"`
+	StateEvent  *string  `url:"state_event,omitempty" json:"state_event,omitempty"`
+}
+
+// UpdateGroupMilestone updates an existing group milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#edit-milestone
+func (s *GroupMilestonesService) UpdateGroupMilestone(gid interface{}, milestone int, opt *UpdateGroupMilestoneOptions, options ...OptionFunc) (*GroupMilestone, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones/%d", url.QueryEscape(group), milestone)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(GroupMilestone)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// GetGroupMilestoneIssuesOptions represents the available GetGroupMilestoneIssues() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#get-all-issues-assigned-to-a-single-milestone
+type GetGroupMilestoneIssuesOptions ListOptions
+
+// GetGroupMilestoneIssues gets all issues assigned to a single group milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#get-all-issues-assigned-to-a-single-milestone
+func (s *GroupMilestonesService) GetGroupMilestoneIssues(gid interface{}, milestone int, opt *GetGroupMilestoneIssuesOptions, options ...OptionFunc) ([]*Issue, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones/%d/issues", url.QueryEscape(group), milestone)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var i []*Issue
+	resp, err := s.client.Do(req, &i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
+}
+
+// GetGroupMilestoneMergeRequestsOptions represents the available
+// GetGroupMilestoneMergeRequests() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
+type GetGroupMilestoneMergeRequestsOptions ListOptions
+
+// GetGroupMilestoneMergeRequests gets all merge requests assigned to a
+// single group milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
+func (s *GroupMilestonesService) GetGroupMilestoneMergeRequests(gid interface{}, milestone int, opt *GetGroupMilestoneMergeRequestsOptions, options ...OptionFunc) ([]*MergeRequest, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones/%d/merge_requests", url.QueryEscape(group), milestone)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var mr []*MergeRequest
+	resp, err := s.client.Do(req, &mr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return mr, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/groups.go
+++ b/vendor/github.com/xanzy/go-gitlab/groups.go
@@ -19,7 +19,6 @@ package gitlab
 import (
 	"fmt"
 	"net/url"
-	"time"
 )
 
 // GroupsService handles communication with the group related methods of
@@ -236,62 +235,12 @@ func (s *GroupsService) SearchGroup(query string, options ...OptionFunc) ([]*Gro
 	return g, resp, err
 }
 
-// GroupMember represents a GitLab group member.
-//
-// GitLab API docs: https://docs.gitlab.com/ce/api/members.html
-type GroupMember struct {
-	ID          int              `json:"id"`
-	Username    string           `json:"username"`
-	Email       string           `json:"email"`
-	Name        string           `json:"name"`
-	State       string           `json:"state"`
-	CreatedAt   *time.Time       `json:"created_at"`
-	AccessLevel AccessLevelValue `json:"access_level"`
-}
-
-// ListGroupMembersOptions represents the available ListGroupMembers()
-// options.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
-type ListGroupMembersOptions struct {
-	ListOptions
-}
-
-// ListGroupMembers get a list of group members viewable by the authenticated
-// user.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
-func (s *GroupsService) ListGroupMembers(gid interface{}, opt *ListGroupMembersOptions, options ...OptionFunc) ([]*GroupMember, *Response, error) {
-	group, err := parseID(gid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("groups/%s/members", url.QueryEscape(group))
-
-	req, err := s.client.NewRequest("GET", u, opt, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var g []*GroupMember
-	resp, err := s.client.Do(req, &g)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return g, resp, err
-}
-
 // ListGroupProjectsOptions represents the available ListGroupProjects()
 // options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/groups.html#list-a-group-s-projects
-type ListGroupProjectsOptions struct {
-	ListOptions
-}
+type ListGroupProjectsOptions ListOptions
 
 // ListGroupProjects get a list of group projects
 //
@@ -318,91 +267,34 @@ func (s *GroupsService) ListGroupProjects(gid interface{}, opt *ListGroupProject
 	return p, resp, err
 }
 
-// AddGroupMemberOptions represents the available AddGroupMember() options.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#add-a-member-to-a-group-or-project
-type AddGroupMemberOptions struct {
-	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
-	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
-	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at"`
-}
-
-// AddGroupMember adds a user to the list of group members.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#add-a-member-to-a-group-or-project
-func (s *GroupsService) AddGroupMember(gid interface{}, opt *AddGroupMemberOptions, options ...OptionFunc) (*GroupMember, *Response, error) {
-	group, err := parseID(gid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("groups/%s/members", url.QueryEscape(group))
-
-	req, err := s.client.NewRequest("POST", u, opt, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	g := new(GroupMember)
-	resp, err := s.client.Do(req, g)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return g, resp, err
-}
-
-// EditGroupMemberOptions represents the available EditGroupMember()
+// ListSubgroupsOptions represents the available ListSubgroupsOptions()
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#edit-a-member-of-a-group-or-project
-type EditGroupMemberOptions struct {
-	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
-	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at"`
-}
+// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-s-subgroups
+type ListSubgroupsOptions ListGroupsOptions
 
-// EditGroupMember updates a member of a group.
+// ListSubgroups gets a list of subgroups for a given project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#edit-a-member-of-a-group-or-project
-func (s *GroupsService) EditGroupMember(gid interface{}, user int, opt *EditGroupMemberOptions, options ...OptionFunc) (*GroupMember, *Response, error) {
+// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-s-subgroups
+func (s *GroupsService) ListSubgroups(gid interface{}, opt *ListSubgroupsOptions, options ...OptionFunc) ([]*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/members/%d", url.QueryEscape(group), user)
+	u := fmt.Sprintf("groups/%s/subgroups", url.QueryEscape(group))
 
-	req, err := s.client.NewRequest("PUT", u, opt, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	g := new(GroupMember)
-	resp, err := s.client.Do(req, g)
+	var g []*Group
+	resp, err := s.client.Do(req, &g)
 	if err != nil {
 		return nil, resp, err
 	}
 
 	return g, resp, err
-}
-
-// RemoveGroupMember removes user from user team.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#remove-a-member-from-a-group-or-project
-func (s *GroupsService) RemoveGroupMember(gid interface{}, user int, options ...OptionFunc) (*Response, error) {
-	group, err := parseID(gid)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("groups/%s/members/%d", url.QueryEscape(group), user)
-
-	req, err := s.client.NewRequest("DELETE", u, nil, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(req, nil)
 }

--- a/vendor/github.com/xanzy/go-gitlab/issue_links.go
+++ b/vendor/github.com/xanzy/go-gitlab/issue_links.go
@@ -1,0 +1,128 @@
+//
+// Copyright 2017, Arkbriar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// IssueLinksService handles communication with the issue relations related methods
+// of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issue_links.html
+type IssueLinksService struct {
+	client *Client
+}
+
+// IssueLink represents a two-way relation between two issues.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issue_links.html
+type IssueLink struct {
+	SourceIssue *Issue `json:"source_issue"`
+	TargetIssue *Issue `json:"target_issue"`
+}
+
+// ListIssueRelations gets a list of related issues of a given issue,
+// sorted by the relationship creation datetime (ascending).
+//
+// Issues will be filtered according to the user authorizations.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issue_links.html#list-issue-relations
+func (s *IssueLinksService) ListIssueRelations(pid interface{}, issueIID int, options ...OptionFunc) ([]*Issue, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/links", url.QueryEscape(project), issueIID)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var is []*Issue
+	resp, err := s.client.Do(req, &is)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return is, resp, err
+}
+
+// CreateIssueLinkOptions represents the available CreateIssueLink() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issue_links.html
+type CreateIssueLinkOptions struct {
+	TargetProjectID *string `json:"target_project_id"`
+	TargetIssueIID  *string `json:"target_issue_iid"`
+}
+
+// CreateIssueLink creates a two-way relation between two issues.
+// User must be allowed to update both issues in order to succeed.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issue_links.html#create-an-issue-link
+func (s *IssueLinksService) CreateIssueLink(pid interface{}, issueIID int, opt *CreateIssueLinkOptions, options ...OptionFunc) (*IssueLink, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/links", url.QueryEscape(project), issueIID)
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i := new(IssueLink)
+	resp, err := s.client.Do(req, &i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
+}
+
+// DeleteIssueLink deletes an issue link, thus removes the two-way relationship.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issue_links.html#delete-an-issue-link
+func (s *IssueLinksService) DeleteIssueLink(pid interface{}, issueIID, issueLinkID int, options ...OptionFunc) (*IssueLink, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/links/%d",
+		url.QueryEscape(project),
+		issueIID,
+		issueLinkID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i := new(IssueLink)
+	resp, err := s.client.Do(req, &i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/issues.go
+++ b/vendor/github.com/xanzy/go-gitlab/issues.go
@@ -37,22 +37,11 @@ type IssuesService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html
 type Issue struct {
-	ID          int        `json:"id"`
-	IID         int        `json:"iid"`
-	ProjectID   int        `json:"project_id"`
-	Title       string     `json:"title"`
-	Description string     `json:"description"`
-	Labels      []string   `json:"labels"`
-	Milestone   *Milestone `json:"milestone"`
-	Assignee    struct {
-		ID        int        `json:"id"`
-		Username  string     `json:"username"`
-		Email     string     `json:"email"`
-		Name      string     `json:"name"`
-		State     string     `json:"state"`
-		CreatedAt *time.Time `json:"created_at"`
-	} `json:"assignee"`
-	Author struct {
+	ID        int        `json:"id"`
+	IID       int        `json:"iid"`
+	ProjectID int        `json:"project_id"`
+	Milestone *Milestone `json:"milestone"`
+	Author    struct {
 		ID        int        `json:"id"`
 		Username  string     `json:"username"`
 		Email     string     `json:"email"`
@@ -60,14 +49,46 @@ type Issue struct {
 		State     string     `json:"state"`
 		CreatedAt *time.Time `json:"created_at"`
 	} `json:"author"`
-	State          string     `json:"state"`
-	UpdatedAt      *time.Time `json:"updated_at"`
-	CreatedAt      *time.Time `json:"created_at"`
-	Subscribed     bool       `json:"subscribed"`
-	UserNotesCount int        `json:"user_notes_count"`
-	Confidential   bool       `json:"confidential"`
-	DueDate        string     `json:"due_date"`
-	WebURL         string     `json:"web_url"`
+	Description string `json:"description"`
+	State       string `json:"state"`
+	Assignees   []struct {
+		ID        int        `json:"id"`
+		Username  string     `json:"username"`
+		Email     string     `json:"email"`
+		Name      string     `json:"name"`
+		State     string     `json:"state"`
+		CreatedAt *time.Time `json:"created_at"`
+	} `json:"assignees"`
+	Assignee struct {
+		ID        int    `json:"id"`
+		Name      string `json:"name"`
+		Username  string `json:"username"`
+		State     string `json:"state"`
+		AvatarURL string `json:"avatar_url"`
+		WebURL    string `json:"web_url"`
+	} `json:"assignee"`
+	Upvotes          int        `json:"upvotes"`
+	Downvotes        int        `json:"downvotes"`
+	Labels           []string   `json:"labels"`
+	Title            string     `json:"title"`
+	UpdatedAt        *time.Time `json:"updated_at"`
+	CreatedAt        *time.Time `json:"created_at"`
+	ClosedAt         *time.Time `json:"closed_at"`
+	Subscribed       bool       `json:"subscribed"`
+	UserNotesCount   int        `json:"user_notes_count"`
+	DueDate          *ISOTime   `json:"due_date"`
+	WebURL           string     `json:"web_url"`
+	TimeStats        *TimeStats `json:"time_stats"`
+	Confidential     bool       `json:"confidential"`
+	Weight           int        `json:"weight"`
+	DiscussionLocked bool       `json:"discussion_locked"`
+	Links            struct {
+		Self       string `json:"self"`
+		Notes      string `json:"notes"`
+		AwardEmoji string `json:"award_emoji"`
+		Project    string `json:"project"`
+	} `json:"_links"`
+	IssueLinkID int `json:"issue_link_id"`
 }
 
 func (i Issue) String() string {
@@ -146,7 +167,7 @@ func (s *IssuesService) ListGroupIssues(pid interface{}, opt *ListGroupIssuesOpt
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("group/%s/issues", url.QueryEscape(group))
+	u := fmt.Sprintf("groups/%s/issues", url.QueryEscape(group))
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
@@ -235,11 +256,17 @@ func (s *IssuesService) GetIssue(pid interface{}, issue int, options ...OptionFu
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#new-issues
 type CreateIssueOptions struct {
-	Title       *string `url:"title,omitempty" json:"title,omitempty"`
-	Description *string `url:"description,omitempty" json:"description,omitempty"`
-	AssigneeID  *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MilestoneID *int    `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
-	Labels      Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	Title                              *string    `url:"title,omitempty" json:"title,omitempty"`
+	Description                        *string    `url:"description,omitempty" json:"description,omitempty"`
+	Confidential                       *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
+	AssigneeIDs                        []int      `url:"assignee_ids,omitempty" json:"assignee_ids,omitempty"`
+	MilestoneID                        *int       `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
+	Labels                             Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	CreatedAt                          *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
+	DueDate                            *ISOTime   `url:"due_date,omitempty" json:"due_date,omitempty"`
+	MergeRequestToResolveDiscussionsOf *int       `url:"merge_request_to_resolve_discussions_of,omitempty" json:"merge_request_to_resolve_discussions_of,omitempty"`
+	DiscussionToResolve                *string    `url:"discussion_to_resolve,omitempty" json:"discussion_to_resolve,omitempty"`
+	Weight                             *int       `url:"weight,omitempty" json:"weight,omitempty"`
 }
 
 // CreateIssue creates a new project issue.
@@ -270,12 +297,16 @@ func (s *IssuesService) CreateIssue(pid interface{}, opt *CreateIssueOptions, op
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#edit-issues
 type UpdateIssueOptions struct {
-	Title       *string `url:"title,omitempty" json:"title,omitempty"`
-	Description *string `url:"description,omitempty" json:"description,omitempty"`
-	AssigneeID  *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MilestoneID *int    `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
-	Labels      Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	StateEvent  *string `url:"state_event,omitempty" json:"state_event,omitempty"`
+	Title            *string    `url:"title,omitempty" json:"title,omitempty"`
+	Description      *string    `url:"description,omitempty" json:"description,omitempty"`
+	Confidential     *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
+	AssigneeID       *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	MilestoneID      *int       `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
+	Labels           Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	StateEvent       *string    `url:"state_event,omitempty" json:"state_event,omitempty"`
+	UpdatedAt        *time.Time `url:"updated_at,omitempty" json:"updated_at,omitempty"`
+	DueDate          *ISOTime   `url:"due_date,omitempty" json:"due_date,omitempty"`
+	DiscussionLocked *bool      `url:"discussion_locked,omitempty" json:"discussion_locked,omitempty"`
 }
 
 // UpdateIssue updates an existing project issue. This function is also used

--- a/vendor/github.com/xanzy/go-gitlab/jobs.go
+++ b/vendor/github.com/xanzy/go-gitlab/jobs.go
@@ -24,12 +24,6 @@ import (
 	"time"
 )
 
-// ListJobsOptions are options for two list apis
-type ListJobsOptions struct {
-	ListOptions
-	Scope []BuildState `url:"scope,omitempty" json:"scope,omitempty"`
-}
-
 // JobsService handles communication with the ci builds related methods
 // of the GitLab API.
 //
@@ -44,6 +38,7 @@ type JobsService struct {
 type Job struct {
 	Commit        *Commit    `json:"commit"`
 	CreatedAt     *time.Time `json:"created_at"`
+	Coverage      float64    `json:"coverage"`
 	ArtifactsFile struct {
 		Filename string `json:"filename"`
 		Size     int    `json:"size"`
@@ -64,6 +59,12 @@ type Job struct {
 	Status    string     `json:"status"`
 	Tag       bool       `json:"tag"`
 	User      *User      `json:"user"`
+}
+
+// ListJobsOptions are options for two list apis
+type ListJobsOptions struct {
+	ListOptions
+	Scope []BuildStateValue `url:"scope,omitempty" json:"scope,omitempty"`
 }
 
 // ListProjectJobs gets a list of jobs in a project.
@@ -99,19 +100,19 @@ func (s *JobsService) ListProjectJobs(pid interface{}, opts *ListJobsOptions, op
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/jobs.html#list-pipeline-jobs
-func (s *JobsService) ListPipelineJobs(pid interface{}, pipelineID int, opts *ListJobsOptions, options ...OptionFunc) ([]Job, *Response, error) {
+func (s *JobsService) ListPipelineJobs(pid interface{}, pipelineID int, opts *ListJobsOptions, options ...OptionFunc) ([]*Job, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/pipelines/%d/jobs", project, pipelineID)
+	u := fmt.Sprintf("projects/%s/pipelines/%d/jobs", url.QueryEscape(project), pipelineID)
 
 	req, err := s.client.NewRequest("GET", u, opts, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var jobs []Job
+	var jobs []*Job
 	resp, err := s.client.Do(req, &jobs)
 	if err != nil {
 		return nil, resp, err
@@ -129,7 +130,7 @@ func (s *JobsService) GetJob(pid interface{}, jobID int, options ...OptionFunc) 
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/jobs/%d", project, jobID)
+	u := fmt.Sprintf("projects/%s/jobs/%d", url.QueryEscape(project), jobID)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -154,7 +155,7 @@ func (s *JobsService) GetJobArtifacts(pid interface{}, jobID int, options ...Opt
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/jobs/%d/artifacts", project, jobID)
+	u := fmt.Sprintf("projects/%s/jobs/%d/artifacts", url.QueryEscape(project), jobID)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -180,7 +181,7 @@ func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, job
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/jobs/artifacts/%s/download?job=%s", project, refName, job)
+	u := fmt.Sprintf("projects/%s/jobs/artifacts/%s/download?job=%s", url.QueryEscape(project), refName, job)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -205,7 +206,7 @@ func (s *JobsService) GetTraceFile(pid interface{}, jobID int, options ...Option
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/jobs/%d/trace", project, jobID)
+	u := fmt.Sprintf("projects/%s/jobs/%d/trace", url.QueryEscape(project), jobID)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -230,7 +231,7 @@ func (s *JobsService) CancelJob(pid interface{}, jobID int, options ...OptionFun
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/jobs/%d/cancel", project, jobID)
+	u := fmt.Sprintf("projects/%s/jobs/%d/cancel", url.QueryEscape(project), jobID)
 
 	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
@@ -255,7 +256,7 @@ func (s *JobsService) RetryJob(pid interface{}, jobID int, options ...OptionFunc
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/jobs/%d/retry", project, jobID)
+	u := fmt.Sprintf("projects/%s/jobs/%d/retry", url.QueryEscape(project), jobID)
 
 	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
@@ -281,7 +282,7 @@ func (s *JobsService) EraseJob(pid interface{}, jobID int, options ...OptionFunc
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/jobs/%d/erase", project, jobID)
+	u := fmt.Sprintf("projects/%s/jobs/%d/erase", url.QueryEscape(project), jobID)
 
 	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
@@ -307,7 +308,7 @@ func (s *JobsService) KeepArtifacts(pid interface{}, jobID int, options ...Optio
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/jobs/%d/artifacts/keep", project, jobID)
+	u := fmt.Sprintf("projects/%s/jobs/%d/artifacts/keep", url.QueryEscape(project), jobID)
 
 	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
@@ -323,7 +324,7 @@ func (s *JobsService) KeepArtifacts(pid interface{}, jobID int, options ...Optio
 	return job, resp, err
 }
 
-// PlayJob triggers a nanual action to start a job.
+// PlayJob triggers a manual action to start a job.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/jobs.html#play-a-job
@@ -332,7 +333,7 @@ func (s *JobsService) PlayJob(pid interface{}, jobID int, options ...OptionFunc)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/jobs/%d/play", project, jobID)
+	u := fmt.Sprintf("projects/%s/jobs/%d/play", url.QueryEscape(project), jobID)
 
 	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/labels.go
+++ b/vendor/github.com/xanzy/go-gitlab/labels.go
@@ -21,8 +21,8 @@ import (
 	"net/url"
 )
 
-// LabelsService handles communication with the label related methods
-// of the GitLab API.
+// LabelsService handles communication with the label related methods of the
+// GitLab API.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/labels.html
 type LabelsService struct {
@@ -33,29 +33,37 @@ type LabelsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/labels.html
 type Label struct {
+	ID                     int    `json:"id"`
 	Name                   string `json:"name"`
 	Color                  string `json:"color"`
 	Description            string `json:"description"`
 	OpenIssuesCount        int    `json:"open_issues_count"`
 	ClosedIssuesCount      int    `json:"closed_issues_count"`
 	OpenMergeRequestsCount int    `json:"open_merge_requests_count"`
+	Subscribed             bool   `json:"subscribed"`
+	Priority               int    `json:"priority"`
 }
 
 func (l Label) String() string {
 	return Stringify(l)
 }
 
+// ListLabelsOptions represents the available ListLabels() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#list-labels
+type ListLabelsOptions ListOptions
+
 // ListLabels gets all labels for given project.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#list-labels
-func (s *LabelsService) ListLabels(pid interface{}, options ...OptionFunc) ([]*Label, *Response, error) {
+func (s *LabelsService) ListLabels(pid interface{}, opt *ListLabelsOptions, options ...OptionFunc) ([]*Label, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/labels", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -161,4 +169,60 @@ func (s *LabelsService) UpdateLabel(pid interface{}, opt *UpdateLabelOptions, op
 	}
 
 	return l, resp, err
+}
+
+// SubscribeToLabel subscribes the authenticated user to a label to receive
+// notifications. If the user is already subscribed to the label, the status
+// code 304 is returned.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/labels.html#subscribe-to-a-label
+func (s *LabelsService) SubscribeToLabel(pid interface{}, labelID interface{}, options ...OptionFunc) (*Label, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	label, err := parseID(labelID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/labels/%s/subscribe", url.QueryEscape(project), label)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l := new(Label)
+	resp, err := s.client.Do(req, l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, err
+}
+
+// UnsubscribeFromLabel unsubscribes the authenticated user from a label to not
+// receive notifications from it. If the user is not subscribed to the label, the
+// status code 304 is returned.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/labels.html#unsubscribe-from-a-label
+func (s *LabelsService) UnsubscribeFromLabel(pid interface{}, labelID interface{}, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	label, err := parseID(labelID)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/labels/%s/unsubscribe", url.QueryEscape(project), label)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }

--- a/vendor/github.com/xanzy/go-gitlab/merge_requests.go
+++ b/vendor/github.com/xanzy/go-gitlab/merge_requests.go
@@ -35,55 +35,57 @@ type MergeRequestsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/merge_requests.html
 type MergeRequest struct {
-	ID             int    `json:"id"`
-	IID            int    `json:"iid"`
-	ProjectID      int    `json:"project_id"`
-	Title          string `json:"title"`
-	Description    string `json:"description"`
-	WorkInProgress bool   `json:"work_in_progress"`
-	State          string `json:"state"`
-	CreatedAt      string `json:"created_at"`
-	UpdatedAt      string `json:"updated_at"`
-	TargetBranch   string `json:"target_branch"`
-	SourceBranch   string `json:"source_branch"`
-	Upvotes        int    `json:"upvotes"`
-	Downvotes      int    `json:"downvotes"`
-	Author         struct {
-		Name      string `json:"name"`
-		Username  string `json:"username"`
-		ID        int    `json:"id"`
-		State     string `json:"state"`
-		AvatarURL string `json:"avatar_url"`
+	ID           int        `json:"id"`
+	IID          int        `json:"iid"`
+	TargetBranch string     `json:"target_branch"`
+	SourceBranch string     `json:"source_branch"`
+	ProjectID    int        `json:"project_id"`
+	Title        string     `json:"title"`
+	State        string     `json:"state"`
+	CreatedAt    *time.Time `json:"created_at"`
+	UpdatedAt    *time.Time `json:"updated_at"`
+	Upvotes      int        `json:"upvotes"`
+	Downvotes    int        `json:"downvotes"`
+	Author       struct {
+		ID        int        `json:"id"`
+		Username  string     `json:"username"`
+		Name      string     `json:"name"`
+		State     string     `json:"state"`
+		CreatedAt *time.Time `json:"created_at"`
 	} `json:"author"`
 	Assignee struct {
-		Name      string `json:"name"`
-		Username  string `json:"username"`
-		ID        int    `json:"id"`
-		State     string `json:"state"`
-		AvatarURL string `json:"avatar_url"`
+		ID        int        `json:"id"`
+		Username  string     `json:"username"`
+		Name      string     `json:"name"`
+		State     string     `json:"state"`
+		CreatedAt *time.Time `json:"created_at"`
 	} `json:"assignee"`
-	SourceProjectID int      `json:"source_project_id"`
-	TargetProjectID int      `json:"target_project_id"`
-	Labels          []string `json:"labels"`
-	Milestone       struct {
-		ID          int        `json:"id"`
-		Iid         int        `json:"iid"`
-		ProjectID   int        `json:"project_id"`
-		Title       string     `json:"title"`
-		Description string     `json:"description"`
-		State       string     `json:"state"`
-		CreatedAt   *time.Time `json:"created_at"`
-		UpdatedAt   *time.Time `json:"updated_at"`
-		DueDate     string     `json:"due_date"`
-	} `json:"milestone"`
-	MergeWhenPipelineSucceeds bool   `json:"merge_when_pipeline_succeeds"`
-	MergeStatus               string `json:"merge_status"`
-	SHA                       string `json:"sha"`
-	Subscribed                bool   `json:"subscribed"`
-	UserNotesCount            int    `json:"user_notes_count"`
-	SouldRemoveSourceBranch   bool   `json:"should_remove_source_branch"`
-	ForceRemoveSourceBranch   bool   `json:"force_remove_source_branch"`
-	Changes                   []struct {
+	SourceProjectID           int        `json:"source_project_id"`
+	TargetProjectID           int        `json:"target_project_id"`
+	Labels                    []string   `json:"labels"`
+	Description               string     `json:"description"`
+	WorkInProgress            bool       `json:"work_in_progress"`
+	Milestone                 *Milestone `json:"milestone"`
+	MergeWhenPipelineSucceeds bool       `json:"merge_when_pipeline_succeeds"`
+	MergeStatus               string     `json:"merge_status"`
+	MergedBy                  struct {
+		ID        int        `json:"id"`
+		Username  string     `json:"username"`
+		Name      string     `json:"name"`
+		State     string     `json:"state"`
+		CreatedAt *time.Time `json:"created_at"`
+	} `json:"merged_by"`
+	MergedAt                 *time.Time `json:"merged_at"`
+	Subscribed               bool       `json:"subscribed"`
+	SHA                      string     `json:"sha"`
+	MergeCommitSHA           string     `json:"merge_commit_sha"`
+	UserNotesCount           int        `json:"user_notes_count"`
+	ChangesCount             string     `json:"changes_count"`
+	ShouldRemoveSourceBranch bool       `json:"should_remove_source_branch"`
+	ForceRemoveSourceBranch  bool       `json:"force_remove_source_branch"`
+	WebURL                   string     `json:"web_url"`
+	DiscussionLocked         bool       `json:"discussion_locked"`
+	Changes                  []struct {
 		OldPath     string `json:"old_path"`
 		NewPath     string `json:"new_path"`
 		AMode       string `json:"a_mode"`
@@ -93,7 +95,7 @@ type MergeRequest struct {
 		RenamedFile bool   `json:"renamed_file"`
 		DeletedFile bool   `json:"deleted_file"`
 	} `json:"changes"`
-	WebURL string `json:"web_url"`
+	TimeStats *TimeStats `json:"time_stats"`
 }
 
 func (m MergeRequest) String() string {
@@ -131,6 +133,27 @@ func (m MergeRequestApprovals) String() string {
 	return Stringify(m)
 }
 
+// MergeRequestDiffVersion represents Gitlab merge request version.
+//
+// Gitlab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#get-a-single-mr-diff-version
+type MergeRequestDiffVersion struct {
+	ID             int        `json:"id"`
+	HeadCommitSHA  string     `json:"head_commit_sha,omitempty"`
+	BaseCommitSHA  string     `json:"base_commit_sha,omitempty"`
+	StartCommitSHA string     `json:"start_commit_sha,omitempty"`
+	CreatedAt      *time.Time `json:"created_at,omitempty"`
+	MergeRequestID int        `json:"merge_request_id,omitempty"`
+	State          string     `json:"state,omitempty"`
+	RealSize       string     `json:"real_size,omitempty"`
+	Commits        []*Commit  `json:"commits,omitempty"`
+	Diffs          []*Diff    `json:"diffs,omitempty"`
+}
+
+func (m MergeRequestDiffVersion) String() string {
+	return Stringify(m)
+}
+
 // ListMergeRequestsOptions represents the available ListMergeRequests()
 // options.
 //
@@ -152,10 +175,10 @@ type ListMergeRequestsOptions struct {
 	MyReactionEmoji *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
 }
 
-// ListMergeRequests gets all merge requests. The state
-// parameter can be used to get only merge requests with a given state (opened,
-// closed, or merged) or all of them (all). The pagination parameters page and
-// per_page can be used to restrict the list of merge requests.
+// ListMergeRequests gets all merge requests. The state parameter can be used
+// to get only merge requests with a given state (opened, closed, or merged)
+// or all of them (all). The pagination parameters page and per_page can be
+// used to restrict the list of merge requests.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests
@@ -274,18 +297,25 @@ func (s *MergeRequestsService) GetMergeRequestApprovals(pid interface{}, mergeRe
 	return a, resp, err
 }
 
+// GetMergeRequestCommitsOptions represents the available GetMergeRequestCommits()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-commits
+type GetMergeRequestCommitsOptions ListOptions
+
 // GetMergeRequestCommits gets a list of merge request commits.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-commits
-func (s *MergeRequestsService) GetMergeRequestCommits(pid interface{}, mergeRequest int, options ...OptionFunc) ([]*Commit, *Response, error) {
+func (s *MergeRequestsService) GetMergeRequestCommits(pid interface{}, mergeRequest int, opt *GetMergeRequestCommitsOptions, options ...OptionFunc) ([]*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d/commits", url.QueryEscape(project), mergeRequest)
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -323,6 +353,64 @@ func (s *MergeRequestsService) GetMergeRequestChanges(pid interface{}, mergeRequ
 	}
 
 	return m, resp, err
+}
+
+// ListMergeRequestPipelines gets all pipelines for the provided merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#list-mr-pipelines
+func (s *MergeRequestsService) ListMergeRequestPipelines(pid interface{}, mergeRequest int, options ...OptionFunc) (PipelineList, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%v/pipelines", url.QueryEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var p PipelineList
+	resp, err := s.client.Do(req, &p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// GetIssuesClosedOnMergeOptions represents the available GetIssuesClosedOnMerge()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#list-issues-that-will-close-on-merge
+type GetIssuesClosedOnMergeOptions ListOptions
+
+// GetIssuesClosedOnMerge gets all the issues that would be closed by merging the
+// provided merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#list-issues-that-will-close-on-merge
+func (s *MergeRequestsService) GetIssuesClosedOnMerge(pid interface{}, mergeRequest int, opt *GetIssuesClosedOnMergeOptions, options ...OptionFunc) ([]*Issue, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("/projects/%s/merge_requests/%v/closes_issues", url.QueryEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var i []*Issue
+	resp, err := s.client.Do(req, &i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
 }
 
 // CreateMergeRequestOptions represents the available CreateMergeRequest()
@@ -404,6 +492,25 @@ func (s *MergeRequestsService) UpdateMergeRequest(pid interface{}, mergeRequest 
 	return m, resp, err
 }
 
+// DeleteMergeRequest deletes a merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#delete-a-merge-request
+func (s *MergeRequestsService) DeleteMergeRequest(pid interface{}, mergeRequest int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d", url.QueryEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // AcceptMergeRequestOptions represents the available AcceptMergeRequest()
 // options.
 //
@@ -442,6 +549,173 @@ func (s *MergeRequestsService) AcceptMergeRequest(pid interface{}, mergeRequest 
 	}
 
 	return m, resp, err
+}
+
+// CancelMergeWhenPipelineSucceeds cancels a merge when pipeline succeeds. If
+// you don't have permissions to accept this merge request - you'll get a 401.
+// If the merge request is already merged or closed - you get 405 and error
+// message 'Method Not Allowed'. In case the merge request is not set to be
+// merged when the pipeline succeeds, you'll also get a 406 error.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#cancel-merge-when-pipeline-succeeds
+func (s *MergeRequestsService) CancelMergeWhenPipelineSucceeds(pid interface{}, mergeRequest int, options ...OptionFunc) (*MergeRequest, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/cancel_merge_when_pipeline_succeeds", url.QueryEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("PUT", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(MergeRequest)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// GetMergeRequestDiffVersionsOptions represents the available
+// GetMergeRequestDiffVersions() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#get-mr-diff-versions
+type GetMergeRequestDiffVersionsOptions ListOptions
+
+// GetMergeRequestDiffVersions get a list of merge request diff versions.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#get-mr-diff-versions
+func (s *MergeRequestsService) GetMergeRequestDiffVersions(pid interface{}, mergeRequest int, opt *GetMergeRequestDiffVersionsOptions, options ...OptionFunc) ([]*MergeRequestDiffVersion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/versions", url.QueryEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var v []*MergeRequestDiffVersion
+	resp, err := s.client.Do(req, &v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return v, resp, err
+}
+
+// GetSingleMergeRequestDiffVersion get a single MR diff version
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#get-a-single-mr-diff-version
+func (s *MergeRequestsService) GetSingleMergeRequestDiffVersion(pid interface{}, mergeRequest, version int, options ...OptionFunc) (*MergeRequestDiffVersion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/versions/%d", url.QueryEscape(project), mergeRequest, version)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var v = new(MergeRequestDiffVersion)
+	resp, err := s.client.Do(req, v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return v, resp, err
+}
+
+// SubscribeToMergeRequest subscribes the authenticated user to the given merge request
+// to receive notifications. If the user is already subscribed to the
+// merge request, the status code 304 is returned.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#subscribe-to-a-merge-request
+func (s *MergeRequestsService) SubscribeToMergeRequest(pid interface{}, mergeRequest int, options ...OptionFunc) (*MergeRequest, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/subscribe", url.QueryEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(MergeRequest)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// UnsubscribeFromMergeRequest unsubscribes the authenticated user from the given merge request
+// to not receive notifications from that merge request. If the user is
+// not subscribed to the merge request, status code 304 is returned.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#unsubscribe-from-a-merge-request
+func (s *MergeRequestsService) UnsubscribeFromMergeRequest(pid interface{}, mergeRequest int, options ...OptionFunc) (*MergeRequest, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/unsubscribe", url.QueryEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(MergeRequest)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// CreateTodo manually creates a todo for the current user on a merge request.
+// If there already exists a todo for the user on that merge request,
+// status code 304 is returned.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#create-a-todo
+func (s *MergeRequestsService) CreateTodo(pid interface{}, mergeRequest int, options ...OptionFunc) (*Todo, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/todo", url.QueryEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(Todo)
+	resp, err := s.client.Do(req, t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, err
 }
 
 // SetTimeEstimate sets the time estimate for a single project merge request.

--- a/vendor/github.com/xanzy/go-gitlab/milestones.go
+++ b/vendor/github.com/xanzy/go-gitlab/milestones.go
@@ -35,12 +35,12 @@ type MilestonesService struct {
 // GitLab API docs: https://docs.gitlab.com/ce/api/milestones.html
 type Milestone struct {
 	ID          int        `json:"id"`
-	Iid         int        `json:"iid"`
+	IID         int        `json:"iid"`
 	ProjectID   int        `json:"project_id"`
 	Title       string     `json:"title"`
 	Description string     `json:"description"`
-	StartDate   string     `json:"start_date"`
-	DueDate     string     `json:"due_date"`
+	StartDate   *ISOTime   `json:"start_date"`
+	DueDate     *ISOTime   `json:"due_date"`
 	State       string     `json:"state"`
 	UpdatedAt   *time.Time `json:"updated_at"`
 	CreatedAt   *time.Time `json:"created_at"`
@@ -56,7 +56,9 @@ func (m Milestone) String() string {
 // https://docs.gitlab.com/ce/api/milestones.html#list-project-milestones
 type ListMilestonesOptions struct {
 	ListOptions
-	IIDs []int `url:"iids,omitempty" json:"iids,omitempty"`
+	IIDs   []int  `url:"iids,omitempty" json:"iids,omitempty"`
+	State  string `url:"state,omitempty" json:"state,omitempty"`
+	Search string `url:"search,omitempty" json:"search,omitempty"`
 }
 
 // ListMilestones returns a list of project milestones.
@@ -114,10 +116,10 @@ func (s *MilestonesService) GetMilestone(pid interface{}, milestone int, options
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/milestones.html#create-new-milestone
 type CreateMilestoneOptions struct {
-	Title       *string `url:"title,omitempty" json:"title,omitempty"`
-	Description *string `url:"description,omitempty" json:"description,omitempty"`
-	StartDate   *string `url:"start_date,omitempty" json:"start_date,omitempty"`
-	DueDate     *string `url:"due_date,omitempty" json:"due_date,omitempty"`
+	Title       *string  `url:"title,omitempty" json:"title,omitempty"`
+	Description *string  `url:"description,omitempty" json:"description,omitempty"`
+	StartDate   *ISOTime `url:"start_date,omitempty" json:"start_date,omitempty"`
+	DueDate     *ISOTime `url:"due_date,omitempty" json:"due_date,omitempty"`
 }
 
 // CreateMilestone creates a new project milestone.
@@ -150,11 +152,11 @@ func (s *MilestonesService) CreateMilestone(pid interface{}, opt *CreateMileston
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/milestones.html#edit-milestone
 type UpdateMilestoneOptions struct {
-	Title       *string `url:"title,omitempty" json:"title,omitempty"`
-	Description *string `url:"description,omitempty" json:"description,omitempty"`
-	StartDate   *string `url:"start_date,omitempty" json:"start_date,omitempty"`
-	DueDate     *string `url:"due_date,omitempty" json:"due_date,omitempty"`
-	StateEvent  *string `url:"state_event,omitempty" json:"state_event,omitempty"`
+	Title       *string  `url:"title,omitempty" json:"title,omitempty"`
+	Description *string  `url:"description,omitempty" json:"description,omitempty"`
+	StartDate   *ISOTime `url:"start_date,omitempty" json:"start_date,omitempty"`
+	DueDate     *ISOTime `url:"due_date,omitempty" json:"due_date,omitempty"`
+	StateEvent  *string  `url:"state_event,omitempty" json:"state_event,omitempty"`
 }
 
 // UpdateMilestone updates an existing project milestone.
@@ -186,9 +188,7 @@ func (s *MilestonesService) UpdateMilestone(pid interface{}, milestone int, opt 
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/milestones.html#get-all-issues-assigned-to-a-single-milestone
-type GetMilestoneIssuesOptions struct {
-	ListOptions
-}
+type GetMilestoneIssuesOptions ListOptions
 
 // GetMilestoneIssues gets all issues assigned to a single project milestone.
 //
@@ -213,4 +213,37 @@ func (s *MilestonesService) GetMilestoneIssues(pid interface{}, milestone int, o
 	}
 
 	return i, resp, err
+}
+
+// GetMilestoneMergeRequestsOptions represents the available
+// GetMilestoneMergeRequests() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
+type GetMilestoneMergeRequestsOptions ListOptions
+
+// GetMilestoneMergeRequests gets all merge requests assigned to a single
+// project milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
+func (s *MilestonesService) GetMilestoneMergeRequests(pid interface{}, milestone int, opt *GetMilestoneMergeRequestsOptions, options ...OptionFunc) ([]*MergeRequest, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/milestones/%d/merge_requests", url.QueryEscape(project), milestone)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var mr []*MergeRequest
+	resp, err := s.client.Do(req, &mr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return mr, resp, err
 }

--- a/vendor/github.com/xanzy/go-gitlab/namespaces.go
+++ b/vendor/github.com/xanzy/go-gitlab/namespaces.go
@@ -16,6 +16,10 @@
 
 package gitlab
 
+import (
+	"fmt"
+)
+
 // NamespacesService handles communication with the namespace related methods
 // of the GitLab API.
 //
@@ -28,9 +32,13 @@ type NamespacesService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/namespaces.html
 type Namespace struct {
-	ID   int    `json:"id"`
-	Path string `json:"path"`
-	Kind string `json:"kind"`
+	ID                          int    `json:"id"`
+	Name                        string `json:"name"`
+	Path                        string `json:"path"`
+	Kind                        string `json:"kind"`
+	FullPath                    string `json:"full_path"`
+	ParentID                    int    `json:"parent_id"`
+	MembersCountWithDescendants int    `json:"members_count_with_descendants"`
 }
 
 func (n Namespace) String() string {
@@ -81,6 +89,31 @@ func (s *NamespacesService) SearchNamespace(query string, options ...OptionFunc)
 
 	var n []*Namespace
 	resp, err := s.client.Do(req, &n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// GetNamespace gets a namespace by id.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/namespaces.html#get-namespace-by-id
+func (s *NamespacesService) GetNamespace(id interface{}, options ...OptionFunc) (*Namespace, *Response, error) {
+	namespace, err := parseID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("namespaces/%s", namespace)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := new(Namespace)
+	resp, err := s.client.Do(req, n)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/vendor/github.com/xanzy/go-gitlab/notes.go
+++ b/vendor/github.com/xanzy/go-gitlab/notes.go
@@ -46,11 +46,16 @@ type Note struct {
 		Name      string     `json:"name"`
 		State     string     `json:"state"`
 		CreatedAt *time.Time `json:"created_at"`
+		AvatarURL string     `json:"avatar_url"`
+		WebURL    string     `json:"web_url"`
 	} `json:"author"`
-	System    bool       `json:"system"`
-	ExpiresAt *time.Time `json:"expires_at"`
-	UpdatedAt *time.Time `json:"updated_at"`
-	CreatedAt *time.Time `json:"created_at"`
+	System       bool       `json:"system"`
+	ExpiresAt    *time.Time `json:"expires_at"`
+	UpdatedAt    *time.Time `json:"updated_at"`
+	CreatedAt    *time.Time `json:"created_at"`
+	NoteableID   int        `json:"noteable_id"`
+	NoteableType string     `json:"noteable_type"`
+	NoteableIID  int        `json:"noteable_iid"`
 }
 
 func (n Note) String() string {
@@ -61,9 +66,7 @@ func (n Note) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#list-project-issue-notes
-type ListIssueNotesOptions struct {
-	ListOptions
-}
+type ListIssueNotesOptions ListOptions
 
 // ListIssueNotes gets a list of all notes for a single issue.
 //
@@ -200,19 +203,25 @@ func (s *NotesService) DeleteIssueNote(pid interface{}, issue, note int, options
 	return s.client.Do(req, nil)
 }
 
+// ListSnippetNotesOptions represents the available ListSnippetNotes() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/notes.html#list-all-snippet-notes
+type ListSnippetNotesOptions ListOptions
+
 // ListSnippetNotes gets a list of all notes for a single snippet. Snippet
 // notes are comments users can post to a snippet.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#list-all-snippet-notes
-func (s *NotesService) ListSnippetNotes(pid interface{}, snippet int, options ...OptionFunc) ([]*Note, *Response, error) {
+func (s *NotesService) ListSnippetNotes(pid interface{}, snippet int, opt *ListSnippetNotesOptions, options ...OptionFunc) ([]*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/snippets/%d/notes", url.QueryEscape(project), snippet)
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -337,18 +346,25 @@ func (s *NotesService) DeleteSnippetNote(pid interface{}, snippet, note int, opt
 	return s.client.Do(req, nil)
 }
 
+// ListMergeRequestNotesOptions represents the available ListMergeRequestNotes()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/notes.html#list-all-merge-request-notes
+type ListMergeRequestNotesOptions ListOptions
+
 // ListMergeRequestNotes gets a list of all notes for a single merge request.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#list-all-merge-request-notes
-func (s *NotesService) ListMergeRequestNotes(pid interface{}, mergeRequest int, options ...OptionFunc) ([]*Note, *Response, error) {
+func (s *NotesService) ListMergeRequestNotes(pid interface{}, mergeRequest int, opt *ListMergeRequestNotesOptions, options ...OptionFunc) ([]*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d/notes", url.QueryEscape(project), mergeRequest)
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/xanzy/go-gitlab/notifications.go
+++ b/vendor/github.com/xanzy/go-gitlab/notifications.go
@@ -24,7 +24,7 @@ type NotificationSettings struct {
 	Events            *NotificationEvents    `json:"events"`
 }
 
-// NotificationEvents represents the avialable notification setting events.
+// NotificationEvents represents the available notification setting events.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notification_settings.html#notification-settings

--- a/vendor/github.com/xanzy/go-gitlab/pages_domains.go
+++ b/vendor/github.com/xanzy/go-gitlab/pages_domains.go
@@ -1,0 +1,175 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// PagesDomainsService handles communication with the pages domains
+// related methods of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/pages_domains.html
+type PagesDomainsService struct {
+	client *Client
+}
+
+// PagesDomain represents a pages domain.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/pages_domains.html
+type PagesDomain struct {
+	Domain           string     `json:"domain"`
+	URL              string     `json:"url"`
+	ProjectID        int        `json:"project_id"`
+	Verified         bool       `json:"verified"`
+	VerificationCode string     `json:"verification_code"`
+	EnabledUntil     *time.Time `json:"enabled_until"`
+	Certificate      struct {
+		Expired    bool       `json:"expired"`
+		Expiration *time.Time `json:"expiration"`
+	} `json:"certificate"`
+}
+
+// ListPagesDomainsOptions represents the available ListPagesDomains() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pages_domains.html#list-pages-domains
+type ListPagesDomainsOptions ListOptions
+
+// ListPagesDomains gets a list of project pages domains.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pages_domains.html#list-pages-domains
+func (s *PagesDomainsService) ListPagesDomains(pid interface{}, opt *ListPagesDomainsOptions, options ...OptionFunc) ([]*PagesDomain, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pages/domains", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var pd []*PagesDomain
+	resp, err := s.client.Do(req, &pd)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pd, resp, err
+}
+
+// GetPagesDomain get a specific pages domain for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pages_domains.html#single-pages-domain
+func (s *PagesDomainsService) GetPagesDomain(pid interface{}, domain string, options ...OptionFunc) (*PagesDomain, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pages/domains/%s", url.QueryEscape(project), domain)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pd := new(PagesDomain)
+	resp, err := s.client.Do(req, pd)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pd, resp, err
+}
+
+// CreatePagesDomainOptions represents the available CreatePagesDomain() options.
+//
+// GitLab API docs:
+// // https://docs.gitlab.com/ce/api/pages_domains.html#create-new-pages-domain
+type CreatePagesDomainOptions struct {
+	Domain      *string `url:"domain,omitempty" json:"domain,omitempty"`
+	Certificate *string `url:"certifiate,omitempty" json:"certifiate,omitempty"`
+	Key         *string `url:"key,omitempty" json:"key,omitempty"`
+}
+
+// CreatePagesDomain creates a new project pages domain.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pages_domains.html#create-new-pages-domain
+func (s *PagesDomainsService) CreatePagesDomain(pid interface{}, opt *CreatePagesDomainOptions, options ...OptionFunc) (*PagesDomain, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pages/domains", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pd := new(PagesDomain)
+	resp, err := s.client.Do(req, pd)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pd, resp, err
+}
+
+// UpdatePagesDomainOptions represents the available UpdatePagesDomain() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pages_domains.html#update-pages-domain
+type UpdatePagesDomainOptions struct {
+	Cerificate *string `url:"certifiate" json:"certifiate"`
+	Key        *string `url:"key" json:"key"`
+}
+
+// UpdatePagesDomain updates an existing project pages domain.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pages_domains.html#update-pages-domain
+func (s *PagesDomainsService) UpdatePagesDomain(pid interface{}, domain string, opt *UpdatePagesDomainOptions, options ...OptionFunc) (*PagesDomain, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pages/domains/%s", url.QueryEscape(project), domain)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pd := new(PagesDomain)
+	resp, err := s.client.Do(req, pd)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pd, resp, err
+}
+
+// DeletePagesDomain deletes an existing prject pages domain.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pages_domains.html#delete-pages-domain
+func (s *PagesDomainsService) DeletePagesDomain(pid interface{}, domain string, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pages/domains/%s", url.QueryEscape(project), domain)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/xanzy/go-gitlab/pipeline_schedules.go
+++ b/vendor/github.com/xanzy/go-gitlab/pipeline_schedules.go
@@ -1,0 +1,341 @@
+//
+// Copyright 2018, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// PipelineSchedulesService handles communication with the pipeline
+// schedules related methods of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/pipeline_schedules.html
+type PipelineSchedulesService struct {
+	client *Client
+}
+
+// PipelineVariable represents a pipeline schedule variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#pipeline-schedule-variable
+type PipelineVariable struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// PipelineSchedule represents a pipeline schedule.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html
+type PipelineSchedule struct {
+	ID           int        `json:"id"`
+	Description  string     `json:"description"`
+	Ref          string     `json:"ref"`
+	Cron         string     `json:"cron"`
+	CronTimezone string     `json:"cron_timezone"`
+	NextRunAt    *time.Time `json:"next_run_at"`
+	Active       bool       `json:"active"`
+	CreatedAt    *time.Time `json:"created_at"`
+	UpdatedAt    *time.Time `json:"updated_at"`
+	Owner        *User      `json:"owner"`
+	LastPipeline struct {
+		ID     int    `json:"id"`
+		Sha    string `json:"sha"`
+		Ref    string `json:"ref"`
+		Status string `json:"status"`
+	} `json:"last_pipeline"`
+	Variables []*PipelineVariable `json:"variables"`
+}
+
+// ListPipelineSchedulesOptions represents the available ListPipelineTriggers() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_triggers.html#list-project-triggers
+type ListPipelineSchedulesOptions ListOptions
+
+// ListPipelineSchedules gets a list of project triggers.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html
+func (s *PipelineSchedulesService) ListPipelineSchedules(pid interface{}, opt *ListPipelineSchedulesOptions, options ...OptionFunc) ([]*PipelineSchedule, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipeline_schedules", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ps []*PipelineSchedule
+	resp, err := s.client.Do(req, &ps)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ps, resp, err
+}
+
+// GetPipelineSchedule gets a pipeline schedule.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html
+func (s *PipelineSchedulesService) GetPipelineSchedule(pid interface{}, schedule int, options ...OptionFunc) (*PipelineSchedule, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipeline_schedules/%d", url.QueryEscape(project), schedule)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PipelineSchedule)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// CreatePipelineScheduleOptions represents the available
+// CreatePipelineSchedule() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+type CreatePipelineScheduleOptions struct {
+	Description  *string `url:"description" json:"description"`
+	Ref          *string `url:"ref" json:"ref"`
+	Cron         *string `url:"cron" json:"cron"`
+	CronTimezone *string `url:"cron_timezone,omitempty" json:"cron_timezone,omitempty"`
+	Active       *bool   `url:"active,omitempty" json:"active,omitempty"`
+}
+
+// CreatePipelineSchedule creates a pipeline schedule.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+func (s *PipelineSchedulesService) CreatePipelineSchedule(pid interface{}, opt *CreatePipelineScheduleOptions, options ...OptionFunc) (*PipelineSchedule, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipeline_schedules", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PipelineSchedule)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// EditPipelineScheduleOptions represents the available
+// EditPipelineSchedule() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+type EditPipelineScheduleOptions struct {
+	Description  *string `url:"description,omitempty" json:"description,omitempty"`
+	Ref          *string `url:"ref,omitempty" json:"ref,omitempty"`
+	Cron         *string `url:"cron,omitempty" json:"cron,omitempty"`
+	CronTimezone *string `url:"cron_timezone,omitempty" json:"cron_timezone,omitempty"`
+	Active       *bool   `url:"active,omitempty" json:"active,omitempty"`
+}
+
+// EditPipelineSchedule edits a pipeline schedule.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#edit-a-pipeline-schedule
+func (s *PipelineSchedulesService) EditPipelineSchedule(pid interface{}, schedule int, opt *EditPipelineScheduleOptions, options ...OptionFunc) (*PipelineSchedule, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipeline_schedules/%d", url.QueryEscape(project), schedule)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PipelineSchedule)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// TakeOwnershipOfPipelineSchedule sets the owner of the specified
+// pipeline schedule to the user issuing the request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#take-ownership-of-a-pipeline-schedule
+func (s *PipelineSchedulesService) TakeOwnershipOfPipelineSchedule(pid interface{}, schedule int, options ...OptionFunc) (*PipelineSchedule, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipeline_schedules/%d/take_ownership", url.QueryEscape(project), schedule)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PipelineSchedule)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// DeletePipelineSchedule deletes a pipeline schedule.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#delete-a-pipeline-schedule
+func (s *PipelineSchedulesService) DeletePipelineSchedule(pid interface{}, schedule int, options ...OptionFunc) (*PipelineSchedule, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipeline_schedules/%d", url.QueryEscape(project), schedule)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PipelineSchedule)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// CreatePipelineScheduleVariableOptions represents the available
+// CreatePipelineScheduleVariable() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+type CreatePipelineScheduleVariableOptions struct {
+	Key   *string `url:"key" json:"key"`
+	Value *string `url:"value" json:"value"`
+}
+
+// CreatePipelineScheduleVariable creates a pipeline schedule variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+func (s *PipelineSchedulesService) CreatePipelineScheduleVariable(pid interface{}, schedule int, opt *CreatePipelineScheduleVariableOptions, options ...OptionFunc) (*PipelineVariable, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipeline_schedules/%d/variables", url.QueryEscape(project), schedule)
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PipelineVariable)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// EditPipelineScheduleVariableOptions represents the available
+// EditPipelineScheduleVariable() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#edit-a-pipeline-schedule-variable
+type EditPipelineScheduleVariableOptions struct {
+	Value *string `url:"value" json:"value"`
+}
+
+// EditPipelineScheduleVariable creates a pipeline schedule variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#edit-a-pipeline-schedule-variable
+func (s *PipelineSchedulesService) EditPipelineScheduleVariable(pid interface{}, schedule int, key string, opt *EditPipelineScheduleVariableOptions, options ...OptionFunc) (*PipelineVariable, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipeline_schedules/%d/variables/%s", url.QueryEscape(project), schedule, key)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PipelineVariable)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// DeletePipelineScheduleVariable creates a pipeline schedule variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#delete-a-pipeline-schedule-variable
+func (s *PipelineSchedulesService) DeletePipelineScheduleVariable(pid interface{}, schedule int, key string, options ...OptionFunc) (*PipelineVariable, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipeline_schedules/%d/variables/%s", url.QueryEscape(project), schedule, key)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PipelineVariable)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/pipeline_triggers.go
+++ b/vendor/github.com/xanzy/go-gitlab/pipeline_triggers.go
@@ -33,9 +33,7 @@ type PipelineTrigger struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/pipeline_triggers.html#list-project-triggers
-type ListPipelineTriggersOptions struct {
-	ListOptions
-}
+type ListPipelineTriggersOptions ListOptions
 
 // ListPipelineTriggers gets a list of project triggers.
 //
@@ -196,4 +194,39 @@ func (s *PipelineTriggersService) DeletePipelineTrigger(pid interface{}, trigger
 	}
 
 	return s.client.Do(req, nil)
+}
+
+// RunPipelineTriggerOptions represents the available RunPipelineTrigger() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/ci/triggers/README.html#triggering-a-pipeline
+type RunPipelineTriggerOptions struct {
+	Ref       *string           `url:"ref" json:"ref"`
+	Token     *string           `url:"token" json:"token"`
+	Variables map[string]string `url:"variables,omitempty" json:"variables,omitempty"`
+}
+
+// RunPipelineTrigger starts a trigger from a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/ci/triggers/README.html#triggering-a-pipeline
+func (s *PipelineTriggersService) RunPipelineTrigger(pid interface{}, opt *RunPipelineTriggerOptions, options ...OptionFunc) (*Pipeline, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/trigger/pipeline", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pt := new(Pipeline)
+	resp, err := s.client.Do(req, pt)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pt, resp, err
 }

--- a/vendor/github.com/xanzy/go-gitlab/pipelines.go
+++ b/vendor/github.com/xanzy/go-gitlab/pipelines.go
@@ -76,17 +76,32 @@ func (i PipelineList) String() string {
 	return Stringify(i)
 }
 
+// ListProjectPipelinesOptions represents the available ListProjectPipelines() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#list-project-pipelines
+type ListProjectPipelinesOptions struct {
+	ListOptions
+	Scope      *string          `url:"scope,omitempty" json:"scope,omitempty"`
+	Status     *BuildStateValue `url:"status,omitempty" json:"status,omitempty"`
+	Ref        *string          `url:"ref,omitempty" json:"ref,omitempty"`
+	YamlErrors *bool            `url:"yaml_errors,omitempty" json:"yaml_errors,omitempty"`
+	Name       *string          `url:"name,omitempty" json:"name,omitempty"`
+	Username   *string          `url:"username,omitempty" json:"username,omitempty"`
+	OrderBy    *OrderByValue    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort       *string          `url:"sort,omitempty" json:"sort,omitempty"`
+}
+
 // ListProjectPipelines gets a list of project piplines.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#list-project-pipelines
-func (s *PipelinesService) ListProjectPipelines(pid interface{}, options ...OptionFunc) (PipelineList, *Response, error) {
+func (s *PipelinesService) ListProjectPipelines(pid interface{}, opt *ListProjectPipelinesOptions, options ...OptionFunc) (PipelineList, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/pipelines", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/xanzy/go-gitlab/project_members.go
+++ b/vendor/github.com/xanzy/go-gitlab/project_members.go
@@ -21,7 +21,7 @@ import (
 	"net/url"
 )
 
-// ProjectProjectMembersService handles communication with the project members
+// ProjectMembersService handles communication with the project members
 // related methods of the GitLab API.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/members.html

--- a/vendor/github.com/xanzy/go-gitlab/project_snippets.go
+++ b/vendor/github.com/xanzy/go-gitlab/project_snippets.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
-	"time"
 )
 
 // ProjectSnippetsService handles communication with the project snippets
@@ -31,40 +30,15 @@ type ProjectSnippetsService struct {
 	client *Client
 }
 
-// Snippet represents a GitLab project snippet.
-//
-// GitLab API docs: https://docs.gitlab.com/ce/api/project_snippets.html
-type Snippet struct {
-	ID       int    `json:"id"`
-	Title    string `json:"title"`
-	FileName string `json:"file_name"`
-	Author   struct {
-		ID        int        `json:"id"`
-		Username  string     `json:"username"`
-		Email     string     `json:"email"`
-		Name      string     `json:"name"`
-		State     string     `json:"state"`
-		CreatedAt *time.Time `json:"created_at"`
-	} `json:"author"`
-	UpdatedAt *time.Time `json:"updated_at"`
-	CreatedAt *time.Time `json:"created_at"`
-}
-
-func (s Snippet) String() string {
-	return Stringify(s)
-}
-
-// ListSnippetsOptions represents the available ListSnippets() options.
+// ListProjectSnippetsOptions represents the available ListSnippets() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/project_snippets.html#list-snippets
-type ListSnippetsOptions struct {
-	ListOptions
-}
+type ListProjectSnippetsOptions ListOptions
 
 // ListSnippets gets a list of project snippets.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/project_snippets.html#list-snippets
-func (s *ProjectSnippetsService) ListSnippets(pid interface{}, opt *ListSnippetsOptions, options ...OptionFunc) ([]*Snippet, *Response, error) {
+func (s *ProjectSnippetsService) ListSnippets(pid interface{}, opt *ListProjectSnippetsOptions, options ...OptionFunc) ([]*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -110,15 +84,16 @@ func (s *ProjectSnippetsService) GetSnippet(pid interface{}, snippet int, option
 	return ps, resp, err
 }
 
-// CreateSnippetOptions represents the available CreateSnippet() options.
+// CreateProjectSnippetOptions represents the available CreateSnippet() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/project_snippets.html#create-new-snippet
-type CreateSnippetOptions struct {
-	Title      *string          `url:"title,omitempty" json:"title,omitempty"`
-	FileName   *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
-	Code       *string          `url:"code,omitempty" json:"code,omitempty"`
-	Visibility *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
+type CreateProjectSnippetOptions struct {
+	Title       *string          `url:"title,omitempty" json:"title,omitempty"`
+	FileName    *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
+	Description *string          `url:"description,omitempty" json:"description,omitempty"`
+	Code        *string          `url:"code,omitempty" json:"code,omitempty"`
+	Visibility  *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
 }
 
 // CreateSnippet creates a new project snippet. The user must have permission
@@ -126,7 +101,7 @@ type CreateSnippetOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/project_snippets.html#create-new-snippet
-func (s *ProjectSnippetsService) CreateSnippet(pid interface{}, opt *CreateSnippetOptions, options ...OptionFunc) (*Snippet, *Response, error) {
+func (s *ProjectSnippetsService) CreateSnippet(pid interface{}, opt *CreateProjectSnippetOptions, options ...OptionFunc) (*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -147,15 +122,16 @@ func (s *ProjectSnippetsService) CreateSnippet(pid interface{}, opt *CreateSnipp
 	return ps, resp, err
 }
 
-// UpdateSnippetOptions represents the available UpdateSnippet() options.
+// UpdateProjectSnippetOptions represents the available UpdateSnippet() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/project_snippets.html#update-snippet
-type UpdateSnippetOptions struct {
-	Title      *string          `url:"title,omitempty" json:"title,omitempty"`
-	FileName   *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
-	Code       *string          `url:"code,omitempty" json:"code,omitempty"`
-	Visibility *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
+type UpdateProjectSnippetOptions struct {
+	Title       *string          `url:"title,omitempty" json:"title,omitempty"`
+	FileName    *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
+	Description *string          `url:"description,omitempty" json:"description,omitempty"`
+	Code        *string          `url:"code,omitempty" json:"code,omitempty"`
+	Visibility  *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
 }
 
 // UpdateSnippet updates an existing project snippet. The user must have
@@ -163,7 +139,7 @@ type UpdateSnippetOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/project_snippets.html#update-snippet
-func (s *ProjectSnippetsService) UpdateSnippet(pid interface{}, snippet int, opt *UpdateSnippetOptions, options ...OptionFunc) (*Snippet, *Response, error) {
+func (s *ProjectSnippetsService) UpdateSnippet(pid interface{}, snippet int, opt *UpdateProjectSnippetOptions, options ...OptionFunc) (*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err

--- a/vendor/github.com/xanzy/go-gitlab/projects.go
+++ b/vendor/github.com/xanzy/go-gitlab/projects.go
@@ -65,6 +65,8 @@ type Project struct {
 	LastActivityAt                            *time.Time        `json:"last_activity_at,omitempty"`
 	CreatorID                                 int               `json:"creator_id"`
 	Namespace                                 *ProjectNamespace `json:"namespace"`
+	ImportStatus                              string            `json:"import_status"`
+	ImportError                               string            `json:"import_error"`
 	Permissions                               *Permissions      `json:"permissions"`
 	Archived                                  bool              `json:"archived"`
 	AvatarURL                                 string            `json:"avatar_url"`
@@ -83,7 +85,9 @@ type Project struct {
 		GroupName        string `json:"group_name"`
 		GroupAccessLevel int    `json:"group_access_level"`
 	} `json:"shared_with_groups"`
-	Statistics *ProjectStatistics `json:"statistics"`
+	Statistics   *ProjectStatistics `json:"statistics"`
+	Links        *Links             `json:"_links,omitempty"`
+	CIConfigPath *string            `json:"ci_config_path"`
 }
 
 // Repository represents a repository.
@@ -106,13 +110,11 @@ type Repository struct {
 
 // ProjectNamespace represents a project namespace.
 type ProjectNamespace struct {
-	CreatedAt   *time.Time `json:"created_at"`
-	Description string     `json:"description"`
-	ID          int        `json:"id"`
-	Name        string     `json:"name"`
-	OwnerID     int        `json:"owner_id"`
-	Path        string     `json:"path"`
-	UpdatedAt   *time.Time `json:"updated_at"`
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	Path     string `json:"path"`
+	Kind     string `json:"kind"`
+	FullPath string `json:"full_path"`
 }
 
 // StorageStatistics represents a statistics record for a group or project.
@@ -129,7 +131,7 @@ type ProjectStatistics struct {
 	CommitCount int `json:"commit_count"`
 }
 
-// Permissions represents premissions.
+// Permissions represents permissions.
 type Permissions struct {
 	ProjectAccess *ProjectAccess `json:"project_access"`
 	GroupAccess   *GroupAccess   `json:"group_access"`
@@ -158,6 +160,18 @@ type ForkParent struct {
 	WebURL            string `json:"web_url"`
 }
 
+// Links represents a project web links for self, issues, merge_requests,
+// repo_branches, labels, events, members.
+type Links struct {
+	Self          string `json:"self"`
+	Issues        string `json:"issues"`
+	MergeRequests string `json:"merge_requests"`
+	RepoBranches  string `json:"repo_branches"`
+	Labels        string `json:"labels"`
+	Events        string `json:"events"`
+	Members       string `json:"members"`
+}
+
 func (s Project) String() string {
 	return Stringify(s)
 }
@@ -167,16 +181,18 @@ func (s Project) String() string {
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-projects
 type ListProjectsOptions struct {
 	ListOptions
-	Archived   *bool            `url:"archived,omitempty" json:"archived,omitempty"`
-	OrderBy    *string          `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort       *string          `url:"sort,omitempty" json:"sort,omitempty"`
-	Search     *string          `url:"search,omitempty" json:"search,omitempty"`
-	Simple     *bool            `url:"simple,omitempty" json:"simple,omitempty"`
-	Owned      *bool            `url:"owned,omitempty" json:"owned,omitempty"`
-	Membership *bool            `url:"membership,omitempty" json:"membership,omitempty"`
-	Starred    *bool            `url:"starred,omitempty" json:"starred,omitempty"`
-	Statistics *bool            `url:"statistics,omitempty" json:"statistics,omitempty"`
-	Visibility *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
+	Archived                 *bool            `url:"archived,omitempty" json:"archived,omitempty"`
+	OrderBy                  *string          `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort                     *string          `url:"sort,omitempty" json:"sort,omitempty"`
+	Search                   *string          `url:"search,omitempty" json:"search,omitempty"`
+	Simple                   *bool            `url:"simple,omitempty" json:"simple,omitempty"`
+	Owned                    *bool            `url:"owned,omitempty" json:"owned,omitempty"`
+	Membership               *bool            `url:"membership,omitempty" json:"membership,omitempty"`
+	Starred                  *bool            `url:"starred,omitempty" json:"starred,omitempty"`
+	Statistics               *bool            `url:"statistics,omitempty" json:"statistics,omitempty"`
+	Visibility               *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
+	WithIssuesEnabled        *bool            `url:"with_issues_enabled,omitempty" json:"with_issues_enabled,omitempty"`
+	WithMergeRequestsEnabled *bool            `url:"with_merge_requests_enabled,omitempty" json:"with_merge_requests_enabled,omitempty"`
 }
 
 // ListProjects gets a list of projects accessible by the authenticated user.
@@ -189,6 +205,74 @@ func (s *ProjectsService) ListProjects(opt *ListProjectsOptions, options ...Opti
 	}
 
 	var p []*Project
+	resp, err := s.client.Do(req, &p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// ListUserProjects gets a list of projects for the given user.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/projects.html#list-user-projects
+func (s *ProjectsService) ListUserProjects(uid interface{}, opt *ListProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
+	user, err := parseID(uid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("users/%s/projects", user)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var p []*Project
+	resp, err := s.client.Do(req, &p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// ProjectUser represents a GitLab project user.
+type ProjectUser struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Username  string `json:"username"`
+	State     string `json:"state"`
+	AvatarURL string `json:"avatar_url"`
+	WebURL    string `json:"web_url"`
+}
+
+// ListProjectUserOptions represents the available ListProjectsUsers() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#get-project-users
+type ListProjectUserOptions struct {
+	ListOptions
+	Search *string `url:"search,omitempty" json:"search,omitempty"`
+}
+
+// ListProjectsUsers gets a list of users for the given project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/projects.html#get-project-users
+func (s *ProjectsService) ListProjectsUsers(pid interface{}, opt *ListProjectUserOptions, options ...OptionFunc) ([]*ProjectUser, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/users", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var p []*ProjectUser
 	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err
@@ -256,9 +340,7 @@ func (s ProjectEvent) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#get-project-events
-type GetProjectEventsOptions struct {
-	ListOptions
-}
+type GetProjectEventsOptions ListOptions
 
 // GetProjectEvents gets the events for the specified project. Sorted from
 // newest to latest.
@@ -300,6 +382,7 @@ type CreateProjectOptions struct {
 	JobsEnabled                               *bool            `url:"jobs_enabled,omitempty" json:"jobs_enabled,omitempty"`
 	WikiEnabled                               *bool            `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
 	SnippetsEnabled                           *bool            `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
+	ResolveOutdatedDiffDiscussions            *bool            `url:"resolve_outdated_diff_discussions,omitempty" json:"resolve_outdated_diff_discussions,omitempty"`
 	ContainerRegistryEnabled                  *bool            `url:"container_registry_enabled,omitempty" json:"container_registry_enabled,omitempty"`
 	SharedRunnersEnabled                      *bool            `url:"shared_runners_enabled,omitempty" json:"shared_runners_enabled,omitempty"`
 	Visibility                                *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
@@ -309,6 +392,9 @@ type CreateProjectOptions struct {
 	OnlyAllowMergeIfAllDiscussionsAreResolved *bool            `url:"only_allow_merge_if_all_discussions_are_resolved,omitempty" json:"only_allow_merge_if_all_discussions_are_resolved,omitempty"`
 	LFSEnabled                                *bool            `url:"lfs_enabled,omitempty" json:"lfs_enabled,omitempty"`
 	RequestAccessEnabled                      *bool            `url:"request_access_enabled,omitempty" json:"request_access_enabled,omitempty"`
+	TagList                                   *[]string        `url:"tag_list,omitempty" json:"tag_list,omitempty"`
+	PrintingMergeRequestLinkEnabled           *bool            `url:"printing_merge_request_link_enabled,omitempty" json:"printing_merge_request_link_enabled,omitempty"`
+	CIConfigPath                              *string          `url:"ci_config_path,omitempty" json:"ci_config_path,omitempty"`
 }
 
 // CreateProject creates a new project owned by the authenticated user.
@@ -579,27 +665,26 @@ type ProjectMember struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#list-project-hooks
 type ProjectHook struct {
-	ID                    int        `json:"id"`
-	URL                   string     `json:"url"`
-	ProjectID             int        `json:"project_id"`
-	PushEvents            bool       `json:"push_events"`
-	IssuesEvents          bool       `json:"issues_events"`
-	MergeRequestsEvents   bool       `json:"merge_requests_events"`
-	TagPushEvents         bool       `json:"tag_push_events"`
-	NoteEvents            bool       `json:"note_events"`
-	JobEvents             bool       `json:"job_events"`
-	PipelineEvents        bool       `json:"pipeline_events"`
-	WikiPageEvents        bool       `json:"wiki_page_events"`
-	EnableSSLVerification bool       `json:"enable_ssl_verification"`
-	CreatedAt             *time.Time `json:"created_at"`
+	ID                       int        `json:"id"`
+	URL                      string     `json:"url"`
+	ProjectID                int        `json:"project_id"`
+	PushEvents               bool       `json:"push_events"`
+	IssuesEvents             bool       `json:"issues_events"`
+	ConfidentialIssuesEvents bool       `json:"confidential_issues_events"`
+	MergeRequestsEvents      bool       `json:"merge_requests_events"`
+	TagPushEvents            bool       `json:"tag_push_events"`
+	NoteEvents               bool       `json:"note_events"`
+	JobEvents                bool       `json:"job_events"`
+	PipelineEvents           bool       `json:"pipeline_events"`
+	WikiPageEvents           bool       `json:"wiki_page_events"`
+	EnableSSLVerification    bool       `json:"enable_ssl_verification"`
+	CreatedAt                *time.Time `json:"created_at"`
 }
 
 // ListProjectHooksOptions represents the available ListProjectHooks() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-project-hooks
-type ListProjectHooksOptions struct {
-	ListOptions
-}
+type ListProjectHooksOptions ListOptions
 
 // ListProjectHooks gets a list of project hooks.
 //
@@ -656,17 +741,18 @@ func (s *ProjectsService) GetProjectHook(pid interface{}, hook int, options ...O
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#add-project-hook
 type AddProjectHookOptions struct {
-	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
-	PushEvents            *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
-	IssuesEvents          *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
-	MergeRequestsEvents   *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
-	TagPushEvents         *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
-	NoteEvents            *bool   `url:"note_events,omitempty" json:"note_events,omitempty"`
-	JobEvents             *bool   `url:"job_events,omitempty" json:"job_events,omitempty"`
-	PipelineEvents        *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
-	WikiPageEvents        *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
-	EnableSSLVerification *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
-	Token                 *string `url:"token,omitempty" json:"token,omitempty"`
+	URL                      *string `url:"url,omitempty" json:"url,omitempty"`
+	PushEvents               *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
+	IssuesEvents             *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
+	ConfidentialIssuesEvents *bool   `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
+	MergeRequestsEvents      *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
+	TagPushEvents            *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
+	NoteEvents               *bool   `url:"note_events,omitempty" json:"note_events,omitempty"`
+	JobEvents                *bool   `url:"job_events,omitempty" json:"job_events,omitempty"`
+	PipelineEvents           *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
+	WikiPageEvents           *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
+	EnableSSLVerification    *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
+	Token                    *string `url:"token,omitempty" json:"token,omitempty"`
 }
 
 // AddProjectHook adds a hook to a specified project.
@@ -699,17 +785,18 @@ func (s *ProjectsService) AddProjectHook(pid interface{}, opt *AddProjectHookOpt
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#edit-project-hook
 type EditProjectHookOptions struct {
-	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
-	PushEvents            *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
-	IssuesEvents          *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
-	MergeRequestsEvents   *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
-	TagPushEvents         *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
-	NoteEvents            *bool   `url:"note_events,omitempty" json:"note_events,omitempty"`
-	JobEvents             *bool   `url:"job_events,omitempty" json:"job_events,omitempty"`
-	PipelineEvents        *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
-	WikiPageEvents        *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
-	EnableSSLVerification *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
-	Token                 *string `url:"token,omitempty" json:"token,omitempty"`
+	URL                      *string `url:"url,omitempty" json:"url,omitempty"`
+	PushEvents               *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
+	IssuesEvents             *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
+	ConfidentialIssuesEvents *bool   `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
+	MergeRequestsEvents      *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
+	TagPushEvents            *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
+	NoteEvents               *bool   `url:"note_events,omitempty" json:"note_events,omitempty"`
+	JobEvents                *bool   `url:"job_events,omitempty" json:"job_events,omitempty"`
+	PipelineEvents           *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
+	WikiPageEvents           *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
+	EnableSSLVerification    *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
+	Token                    *string `url:"token,omitempty" json:"token,omitempty"`
 }
 
 // EditProjectHook edits a hook for a specified project.
@@ -862,4 +949,29 @@ func (s *ProjectsService) UploadFile(pid interface{}, file string, options ...Op
 	}
 
 	return uf, resp, nil
+}
+
+// ListProjectForks gets a list of project forks.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/projects.html#list-forks-of-a-project
+func (s *ProjectsService) ListProjectForks(pid interface{}, opt *ListProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/forks", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var forks []*Project
+	resp, err := s.client.Do(req, &forks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return forks, resp, err
 }

--- a/vendor/github.com/xanzy/go-gitlab/protected_branches.go
+++ b/vendor/github.com/xanzy/go-gitlab/protected_branches.go
@@ -1,0 +1,165 @@
+//
+// Copyright 2017, Sander van Harmelen, Michael Lihs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ProtectedBranchesService handles communication with the protected branch
+// related methods of the GitLab API.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/protected_branches.html#protected-branches-api
+type ProtectedBranchesService struct {
+	client *Client
+}
+
+// BranchAccessDescription represents the access description for a protected
+// branch.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/protected_branches.html#protected-branches-api
+type BranchAccessDescription struct {
+	AccessLevel            AccessLevelValue `json:"access_level"`
+	AccessLevelDescription string           `json:"access_level_description"`
+}
+
+// ProtectedBranch represents a protected branch.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/protected_branches.html#list-protected-branches
+type ProtectedBranch struct {
+	Name              string                     `json:"name"`
+	PushAccessLevels  []*BranchAccessDescription `json:"push_access_levels"`
+	MergeAccessLevels []*BranchAccessDescription `json:"merge_access_levels"`
+}
+
+// ListProtectedBranchesOptions represents the available ListProtectedBranches()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/protected_branches.html#list-protected-branches
+type ListProtectedBranchesOptions ListOptions
+
+// ListProtectedBranches gets a list of protected branches from a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/protected_branches.html#list-protected-branches
+func (s *ProtectedBranchesService) ListProtectedBranches(pid interface{}, opt *ListProtectedBranchesOptions, options ...OptionFunc) ([]*ProtectedBranch, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/protected_branches", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var p []*ProtectedBranch
+	resp, err := s.client.Do(req, &p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// GetProtectedBranch gets a single protected branch or wildcard protected branch.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/protected_branches.html#get-a-single-protected-branch-or-wildcard-protected-branch
+func (s *ProtectedBranchesService) GetProtectedBranch(pid interface{}, branch string, options ...OptionFunc) (*ProtectedBranch, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/protected_branches/%s", url.QueryEscape(project), branch)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(ProtectedBranch)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// ProtectRepositoryBranchesOptions represents the available
+// ProtectRepositoryBranches() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/protected_branches.html#protect-repository-branches
+type ProtectRepositoryBranchesOptions struct {
+	Name             *string           `url:"name,omitempty" json:"name,omitempty"`
+	PushAccessLevel  *AccessLevelValue `url:"push_access_level,omitempty" json:"push_access_level,omitempty"`
+	MergeAccessLevel *AccessLevelValue `url:"merge_access_level,omitempty" json:"merge_access_level,omitempty"`
+}
+
+// ProtectRepositoryBranches protects a single repository branch or several
+// project repository branches using a wildcard protected branch.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/protected_branches.html#protect-repository-branches
+func (s *ProtectedBranchesService) ProtectRepositoryBranches(pid interface{}, opt *ProtectRepositoryBranchesOptions, options ...OptionFunc) (*ProtectedBranch, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/protected_branches", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(ProtectedBranch)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// UnprotectRepositoryBranches unprotects the given protected branch or wildcard
+// protected branch.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/protected_branches.html#unprotect-repository-branches
+func (s *ProtectedBranchesService) UnprotectRepositoryBranches(pid interface{}, branch string, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/protected_branches/%s", url.QueryEscape(project), branch)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/xanzy/go-gitlab/repositories.go
+++ b/vendor/github.com/xanzy/go-gitlab/repositories.go
@@ -215,7 +215,7 @@ func (s *RepositoriesService) Compare(pid interface{}, opt *CompareOptions, opti
 
 // Contributor represents a GitLap contributor.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html#contributer
+// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html#contributors
 type Contributor struct {
 	Name      string `json:"name,omitempty"`
 	Email     string `json:"email,omitempty"`
@@ -228,17 +228,23 @@ func (c Contributor) String() string {
 	return Stringify(c)
 }
 
+// ListContributorsOptions represents the available ListContributorsOptions()
+// options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html#contributors
+type ListContributorsOptions ListOptions
+
 // Contributors gets the repository contributors list.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html#contributer
-func (s *RepositoriesService) Contributors(pid interface{}, options ...OptionFunc) ([]*Contributor, *Response, error) {
+// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html#contributors
+func (s *RepositoriesService) Contributors(pid interface{}, opt *ListContributorsOptions, options ...OptionFunc) ([]*Contributor, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/contributors", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/xanzy/go-gitlab/repository_files.go
+++ b/vendor/github.com/xanzy/go-gitlab/repository_files.go
@@ -17,6 +17,7 @@
 package gitlab
 
 import (
+	"bytes"
 	"fmt"
 	"net/url"
 )
@@ -93,7 +94,7 @@ type GetRawFileOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repository_files.html#get-raw-file-from-repository
-func (s *RepositoryFilesService) GetRawFile(pid interface{}, fileName string, opt *GetRawFileOptions, options ...OptionFunc) (*File, *Response, error) {
+func (s *RepositoryFilesService) GetRawFile(pid interface{}, fileName string, opt *GetRawFileOptions, options ...OptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -105,13 +106,13 @@ func (s *RepositoryFilesService) GetRawFile(pid interface{}, fileName string, op
 		return nil, nil, err
 	}
 
-	f := new(File)
-	resp, err := s.client.Do(req, f)
+	var f bytes.Buffer
+	resp, err := s.client.Do(req, &f)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return f, resp, err
+	return f.Bytes(), resp, err
 }
 
 // FileInfo represents file details of a GitLab repository file.

--- a/vendor/github.com/xanzy/go-gitlab/runners.go
+++ b/vendor/github.com/xanzy/go-gitlab/runners.go
@@ -1,0 +1,326 @@
+//
+// Copyright 2017, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// RunnersService handles communication with the runner related methods of the
+// GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/runners.html
+type RunnersService struct {
+	client *Client
+}
+
+// Runner represents a GitLab CI Runner.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/runners.html
+type Runner struct {
+	ID          int    `json:"id"`
+	Description string `json:"description"`
+	Active      bool   `json:"active"`
+	IsShared    bool   `json:"is_shared"`
+	Name        string `json:"name"`
+	Online      bool   `json:"online"`
+	Status      string `json:"status"`
+}
+
+// RunnerDetails represents the GitLab CI runner details.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/runners.html
+type RunnerDetails struct {
+	Active       bool       `json:"active"`
+	Architecture string     `json:"architecture"`
+	Description  string     `json:"description"`
+	ID           int        `json:"id"`
+	IsShared     bool       `json:"is_shared"`
+	ContactedAt  *time.Time `json:"contacted_at,omitempty"`
+	Name         string     `json:"name"`
+	Online       bool       `json:"online"`
+	Status       string     `json:"status"`
+	Platform     string     `json:"platform,omitempty"`
+	Projects     []struct {
+		ID                int    `json:"id"`
+		Name              string `json:"name"`
+		NameWithNamespace string `json:"name_with_namespace"`
+		Path              string `json:"path"`
+		PathWithNamespace string `json:"path_with_namespace"`
+	} `json:"projects"`
+	Token       string   `json:"Token"`
+	Revision    string   `json:"revision,omitempty"`
+	TagList     []string `json:"tag_list"`
+	Version     string   `json:"version,omitempty"`
+	AccessLevel string   `json:"access_level"`
+}
+
+// ListRunnersOptions represents the available ListRunners() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#list-owned-runners
+type ListRunnersOptions struct {
+	ListOptions
+	Scope *string `url:"scope,omitempty" json:"scope,omitempty"`
+}
+
+// ListRunners gets a list of runners accessible by the authenticated user.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#list-owned-runners
+func (s *RunnersService) ListRunners(opt *ListRunnersOptions, options ...OptionFunc) ([]*Runner, *Response, error) {
+	req, err := s.client.NewRequest("GET", "runners", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rs []*Runner
+	resp, err := s.client.Do(req, &rs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rs, resp, err
+}
+
+// ListAllRunners gets a list of all runners in the GitLab instance. Access is
+// restricted to users with admin privileges.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#list-all-runners
+func (s *RunnersService) ListAllRunners(opt *ListRunnersOptions, options ...OptionFunc) ([]*Runner, *Response, error) {
+	req, err := s.client.NewRequest("GET", "runners/all", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rs []*Runner
+	resp, err := s.client.Do(req, &rs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rs, resp, err
+}
+
+// GetRunnerDetails returns details for given runner.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#get-runner-39-s-details
+func (s *RunnersService) GetRunnerDetails(rid interface{}, options ...OptionFunc) (*RunnerDetails, *Response, error) {
+	runner, err := parseID(rid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("runners/%s", runner)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rs *RunnerDetails
+	resp, err := s.client.Do(req, &rs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rs, resp, err
+}
+
+// UpdateRunnerDetailsOptions represents the available UpdateRunnerDetails() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#update-runner-39-s-details
+type UpdateRunnerDetailsOptions struct {
+	Description *string  `url:"description,omitempty" json:"description,omitempty"`
+	Active      *bool    `url:"active,omitempty" json:"active,omitempty"`
+	TagList     []string `url:"tag_list[],omitempty" json:"tag_list,omitempty"`
+	RunUntagged *bool    `url:"run_untagged,omitempty" json:"run_untagged,omitempty"`
+	Locked      *bool    `url:"locked,omitempty" json:"locked,omitempty"`
+	AccessLevel *string  `url:"access_level,omitempty" json:"access_level,omitempty"`
+}
+
+// UpdateRunnerDetails updates details for a given runner.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#update-runner-39-s-details
+func (s *RunnersService) UpdateRunnerDetails(rid interface{}, opt *UpdateRunnerDetailsOptions, options ...OptionFunc) (*RunnerDetails, *Response, error) {
+	runner, err := parseID(rid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("runners/%s", runner)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rs *RunnerDetails
+	resp, err := s.client.Do(req, &rs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rs, resp, err
+}
+
+// RemoveRunner removes a runner.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#remove-a-runner
+func (s *RunnersService) RemoveRunner(rid interface{}, options ...OptionFunc) (*Response, error) {
+	runner, err := parseID(rid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("runners/%s", runner)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// ListRunnerJobsOptions represents the available ListRunnerJobs()
+// options. Status can be one of: running, success, failed, canceled.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#list-runner-39-s-jobs
+type ListRunnerJobsOptions struct {
+	ListOptions
+	Status *string `url:"status,omitempty" json:"status,omitempty"`
+}
+
+// ListRunnerJobs gets a list of jobs that are being processed or were processed by specified Runner.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#list-runner-39-s-jobs
+func (s *RunnersService) ListRunnerJobs(rid interface{}, opt *ListRunnerJobsOptions, options ...OptionFunc) ([]*Job, *Response, error) {
+	runner, err := parseID(rid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("runners/%s/jobs", runner)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rs []*Job
+	resp, err := s.client.Do(req, &rs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rs, resp, err
+}
+
+// ListProjectRunnersOptions represents the available ListProjectRunners()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#list-project-s-runners
+type ListProjectRunnersOptions ListRunnersOptions
+
+// ListProjectRunners gets a list of runners accessible by the authenticated user.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#list-project-s-runners
+func (s *RunnersService) ListProjectRunners(pid interface{}, opt *ListProjectRunnersOptions, options ...OptionFunc) ([]*Runner, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/runners", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rs []*Runner
+	resp, err := s.client.Do(req, &rs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rs, resp, err
+}
+
+// EnableProjectRunnerOptions represents the available EnableProjectRunner()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#enable-a-runner-in-project
+type EnableProjectRunnerOptions struct {
+	RunnerID int `json:"runner_id"`
+}
+
+// EnableProjectRunner enables an available specific runner in the project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#enable-a-runner-in-project
+func (s *RunnersService) EnableProjectRunner(pid interface{}, opt *EnableProjectRunnerOptions, options ...OptionFunc) (*Runner, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/runners", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var r *Runner
+	resp, err := s.client.Do(req, &r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, err
+}
+
+// DisableProjectRunner disables a specific runner from project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/runners.html#disable-a-runner-from-project
+func (s *RunnersService) DisableProjectRunner(pid interface{}, rid interface{}, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	runner, err := parseID(rid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/runners/%s", url.QueryEscape(project), url.QueryEscape(runner))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/xanzy/go-gitlab/search.go
+++ b/vendor/github.com/xanzy/go-gitlab/search.go
@@ -1,0 +1,326 @@
+//
+// Copyright 2018, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// SearchService handles communication with the search related methods of the
+// GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html
+type SearchService struct {
+	client *Client
+}
+
+// SearchOptions represents the available options for all search methods.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html
+type SearchOptions ListOptions
+
+type searchOptions struct {
+	SearchOptions
+	Scope  string `url:"scope" json:"scope"`
+	Search string `url:"search" json:"search"`
+}
+
+// Projects searches the expression within projects
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-projects
+func (s *SearchService) Projects(query string, opt *SearchOptions, options ...OptionFunc) ([]*Project, *Response, error) {
+	var ps []*Project
+	resp, err := s.search("projects", query, &ps, opt, options...)
+	return ps, resp, err
+}
+
+// ProjectsByGroup searches the expression within projects for
+// the specified group
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#group-search-api
+func (s *SearchService) ProjectsByGroup(gid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*Project, *Response, error) {
+	var ps []*Project
+	resp, err := s.searchByGroup(gid, "projects", query, &ps, opt, options...)
+	return ps, resp, err
+}
+
+// Issues searches the expression within issues
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-issues
+func (s *SearchService) Issues(query string, opt *SearchOptions, options ...OptionFunc) ([]*Issue, *Response, error) {
+	var is []*Issue
+	resp, err := s.search("issues", query, &is, opt, options...)
+	return is, resp, err
+}
+
+// IssuesByGroup searches the expression within issues for
+// the specified group
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-issues
+func (s *SearchService) IssuesByGroup(gid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*Issue, *Response, error) {
+	var is []*Issue
+	resp, err := s.searchByGroup(gid, "issues", query, &is, opt, options...)
+	return is, resp, err
+}
+
+// IssuesByProject searches the expression within issues for
+// the specified project
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-issues
+func (s *SearchService) IssuesByProject(pid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*Issue, *Response, error) {
+	var is []*Issue
+	resp, err := s.searchByProject(pid, "issues", query, &is, opt, options...)
+	return is, resp, err
+}
+
+// MergeRequests searches the expression within merge requests
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/search.html#scope-merge_requests
+func (s *SearchService) MergeRequests(query string, opt *SearchOptions, options ...OptionFunc) ([]*MergeRequest, *Response, error) {
+	var ms []*MergeRequest
+	resp, err := s.search("merge_requests", query, &ms, opt, options...)
+	return ms, resp, err
+}
+
+// MergeRequestsByGroup searches the expression within merge requests for
+// the specified group
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/search.html#scope-merge_requests
+func (s *SearchService) MergeRequestsByGroup(gid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*MergeRequest, *Response, error) {
+	var ms []*MergeRequest
+	resp, err := s.searchByGroup(gid, "merge_requests", query, &ms, opt, options...)
+	return ms, resp, err
+}
+
+// MergeRequestsByProject searches the expression within merge requests for
+// the specified project
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/search.html#scope-merge_requests
+func (s *SearchService) MergeRequestsByProject(pid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*MergeRequest, *Response, error) {
+	var ms []*MergeRequest
+	resp, err := s.searchByProject(pid, "merge_requests", query, &ms, opt, options...)
+	return ms, resp, err
+}
+
+// Milestones searches the expression within milestones
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-milestones
+func (s *SearchService) Milestones(query string, opt *SearchOptions, options ...OptionFunc) ([]*Milestone, *Response, error) {
+	var ms []*Milestone
+	resp, err := s.search("milestones", query, &ms, opt, options...)
+	return ms, resp, err
+}
+
+// MilestonesByGroup searches the expression within milestones for
+// the specified group
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-milestones
+func (s *SearchService) MilestonesByGroup(gid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*Milestone, *Response, error) {
+	var ms []*Milestone
+	resp, err := s.searchByGroup(gid, "milestones", query, &ms, opt, options...)
+	return ms, resp, err
+}
+
+// MilestonesByProject searches the expression within milestones for
+// the specified project
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-milestones
+func (s *SearchService) MilestonesByProject(pid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*Milestone, *Response, error) {
+	var ms []*Milestone
+	resp, err := s.searchByProject(pid, "milestones", query, &ms, opt, options...)
+	return ms, resp, err
+}
+
+// SnippetTitles searches the expression within snippet titles
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/search.html#scope-snippet_titles
+func (s *SearchService) SnippetTitles(query string, opt *SearchOptions, options ...OptionFunc) ([]*Snippet, *Response, error) {
+	var ss []*Snippet
+	resp, err := s.search("snippet_titles", query, &ss, opt, options...)
+	return ss, resp, err
+}
+
+// SnippetBlobs searches the expression within snippet blobs
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/search.html#scope-snippet_blobs
+func (s *SearchService) SnippetBlobs(query string, opt *SearchOptions, options ...OptionFunc) ([]*Snippet, *Response, error) {
+	var ss []*Snippet
+	resp, err := s.search("snippet_blobs", query, &ss, opt, options...)
+	return ss, resp, err
+}
+
+// NotesByProject searches the expression within notes for the specified
+// project
+//
+// GitLab API docs: // https://docs.gitlab.com/ce/api/search.html#scope-notes
+func (s *SearchService) NotesByProject(pid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*Note, *Response, error) {
+	var ns []*Note
+	resp, err := s.searchByProject(pid, "notes", query, &ns, opt, options...)
+	return ns, resp, err
+}
+
+// WikiBlobs searches the expression within all wiki blobs
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/search.html#scope-wiki_blobs
+func (s *SearchService) WikiBlobs(query string, opt *SearchOptions, options ...OptionFunc) ([]*Wiki, *Response, error) {
+	var ws []*Wiki
+	resp, err := s.search("wiki_blobs", query, &ws, opt, options...)
+	return ws, resp, err
+}
+
+// WikiBlobsByGroup searches the expression within wiki blobs for
+// specified group
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/search.html#scope-wiki_blobs
+func (s *SearchService) WikiBlobsByGroup(gid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*Wiki, *Response, error) {
+	var ws []*Wiki
+	resp, err := s.searchByGroup(gid, "wiki_blobs", query, &ws, opt, options...)
+	return ws, resp, err
+}
+
+// WikiBlobsByProject searches the expression within wiki blobs for
+// the specified project
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/search.html#scope-wiki_blobs
+func (s *SearchService) WikiBlobsByProject(pid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*Wiki, *Response, error) {
+	var ws []*Wiki
+	resp, err := s.searchByProject(pid, "wiki_blobs", query, &ws, opt, options...)
+	return ws, resp, err
+}
+
+// Commits searches the expression within all commits
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-commits
+func (s *SearchService) Commits(query string, opt *SearchOptions, options ...OptionFunc) ([]*Commit, *Response, error) {
+	var cs []*Commit
+	resp, err := s.search("commits", query, &cs, opt, options...)
+	return cs, resp, err
+}
+
+// CommitsByGroup searches the expression within commits for the specified
+// group
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-commits
+func (s *SearchService) CommitsByGroup(gid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*Commit, *Response, error) {
+	var cs []*Commit
+	resp, err := s.searchByGroup(gid, "commits", query, &cs, opt, options...)
+	return cs, resp, err
+}
+
+// CommitsByProject searches the expression within commits for the
+// specified project
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-commits
+func (s *SearchService) CommitsByProject(pid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*Commit, *Response, error) {
+	var cs []*Commit
+	resp, err := s.searchByProject(pid, "commits", query, &cs, opt, options...)
+	return cs, resp, err
+}
+
+// Blob represents a single blob.
+type Blob struct {
+	Basename  string `json:"basename"`
+	Data      string `json:"data"`
+	Filename  string `json:"filename"`
+	ID        int    `json:"id"`
+	Ref       string `json:"ref"`
+	Startline int    `json:"startline"`
+	ProjectID int    `json:"project_id"`
+}
+
+// Blobs searches the expression within all blobs
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-blobs
+func (s *SearchService) Blobs(query string, opt *SearchOptions, options ...OptionFunc) ([]*Blob, *Response, error) {
+	var bs []*Blob
+	resp, err := s.search("blobs", query, &bs, opt, options...)
+	return bs, resp, err
+}
+
+// BlobsByGroup searches the expression within blobs for the specified
+// group
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-blobs
+func (s *SearchService) BlobsByGroup(gid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*Blob, *Response, error) {
+	var bs []*Blob
+	resp, err := s.searchByGroup(gid, "blobs", query, &bs, opt, options...)
+	return bs, resp, err
+}
+
+// BlobsByProject searches the expression within blobs for the specified
+// project
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-blobs
+func (s *SearchService) BlobsByProject(pid interface{}, query string, opt *SearchOptions, options ...OptionFunc) ([]*Blob, *Response, error) {
+	var bs []*Blob
+	resp, err := s.searchByProject(pid, "blobs", query, &bs, opt, options...)
+	return bs, resp, err
+}
+
+func (s *SearchService) search(scope, query string, result interface{}, opt *SearchOptions, options ...OptionFunc) (*Response, error) {
+	opts := &searchOptions{SearchOptions: *opt, Scope: scope, Search: query}
+
+	req, err := s.client.NewRequest("GET", "search", opts, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, result)
+}
+
+func (s *SearchService) searchByGroup(gid interface{}, scope, query string, result interface{}, opt *SearchOptions, options ...OptionFunc) (*Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/-/search", url.QueryEscape(group))
+
+	opts := &searchOptions{SearchOptions: *opt, Scope: scope, Search: query}
+
+	req, err := s.client.NewRequest("GET", u, opts, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, result)
+}
+
+func (s *SearchService) searchByProject(pid interface{}, scope, query string, result interface{}, opt *SearchOptions, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/-/search", url.QueryEscape(project))
+
+	opts := &searchOptions{SearchOptions: *opt, Scope: scope, Search: query}
+
+	req, err := s.client.NewRequest("GET", u, opts, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, result)
+}

--- a/vendor/github.com/xanzy/go-gitlab/services.go
+++ b/vendor/github.com/xanzy/go-gitlab/services.go
@@ -34,16 +34,19 @@ type ServicesService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/services.html
 type Service struct {
-	ID                  *int       `json:"id"`
-	Title               *string    `json:"title"`
-	CreatedAt           *time.Time `json:"created_at"`
-	UpdatedAt           *time.Time `json:"created_at"`
-	Active              *bool      `json:"active"`
-	PushEvents          *bool      `json:"push_events"`
-	IssuesEvents        *bool      `json:"issues_events"`
-	MergeRequestsEvents *bool      `json:"merge_requests_events"`
-	TagPushEvents       *bool      `json:"tag_push_events"`
-	NoteEvents          *bool      `json:"note_events"`
+	ID                       int        `json:"id"`
+	Title                    string     `json:"title"`
+	CreatedAt                *time.Time `json:"created_at"`
+	UpdatedAt                *time.Time `json:"updated_at"`
+	Active                   bool       `json:"active"`
+	PushEvents               bool       `json:"push_events"`
+	IssuesEvents             bool       `json:"issues_events"`
+	ConfidentialIssuesEvents bool       `json:"confidential_issues_events"`
+	MergeRequestsEvents      bool       `json:"merge_requests_events"`
+	TagPushEvents            bool       `json:"tag_push_events"`
+	NoteEvents               bool       `json:"note_events"`
+	PipelineEvents           bool       `json:"pipeline_events"`
+	JobEvents                bool       `json:"job_events"`
 }
 
 // SetGitLabCIServiceOptions represents the available SetGitLabCIService()
@@ -142,6 +145,50 @@ func (s *ServicesService) DeleteHipChatService(pid interface{}, options ...Optio
 	return s.client.Do(req, nil)
 }
 
+// DroneCIService represents Drone CI service settings.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#drone-ci
+type DroneCIService struct {
+	Service
+	Properties *DroneCIServiceProperties `json:"properties"`
+}
+
+// DroneCIServiceProperties represents Drone CI specific properties.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#drone-ci
+type DroneCIServiceProperties struct {
+	Token                 string `json:"token"`
+	DroneURL              string `json:"drone_url"`
+	EnableSSLVerification bool   `json:"enable_ssl_verification"`
+}
+
+// GetDroneCIService gets Drone CI service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#get-drone-ci-service-settings
+func (s *ServicesService) GetDroneCIService(pid interface{}, options ...OptionFunc) (*DroneCIService, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/drone-ci", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	svc := new(DroneCIService)
+	resp, err := s.client.Do(req, svc)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return svc, resp, err
+}
+
 // SetDroneCIServiceOptions represents the available SetDroneCIService()
 // options.
 //
@@ -191,42 +238,46 @@ func (s *ServicesService) DeleteDroneCIService(pid interface{}, options ...Optio
 	return s.client.Do(req, nil)
 }
 
-// DroneCIServiceProperties represents Drone CI specific properties.
-type DroneCIServiceProperties struct {
-	Token                 *string `url:"token" json:"token"`
-	DroneURL              *string `url:"drone_url" json:"drone_url"`
-	EnableSSLVerification *bool   `url:"enable_ssl_verification" json:"enable_ssl_verification"`
-}
-
-// DroneCIService represents Drone CI service settings.
-type DroneCIService struct {
-	Service
-	Properties *DroneCIServiceProperties `json:"properties"`
-}
-
-// GetDroneCIService gets Drone CI service settings for a project.
+// SlackService represents Slack service settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-drone-ci-service-settings
-func (s *ServicesService) GetDroneCIService(pid interface{}, options ...OptionFunc) (*DroneCIService, *Response, error) {
+// https://docs.gitlab.com/ce/api/services.html#slack
+type SlackService struct {
+	Service
+	Properties *SlackServiceProperties `json:"properties"`
+}
+
+// SlackServiceProperties represents Slack specific properties.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#slack
+type SlackServiceProperties struct {
+	NotifyOnlyBrokenPipelines bool `json:"notify_only_broken_pipelines"`
+}
+
+// GetSlackService gets Slack service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#get-slack-service-settings
+func (s *ServicesService) GetSlackService(pid interface{}, options ...OptionFunc) (*SlackService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/drone-ci", url.QueryEscape(project))
+	u := fmt.Sprintf("projects/%s/services/slack", url.QueryEscape(project))
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	opt := new(DroneCIService)
-	resp, err := s.client.Do(req, opt)
+	svc := new(SlackService)
+	resp, err := s.client.Do(req, svc)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return opt, resp, err
+	return svc, resp, err
 }
 
 // SetSlackServiceOptions represents the available SetSlackService()
@@ -269,6 +320,191 @@ func (s *ServicesService) DeleteSlackService(pid interface{}, options ...OptionF
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/services/slack", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// JiraService represents Jira service settings.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#jira
+type JiraService struct {
+	Service
+	Properties *JiraServiceProperties `json:"properties"`
+}
+
+// JiraServiceProperties represents Jira specific properties.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#jira
+type JiraServiceProperties struct {
+	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
+	ProjectKey            *string `url:"project_key,omitempty" json:"project_key,omitempty" `
+	Username              *string `url:"username,omitempty" json:"username,omitempty" `
+	Password              *string `url:"password,omitempty" json:"password,omitempty" `
+	JiraIssueTransitionID *string `url:"jira_issue_transition_id,omitempty" json:"jira_issue_transition_id,omitempty"`
+}
+
+// GetJiraService gets Jira service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#get-jira-service-settings
+func (s *ServicesService) GetJiraService(pid interface{}, options ...OptionFunc) (*JiraService, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/jira", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	svc := new(JiraService)
+	resp, err := s.client.Do(req, svc)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return svc, resp, err
+}
+
+// SetJiraServiceOptions represents the available SetJiraService()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#edit-jira-service
+type SetJiraServiceOptions JiraServiceProperties
+
+// SetJiraService sets Jira service for a project
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#edit-jira-service
+func (s *ServicesService) SetJiraService(pid interface{}, opt *SetJiraServiceOptions, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/jira", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// DeleteJiraService deletes Jira service for project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#delete-jira-service
+func (s *ServicesService) DeleteJiraService(pid interface{}, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/jira", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// JenkinsCIService represents Jenkins CI service settings.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/services.html#jenkins-ci
+type JenkinsCIService struct {
+	Service
+	Properties *JenkinsCIServiceProperties `json:"properties"`
+}
+
+// JenkinsCIServiceProperties represents Jenkins CI specific properties.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/services.html#jenkins-ci
+type JenkinsCIServiceProperties struct {
+	URL         *string `url:"jenkins_url,omitempty" json:"jenkins_url,omitempty"`
+	ProjectName *string `url:"project_name,omitempty" json:"project_name,omitempty"`
+	Username    *string `url:"username,omitempty" json:"username,omitempty"`
+}
+
+// GetJenkinsCIService gets Jenkins CI service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/services.html#get-jenkins-ci-service-settings
+func (s *ServicesService) GetJenkinsCIService(pid interface{}, options ...OptionFunc) (*JenkinsCIService, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/jenkins", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	svc := new(JenkinsCIService)
+	resp, err := s.client.Do(req, svc)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return svc, resp, err
+}
+
+// SetJenkinsCIServiceOptions represents the available SetJenkinsCIService()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/services.html#jenkins-ci
+type SetJenkinsCIServiceOptions struct {
+	URL         *string `url:"jenkins_url,omitempty" json:"jenkins_url,omitempty"`
+	ProjectName *string `url:"project_name,omitempty" json:"project_name,omitempty"`
+	Username    *string `url:"username,omitempty" json:"username,omitempty"`
+	Password    *string `url:"password,omitempty" json:"password,omitempty"`
+}
+
+// SetJenkinsCIService sets Jenkins service for a project
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/services.html#create-edit-jenkins-ci-service
+func (s *ServicesService) SetJenkinsCIService(pid interface{}, opt *SetJenkinsCIServiceOptions, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/jenkins", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// DeleteJenkinsCIService deletes Jenkins CI service for project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#delete-jira-service
+func (s *ServicesService) DeleteJenkinsCIService(pid interface{}, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/jenkins", url.QueryEscape(project))
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/settings.go
+++ b/vendor/github.com/xanzy/go-gitlab/settings.go
@@ -30,25 +30,99 @@ type SettingsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/settings.html
 type Settings struct {
-	ID                         int               `json:"id"`
-	DefaultProjectsLimit       int               `json:"default_projects_limit"`
-	SignupEnabled              bool              `json:"signup_enabled"`
-	SigninEnabled              bool              `json:"signin_enabled"`
-	GravatarEnabled            bool              `json:"gravatar_enabled"`
-	SignInText                 string            `json:"sign_in_text"`
-	CreatedAt                  *time.Time        `json:"created_at"`
-	UpdatedAt                  *time.Time        `json:"updated_at"`
-	HomePageURL                string            `json:"home_page_url"`
-	DefaultBranchProtection    int               `json:"default_branch_protection"`
-	TwitterSharingEnabled      bool              `json:"twitter_sharing_enabled"`
-	RestrictedVisibilityLevels []VisibilityValue `json:"restricted_visibility_levels"`
-	MaxAttachmentSize          int               `json:"max_attachment_size"`
-	SessionExpireDelay         int               `json:"session_expire_delay"`
-	DefaultProjectVisibility   int               `json:"default_project_visibility"`
-	DefaultSnippetVisibility   int               `json:"default_snippet_visibility"`
-	RestrictedSignupDomains    []string          `json:"restricted_signup_domains"`
-	UserOauthApplications      bool              `json:"user_oauth_applications"`
-	AfterSignOutPath           string            `json:"after_sign_out_path"`
+	ID                                  int               `json:"id"`
+	CreatedAt                           *time.Time        `json:"created_at"`
+	UpdatedAt                           *time.Time        `json:"updated_at"`
+	AdminNotificationEmail              string            `json:"admin_notification_email"`
+	AfterSignOutPath                    string            `json:"after_sign_out_path"`
+	AfterSignUpText                     string            `json:"after_sign_up_text"`
+	AkismetAPIKey                       string            `json:"akismet_api_key"`
+	AkismetEnabled                      bool              `json:"akismet_enabled"`
+	CircuitbreakerAccessRetries         int               `json:"circuitbreaker_access_retries"`
+	CircuitbreakerBackoffThreshold      int               `json:"circuitbreaker_backoff_threshold"`
+	CircuitbreakerFailureCountThreshold int               `json:"circuitbreaker_failure_count_threshold"`
+	CircuitbreakerFailureResetTime      int               `json:"circuitbreaker_failure_reset_time"`
+	CircuitbreakerFailureWaitTime       int               `json:"circuitbreaker_failure_wait_time"`
+	CircuitbreakerStorageTimeout        int               `json:"circuitbreaker_storage_timeout"`
+	ClientsideSentryDSN                 string            `json:"clientside_sentry_dsn"`
+	ClientsideSentryEnabled             bool              `json:"clientside_sentry_enabled"`
+	ContainerRegistryTokenExpireDelay   int               `json:"container_registry_token_expire_delay"`
+	DefaultArtifactsExpireIn            string            `json:"default_artifacts_expire_in"`
+	DefaultBranchProtection             int               `json:"default_branch_protection"`
+	DefaultGroupVisibility              string            `json:"default_group_visibility"`
+	DefaultProjectVisibility            string            `json:"default_project_visibility"`
+	DefaultProjectsLimit                int               `json:"default_projects_limit"`
+	DefaultSnippetVisibility            string            `json:"default_snippet_visibility"`
+	DisabledOauthSignInSources          []string          `json:"disabled_oauth_sign_in_sources"`
+	DomainBlacklistEnabled              bool              `json:"domain_blacklist_enabled"`
+	DomainBlacklist                     []string          `json:"domain_blacklist"`
+	DomainWhitelist                     []string          `json:"domain_whitelist"`
+	DSAKeyRestriction                   int               `json:"dsa_key_restriction"`
+	ECDSAKeyRestriction                 int               `json:"ecdsa_key_restriction"`
+	Ed25519KeyRestriction               int               `json:"ed25519_key_restriction"`
+	EmailAuthorInBody                   bool              `json:"email_author_in_body"`
+	EnabledGitAccessProtocol            string            `json:"enabled_git_access_protocol"`
+	GravatarEnabled                     bool              `json:"gravatar_enabled"`
+	HelpPageHideCommercialContent       bool              `json:"help_page_hide_commercial_content"`
+	HelpPageSupportURL                  string            `json:"help_page_support_url"`
+	HomePageURL                         string            `json:"home_page_url"`
+	HousekeepingBitmapsEnabled          bool              `json:"housekeeping_bitmaps_enabled"`
+	HousekeepingEnabled                 bool              `json:"housekeeping_enabled"`
+	HousekeepingFullRepackPeriod        int               `json:"housekeeping_full_repack_period"`
+	HousekeepingGcPeriod                int               `json:"housekeeping_gc_period"`
+	HousekeepingIncrementalRepackPeriod int               `json:"housekeeping_incremental_repack_period"`
+	HTMLEmailsEnabled                   bool              `json:"html_emails_enabled"`
+	ImportSources                       []string          `json:"import_sources"`
+	KodingEnabled                       bool              `json:"koding_enabled"`
+	KodingURL                           string            `json:"koding_url"`
+	MaxArtifactsSize                    int               `json:"max_artifacts_size"`
+	MaxAttachmentSize                   int               `json:"max_attachment_size"`
+	MaxPagesSize                        int               `json:"max_pages_size"`
+	MetricsEnabled                      bool              `json:"metrics_enabled"`
+	MetricsHost                         string            `json:"metrics_host"`
+	MetricsMethodCallThreshold          int               `json:"metrics_method_call_threshold"`
+	MetricsPacketSize                   int               `json:"metrics_packet_size"`
+	MetricsPoolSize                     int               `json:"metrics_pool_size"`
+	MetricsPort                         int               `json:"metrics_port"`
+	MetricsSampleInterval               int               `json:"metrics_sample_interval"`
+	MetricsTimeout                      int               `json:"metrics_timeout"`
+	PasswordAuthenticationEnabledForWeb bool              `json:"password_authentication_enabled_for_web"`
+	PasswordAuthenticationEnabledForGit bool              `json:"password_authentication_enabled_for_git"`
+	PerformanceBarAllowedGroupID        string            `json:"performance_bar_allowed_group_id"`
+	PerformanceBarEnabled               bool              `json:"performance_bar_enabled"`
+	PlantumlEnabled                     bool              `json:"plantuml_enabled"`
+	PlantumlURL                         string            `json:"plantuml_url"`
+	PollingIntervalMultiplier           float64           `json:"polling_interval_multiplier"`
+	ProjectExportEnabled                bool              `json:"project_export_enabled"`
+	PrometheusMetricsEnabled            bool              `json:"prometheus_metrics_enabled"`
+	RecaptchaEnabled                    bool              `json:"recaptcha_enabled"`
+	RecaptchaPrivateKey                 string            `json:"recaptcha_private_key"`
+	RecaptchaSiteKey                    string            `json:"recaptcha_site_key"`
+	RepositoryChecksEnabled             bool              `json:"repository_checks_enabled"`
+	RepositoryStorages                  []string          `json:"repository_storages"`
+	RequireTwoFactorAuthentication      bool              `json:"require_two_factor_authentication"`
+	RestrictedVisibilityLevels          []VisibilityValue `json:"restricted_visibility_levels"`
+	RsaKeyRestriction                   int               `json:"rsa_key_restriction"`
+	SendUserConfirmationEmail           bool              `json:"send_user_confirmation_email"`
+	SentryDSN                           string            `json:"sentry_dsn"`
+	SentryEnabled                       bool              `json:"sentry_enabled"`
+	SessionExpireDelay                  int               `json:"session_expire_delay"`
+	SharedRunnersEnabled                bool              `json:"shared_runners_enabled"`
+	SharedRunnersText                   string            `json:"shared_runners_text"`
+	SidekiqThrottlingEnabled            bool              `json:"sidekiq_throttling_enabled"`
+	SidekiqThrottlingFactor             float64           `json:"sidekiq_throttling_factor"`
+	SidekiqThrottlingQueues             []string          `json:"sidekiq_throttling_queues"`
+	SignInText                          string            `json:"sign_in_text"`
+	SignupEnabled                       bool              `json:"signup_enabled"`
+	TerminalMaxSessionTime              int               `json:"terminal_max_session_time"`
+	TwoFactorGracePeriod                int               `json:"two_factor_grace_period"`
+	UniqueIPsLimitEnabled               bool              `json:"unique_ips_limit_enabled"`
+	UniqueIPsLimitPerUser               int               `json:"unique_ips_limit_per_user"`
+	UniqueIPsLimitTimeWindow            int               `json:"unique_ips_limit_time_window"`
+	UsagePingEnabled                    bool              `json:"usage_ping_enabled"`
+	UserDefaultExternal                 bool              `json:"user_default_external"`
+	UserOauthApplications               bool              `json:"user_oauth_applications"`
+	VersionCheckEnabled                 bool              `json:"version_check_enabled"`
 }
 
 func (s Settings) String() string {
@@ -79,22 +153,96 @@ func (s *SettingsService) GetSettings(options ...OptionFunc) (*Settings, *Respon
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/settings.html#change-application.settings
 type UpdateSettingsOptions struct {
-	DefaultProjectsLimit       *int              `url:"default_projects_limit,omitempty" json:"default_projects_limit,omitempty"`
-	SignupEnabled              *bool             `url:"signup_enabled,omitempty" json:"signup_enabled,omitempty"`
-	SigninEnabled              *bool             `url:"signin_enabled,omitempty" json:"signin_enabled,omitempty"`
-	GravatarEnabled            *bool             `url:"gravatar_enabled,omitempty" json:"gravatar_enabled,omitempty"`
-	SignInText                 *string           `url:"sign_in_text,omitempty" json:"sign_in_text,omitempty"`
-	HomePageURL                *string           `url:"home_page_url,omitempty" json:"home_page_url,omitempty"`
-	DefaultBranchProtection    *int              `url:"default_branch_protection,omitempty" json:"default_branch_protection,omitempty"`
-	TwitterSharingEnabled      *bool             `url:"twitter_sharing_enabled,omitempty" json:"twitter_sharing_enabled,omitempty"`
-	RestrictedVisibilityLevels []VisibilityValue `url:"restricted_visibility_levels,omitempty" json:"restricted_visibility_levels,omitempty"`
-	MaxAttachmentSize          *int              `url:"max_attachment_size,omitempty" json:"max_attachment_size,omitempty"`
-	SessionExpireDelay         *int              `url:"session_expire_delay,omitempty" json:"session_expire_delay,omitempty"`
-	DefaultProjectVisibility   *int              `url:"default_project_visibility,omitempty" json:"default_project_visibility,omitempty"`
-	DefaultSnippetVisibility   *int              `url:"default_snippet_visibility,omitempty" json:"default_snippet_visibility,omitempty"`
-	RestrictedSignupDomains    []string          `url:"restricted_signup_domains,omitempty" json:"restricted_signup_domains,omitempty"`
-	UserOauthApplications      *bool             `url:"user_oauth_applications,omitempty" json:"user_oauth_applications,omitempty"`
-	AfterSignOutPath           *string           `url:"after_sign_out_path,omitempty" json:"after_sign_out_path,omitempty"`
+	AdminNotificationEmail              *string           `url:"admin_notification_email,omitempty" json:"admin_notification_email,omitempty"`
+	AfterSignOutPath                    *string           `url:"after_sign_out_path,omitempty" json:"after_sign_out_path,omitempty"`
+	AfterSignUpText                     *string           `url:"after_sign_up_text,omitempty" json:"after_sign_up_text,omitempty"`
+	AkismetAPIKey                       *string           `url:"akismet_api_key,omitempty" json:"akismet_api_key,omitempty"`
+	AkismetEnabled                      *bool             `url:"akismet_enabled,omitempty" json:"akismet_enabled,omitempty"`
+	CircuitbreakerAccessRetries         *int              `url:"circuitbreaker_access_retries,omitempty" json:"circuitbreaker_access_retries,omitempty"`
+	CircuitbreakerBackoffThreshold      *int              `url:"circuitbreaker_backoff_threshold,omitempty" json:"circuitbreaker_backoff_threshold,omitempty"`
+	CircuitbreakerFailureCountThreshold *int              `url:"circuitbreaker_failure_count_threshold,omitempty" json:"circuitbreaker_failure_count_threshold,omitempty"`
+	CircuitbreakerFailureResetTime      *int              `url:"circuitbreaker_failure_reset_time,omitempty" json:"circuitbreaker_failure_reset_time,omitempty"`
+	CircuitbreakerFailureWaitTime       *int              `url:"circuitbreaker_failure_wait_time,omitempty" json:"circuitbreaker_failure_wait_time,omitempty"`
+	CircuitbreakerStorageTimeout        *int              `url:"circuitbreaker_storage_timeout,omitempty" json:"circuitbreaker_storage_timeout,omitempty"`
+	ClientsideSentryDSN                 *string           `url:"clientside_sentry_dsn,omitempty" json:"clientside_sentry_dsn,omitempty"`
+	ClientsideSentryEnabled             *bool             `url:"clientside_sentry_enabled,omitempty" json:"clientside_sentry_enabled,omitempty"`
+	ContainerRegistryTokenExpireDelay   *int              `url:"container_registry_token_expire_delay,omitempty" json:"container_registry_token_expire_delay,omitempty"`
+	DefaultArtifactsExpireIn            *string           `url:"default_artifacts_expire_in,omitempty" json:"default_artifacts_expire_in,omitempty"`
+	DefaultBranchProtection             *int              `url:"default_branch_protection,omitempty" json:"default_branch_protection,omitempty"`
+	DefaultGroupVisibility              *string           `url:"default_group_visibility,omitempty" json:"default_group_visibility,omitempty"`
+	DefaultProjectVisibility            *string           `url:"default_project_visibility,omitempty" json:"default_project_visibility,omitempty"`
+	DefaultProjectsLimit                *int              `url:"default_projects_limit,omitempty" json:"default_projects_limit,omitempty"`
+	DefaultSnippetVisibility            *string           `url:"default_snippet_visibility,omitempty" json:"default_snippet_visibility,omitempty"`
+	DisabledOauthSignInSources          []string          `url:"disabled_oauth_sign_in_sources,omitempty" json:"disabled_oauth_sign_in_sources,omitempty"`
+	DomainBlacklistEnabled              *bool             `url:"domain_blacklist_enabled,omitempty" json:"domain_blacklist_enabled,omitempty"`
+	DomainBlacklist                     []string          `url:"domain_blacklist,omitempty" json:"domain_blacklist,omitempty"`
+	DomainWhitelist                     []string          `url:"domain_whitelist,omitempty" json:"domain_whitelist,omitempty"`
+	DSAKeyRestriction                   *int              `url:"dsa_key_restriction,omitempty" json:"dsa_key_restriction,omitempty"`
+	ECDSAKeyRestriction                 *int              `url:"ecdsa_key_restriction,omitempty" json:"ecdsa_key_restriction,omitempty"`
+	Ed25519KeyRestriction               *int              `url:"ed25519_key_restriction,omitempty" json:"ed25519_key_restriction,omitempty"`
+	EmailAuthorInBody                   *bool             `url:"email_author_in_body,omitempty" json:"email_author_in_body,omitempty"`
+	EnabledGitAccessProtocol            *string           `url:"enabled_git_access_protocol,omitempty" json:"enabled_git_access_protocol,omitempty"`
+	GravatarEnabled                     *bool             `url:"gravatar_enabled,omitempty" json:"gravatar_enabled,omitempty"`
+	HelpPageHideCommercialContent       *bool             `url:"help_page_hide_commercial_content,omitempty" json:"help_page_hide_commercial_content,omitempty"`
+	HelpPageSupportURL                  *string           `url:"help_page_support_url,omitempty" json:"help_page_support_url,omitempty"`
+	HomePageURL                         *string           `url:"home_page_url,omitempty" json:"home_page_url,omitempty"`
+	HousekeepingBitmapsEnabled          *bool             `url:"housekeeping_bitmaps_enabled,omitempty" json:"housekeeping_bitmaps_enabled,omitempty"`
+	HousekeepingEnabled                 *bool             `url:"housekeeping_enabled,omitempty" json:"housekeeping_enabled,omitempty"`
+	HousekeepingFullRepackPeriod        *int              `url:"housekeeping_full_repack_period,omitempty" json:"housekeeping_full_repack_period,omitempty"`
+	HousekeepingGcPeriod                *int              `url:"housekeeping_gc_period,omitempty" json:"housekeeping_gc_period,omitempty"`
+	HousekeepingIncrementalRepackPeriod *int              `url:"housekeeping_incremental_repack_period,omitempty" json:"housekeeping_incremental_repack_period,omitempty"`
+	HTMLEmailsEnabled                   *bool             `url:"html_emails_enabled,omitempty" json:"html_emails_enabled,omitempty"`
+	ImportSources                       []string          `url:"import_sources,omitempty" json:"import_sources,omitempty"`
+	KodingEnabled                       *bool             `url:"koding_enabled,omitempty" json:"koding_enabled,omitempty"`
+	KodingURL                           *string           `url:"koding_url,omitempty" json:"koding_url,omitempty"`
+	MaxArtifactsSize                    *int              `url:"max_artifacts_size,omitempty" json:"max_artifacts_size,omitempty"`
+	MaxAttachmentSize                   *int              `url:"max_attachment_size,omitempty" json:"max_attachment_size,omitempty"`
+	MaxPagesSize                        *int              `url:"max_pages_size,omitempty" json:"max_pages_size,omitempty"`
+	MetricsEnabled                      *bool             `url:"metrics_enabled,omitempty" json:"metrics_enabled,omitempty"`
+	MetricsHost                         *string           `url:"metrics_host,omitempty" json:"metrics_host,omitempty"`
+	MetricsMethodCallThreshold          *int              `url:"metrics_method_call_threshold,omitempty" json:"metrics_method_call_threshold,omitempty"`
+	MetricsPacketSize                   *int              `url:"metrics_packet_size,omitempty" json:"metrics_packet_size,omitempty"`
+	MetricsPoolSize                     *int              `url:"metrics_pool_size,omitempty" json:"metrics_pool_size,omitempty"`
+	MetricsPort                         *int              `url:"metrics_port,omitempty" json:"metrics_port,omitempty"`
+	MetricsSampleInterval               *int              `url:"metrics_sample_interval,omitempty" json:"metrics_sample_interval,omitempty"`
+	MetricsTimeout                      *int              `url:"metrics_timeout,omitempty" json:"metrics_timeout,omitempty"`
+	PasswordAuthenticationEnabledForWeb *bool             `url:"password_authentication_enabled_for_web,omitempty" json:"password_authentication_enabled_for_web,omitempty"`
+	PasswordAuthenticationEnabledForGit *bool             `url:"password_authentication_enabled_for_git,omitempty" json:"password_authentication_enabled_for_git,omitempty"`
+	PerformanceBarAllowedGroupID        *string           `url:"performance_bar_allowed_group_id,omitempty" json:"performance_bar_allowed_group_id,omitempty"`
+	PerformanceBarEnabled               *bool             `url:"performance_bar_enabled,omitempty" json:"performance_bar_enabled,omitempty"`
+	PlantumlEnabled                     *bool             `url:"plantuml_enabled,omitempty" json:"plantuml_enabled,omitempty"`
+	PlantumlURL                         *string           `url:"plantuml_url,omitempty" json:"plantuml_url,omitempty"`
+	PollingIntervalMultiplier           *float64          `url:"polling_interval_multiplier,omitempty" json:"polling_interval_multiplier,omitempty"`
+	ProjectExportEnabled                *bool             `url:"project_export_enabled,omitempty" json:"project_export_enabled,omitempty"`
+	PrometheusMetricsEnabled            *bool             `url:"prometheus_metrics_enabled,omitempty" json:"prometheus_metrics_enabled,omitempty"`
+	RecaptchaEnabled                    *bool             `url:"recaptcha_enabled,omitempty" json:"recaptcha_enabled,omitempty"`
+	RecaptchaPrivateKey                 *string           `url:"recaptcha_private_key,omitempty" json:"recaptcha_private_key,omitempty"`
+	RecaptchaSiteKey                    *string           `url:"recaptcha_site_key,omitempty" json:"recaptcha_site_key,omitempty"`
+	RepositoryChecksEnabled             *bool             `url:"repository_checks_enabled,omitempty" json:"repository_checks_enabled,omitempty"`
+	RepositoryStorages                  []string          `url:"repository_storages,omitempty" json:"repository_storages,omitempty"`
+	RequireTwoFactorAuthentication      *bool             `url:"require_two_factor_authentication,omitempty" json:"require_two_factor_authentication,omitempty"`
+	RestrictedVisibilityLevels          []VisibilityValue `url:"restricted_visibility_levels,omitempty" json:"restricted_visibility_levels,omitempty"`
+	RsaKeyRestriction                   *int              `url:"rsa_key_restriction,omitempty" json:"rsa_key_restriction,omitempty"`
+	SendUserConfirmationEmail           *bool             `url:"send_user_confirmation_email,omitempty" json:"send_user_confirmation_email,omitempty"`
+	SentryDSN                           *string           `url:"sentry_dsn,omitempty" json:"sentry_dsn,omitempty"`
+	SentryEnabled                       *bool             `url:"sentry_enabled,omitempty" json:"sentry_enabled,omitempty"`
+	SessionExpireDelay                  *int              `url:"session_expire_delay,omitempty" json:"session_expire_delay,omitempty"`
+	SharedRunnersEnabled                *bool             `url:"shared_runners_enabled,omitempty" json:"shared_runners_enabled,omitempty"`
+	SharedRunnersText                   *string           `url:"shared_runners_text,omitempty" json:"shared_runners_text,omitempty"`
+	SidekiqThrottlingEnabled            *bool             `url:"sidekiq_throttling_enabled,omitempty" json:"sidekiq_throttling_enabled,omitempty"`
+	SidekiqThrottlingFactor             *float64          `url:"sidekiq_throttling_factor,omitempty" json:"sidekiq_throttling_factor,omitempty"`
+	SidekiqThrottlingQueues             []string          `url:"sidekiq_throttling_queues,omitempty" json:"sidekiq_throttling_queues,omitempty"`
+	SignInText                          *string           `url:"sign_in_text,omitempty" json:"sign_in_text,omitempty"`
+	SignupEnabled                       *bool             `url:"signup_enabled,omitempty" json:"signup_enabled,omitempty"`
+	TerminalMaxSessionTime              *int              `url:"terminal_max_session_time,omitempty" json:"terminal_max_session_time,omitempty"`
+	TwoFactorGracePeriod                *int              `url:"two_factor_grace_period,omitempty" json:"two_factor_grace_period,omitempty"`
+	UniqueIPsLimitEnabled               *bool             `url:"unique_ips_limit_enabled,omitempty" json:"unique_ips_limit_enabled,omitempty"`
+	UniqueIPsLimitPerUser               *int              `url:"unique_ips_limit_per_user,omitempty" json:"unique_ips_limit_per_user,omitempty"`
+	UniqueIPsLimitTimeWindow            *int              `url:"unique_ips_limit_time_window,omitempty" json:"unique_ips_limit_time_window,omitempty"`
+	UsagePingEnabled                    *bool             `url:"usage_ping_enabled,omitempty" json:"usage_ping_enabled,omitempty"`
+	UserDefaultExternal                 *bool             `url:"user_default_external,omitempty" json:"user_default_external,omitempty"`
+	UserOauthApplications               *bool             `url:"user_oauth_applications,omitempty" json:"user_oauth_applications,omitempty"`
+	VersionCheckEnabled                 *bool             `url:"version_check_enabled,omitempty" json:"version_check_enabled,omitempty"`
 }
 
 // UpdateSettings updates the application settings.

--- a/vendor/github.com/xanzy/go-gitlab/sidekiq_metrics.go
+++ b/vendor/github.com/xanzy/go-gitlab/sidekiq_metrics.go
@@ -1,0 +1,154 @@
+//
+// Copyright 2018, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import "time"
+
+// SidekiqService handles communication with the sidekiq service
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/sidekiq_metrics.html
+type SidekiqService struct {
+	client *Client
+}
+
+// QueueMetrics represents the GitLab sidekiq queue metrics.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-queue-metrics
+type QueueMetrics struct {
+	Queues map[string]struct {
+		Backlog int `json:"backlog"`
+		Latency int `json:"latency"`
+	} `json:"queues"`
+}
+
+// GetQueueMetrics lists information about all the registered queues,
+// their backlog and their latency.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-queue-metrics
+func (s *SidekiqService) GetQueueMetrics(options ...OptionFunc) (*QueueMetrics, *Response, error) {
+	req, err := s.client.NewRequest("GET", "/sidekiq/queue_metrics", nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	q := new(QueueMetrics)
+	resp, err := s.client.Do(req, q)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return q, resp, err
+}
+
+// ProcessMetrics represents the GitLab sidekiq process metrics.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-process-metrics
+type ProcessMetrics struct {
+	Processes []struct {
+		Hostname    string     `json:"hostname"`
+		Pid         int        `json:"pid"`
+		Tag         string     `json:"tag"`
+		StartedAt   *time.Time `json:"started_at"`
+		Queues      []string   `json:"queues"`
+		Labels      []string   `json:"labels"`
+		Concurrency int        `json:"concurrency"`
+		Busy        int        `json:"busy"`
+	} `json:"processes"`
+}
+
+// GetProcessMetrics lists information about all the Sidekiq workers registered
+// to process your queues.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-process-metrics
+func (s *SidekiqService) GetProcessMetrics(options ...OptionFunc) (*ProcessMetrics, *Response, error) {
+	req, err := s.client.NewRequest("GET", "/sidekiq/process_metrics", nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(ProcessMetrics)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// JobStats represents the GitLab sidekiq job stats.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-job-statistics
+type JobStats struct {
+	Jobs struct {
+		Processed int `json:"processed"`
+		Failed    int `json:"failed"`
+		Enqueued  int `json:"enqueued"`
+	} `json:"jobs"`
+}
+
+// GetJobStats list information about the jobs that Sidekiq has performed.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-job-statistics
+func (s *SidekiqService) GetJobStats(options ...OptionFunc) (*JobStats, *Response, error) {
+	req, err := s.client.NewRequest("GET", "/sidekiq/job_stats", nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	j := new(JobStats)
+	resp, err := s.client.Do(req, j)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return j, resp, err
+}
+
+// CompoundMetrics represents the GitLab sidekiq compounded stats.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-a-compound-response-of-all-the-previously-mentioned-metrics
+type CompoundMetrics struct {
+	QueueMetrics
+	ProcessMetrics
+	JobStats
+}
+
+// GetCompoundMetrics lists all the currently available information about Sidekiq.
+// Get a compound response of all the previously mentioned metrics
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-job-statistics
+func (s *SidekiqService) GetCompoundMetrics(options ...OptionFunc) (*CompoundMetrics, *Response, error) {
+	req, err := s.client.NewRequest("GET", "/sidekiq/compound_metrics", nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := new(CompoundMetrics)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/snippets.go
+++ b/vendor/github.com/xanzy/go-gitlab/snippets.go
@@ -1,0 +1,230 @@
+//
+// Copyright 2017, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+)
+
+// SnippetsService handles communication with the snippets
+// related methods of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/snippets.html
+type SnippetsService struct {
+	client *Client
+}
+
+// Snippet represents a GitLab snippet.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/snippets.html
+type Snippet struct {
+	ID          int    `json:"id"`
+	Title       string `json:"title"`
+	FileName    string `json:"file_name"`
+	Description string `json:"description"`
+	Author      struct {
+		ID        int        `json:"id"`
+		Username  string     `json:"username"`
+		Email     string     `json:"email"`
+		Name      string     `json:"name"`
+		State     string     `json:"state"`
+		CreatedAt *time.Time `json:"created_at"`
+	} `json:"author"`
+	UpdatedAt *time.Time `json:"updated_at"`
+	CreatedAt *time.Time `json:"created_at"`
+	WebURL    string     `json:"web_url"`
+	RawURL    string     `json:"raw_url"`
+}
+
+func (s Snippet) String() string {
+	return Stringify(s)
+}
+
+// ListSnippetsOptions represents the available ListSnippets() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/snippets.html#list-snippets
+type ListSnippetsOptions ListOptions
+
+// ListSnippets gets a list of snippets.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/snippets.html#list-snippets
+func (s *SnippetsService) ListSnippets(opt *ListSnippetsOptions, options ...OptionFunc) ([]*Snippet, *Response, error) {
+	req, err := s.client.NewRequest("GET", "snippets", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ps []*Snippet
+	resp, err := s.client.Do(req, &ps)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ps, resp, err
+}
+
+// GetSnippet gets a single snippet
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/snippets.html#single-snippet
+func (s *SnippetsService) GetSnippet(snippet int, options ...OptionFunc) (*Snippet, *Response, error) {
+	u := fmt.Sprintf("snippets/%d", snippet)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ps := new(Snippet)
+	resp, err := s.client.Do(req, ps)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ps, resp, err
+}
+
+// CreateSnippetOptions represents the available CreateSnippet() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/snippets.html#create-new-snippet
+type CreateSnippetOptions struct {
+	Title       *string          `url:"title,omitempty" json:"title,omitempty"`
+	FileName    *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
+	Description *string          `url:"description,omitempty" json:"description,omitempty"`
+	Content     *string          `url:"content,omitempty" json:"content,omitempty"`
+	Visibility  *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
+}
+
+// CreateSnippet creates a new snippet. The user must have permission
+// to create new snippets.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/snippets.html#create-new-snippet
+func (s *SnippetsService) CreateSnippet(opt *CreateSnippetOptions, options ...OptionFunc) (*Snippet, *Response, error) {
+	req, err := s.client.NewRequest("POST", "snippets", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ps := new(Snippet)
+	resp, err := s.client.Do(req, ps)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ps, resp, err
+}
+
+// UpdateSnippetOptions represents the available UpdateSnippet() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/snippets.html#update-snippet
+type UpdateSnippetOptions struct {
+	Title       *string          `url:"title,omitempty" json:"title,omitempty"`
+	FileName    *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
+	Description *string          `url:"description,omitempty" json:"description,omitempty"`
+	Content     *string          `url:"content,omitempty" json:"content,omitempty"`
+	Visibility  *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
+}
+
+// UpdateSnippet updates an existing snippet. The user must have
+// permission to change an existing snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/snippets.html#update-snippet
+func (s *SnippetsService) UpdateSnippet(snippet int, opt *UpdateSnippetOptions, options ...OptionFunc) (*Snippet, *Response, error) {
+	u := fmt.Sprintf("snippets/%d", snippet)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ps := new(Snippet)
+	resp, err := s.client.Do(req, ps)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ps, resp, err
+}
+
+// DeleteSnippet deletes an existing snippet. This is an idempotent
+// function and deleting a non-existent snippet still returns a 200 OK status
+// code.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/snippets.html#delete-snippet
+func (s *SnippetsService) DeleteSnippet(snippet int, options ...OptionFunc) (*Response, error) {
+	u := fmt.Sprintf("snippets/%d", snippet)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// SnippetContent returns the raw snippet as plain text.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/snippets.html#snippet-content
+func (s *SnippetsService) SnippetContent(snippet int, options ...OptionFunc) ([]byte, *Response, error) {
+	u := fmt.Sprintf("snippets/%d/raw", snippet)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var b bytes.Buffer
+	resp, err := s.client.Do(req, &b)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return b.Bytes(), resp, err
+}
+
+// ExploreSnippetsOptions represents the available ExploreSnippets() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/snippets.html#explore-all-public-snippets
+type ExploreSnippetsOptions ListOptions
+
+// ExploreSnippets gets the list of public snippets.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/snippets.html#explore-all-public-snippets
+func (s *SnippetsService) ExploreSnippets(opt *ExploreSnippetsOptions, options ...OptionFunc) ([]*Snippet, *Response, error) {
+	req, err := s.client.NewRequest("GET", "snippets/public", nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ps []*Snippet
+	resp, err := s.client.Do(req, &ps)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ps, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/system_hooks.go
+++ b/vendor/github.com/xanzy/go-gitlab/system_hooks.go
@@ -88,7 +88,7 @@ func (s *SystemHooksService) AddHook(opt *AddHookOptions, options ...OptionFunc)
 	return h, resp, err
 }
 
-// HookEvent represents an event triggert by a GitLab system hook.
+// HookEvent represents an event trigger by a GitLab system hook.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/system_hooks.html
 type HookEvent struct {

--- a/vendor/github.com/xanzy/go-gitlab/tags.go
+++ b/vendor/github.com/xanzy/go-gitlab/tags.go
@@ -33,32 +33,40 @@ type TagsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
 type Tag struct {
-	Commit  *Commit `json:"commit"`
-	Release struct {
-		TagName     string `json:"tag_name"`
-		Description string `json:"description"`
-	} `json:"release"`
-	Name    string `json:"name"`
-	Message string `json:"message"`
+	Commit  *Commit  `json:"commit"`
+	Release *Release `json:"release"`
+	Name    string   `json:"name"`
+	Message string   `json:"message"`
+}
+
+type Release struct {
+	TagName     string `json:"tag_name"`
+	Description string `json:"description"`
 }
 
 func (t Tag) String() string {
 	return Stringify(t)
 }
 
+// ListTagsOptions represents the available ListTags() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/tags.html#list-project-repository-tags
+type ListTagsOptions ListOptions
+
 // ListTags gets a list of tags from a project, sorted by name in reverse
 // alphabetical order.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#list-project-repository-tags
-func (s *TagsService) ListTags(pid interface{}, options ...OptionFunc) ([]*Tag, *Response, error) {
+func (s *TagsService) ListTags(pid interface{}, opt *ListTagsOptions, options ...OptionFunc) ([]*Tag, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/tags", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -151,4 +159,71 @@ func (s *TagsService) DeleteTag(pid interface{}, tag string, options ...OptionFu
 	}
 
 	return s.client.Do(req, nil)
+}
+
+// CreateReleaseOptions represents the available CreateRelease() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/tags.html#create-a-new-release
+type CreateReleaseOptions struct {
+	Description *string `url:"description:omitempty" json:"description,omitempty"`
+}
+
+// CreateRelease Add release notes to the existing git tag.
+// If there already exists a release for the given tag, status code 409 is returned.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/tags.html#create-a-new-release
+func (s *TagsService) CreateRelease(pid interface{}, tag string, opt *CreateReleaseOptions, options ...OptionFunc) (*Release, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/repository/tags/%s/release", url.QueryEscape(project), tag)
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := new(Release)
+	resp, err := s.client.Do(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, err
+}
+
+// UpdateReleaseOptions represents the available UpdateRelease() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/tags.html#update-a-release
+type UpdateReleaseOptions struct {
+	Description *string `url:"description:omitempty" json:"description,omitempty"`
+}
+
+// UpdateRelease Updates the release notes of a given release.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/tags.html#update-a-release
+func (s *TagsService) UpdateRelease(pid interface{}, tag string, opt *UpdateReleaseOptions, options ...OptionFunc) (*Release, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/repository/tags/%s/release", url.QueryEscape(project), tag)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := new(Release)
+	resp, err := s.client.Do(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, err
 }

--- a/vendor/github.com/xanzy/go-gitlab/users.go
+++ b/vendor/github.com/xanzy/go-gitlab/users.go
@@ -83,6 +83,8 @@ type ListUsersOptions struct {
 	Username      *string    `url:"username,omitempty" json:"username,omitempty"`
 	ExternalUID   *string    `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
 	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty" `
+	OrderBy       *string    `url:"order_by,omitempty" json:order_by,omitempty`
+	Sort          *string    `url:"sort,omitempty" json:sort,omitempty`
 }
 
 // ListUsers gets a list of users.

--- a/vendor/github.com/xanzy/go-gitlab/users.go
+++ b/vendor/github.com/xanzy/go-gitlab/users.go
@@ -41,13 +41,16 @@ type User struct {
 	State            string          `json:"state"`
 	CreatedAt        *time.Time      `json:"created_at"`
 	Bio              string          `json:"bio"`
+	Location         string          `json:"location"`
 	Skype            string          `json:"skype"`
 	Linkedin         string          `json:"linkedin"`
 	Twitter          string          `json:"twitter"`
 	WebsiteURL       string          `json:"website_url"`
+	Organization     string          `json:"organization"`
 	ExternUID        string          `json:"extern_uid"`
 	Provider         string          `json:"provider"`
 	ThemeID          int             `json:"theme_id"`
+	LastActivityOn   *ISOTime        `json:"last_activity_on"`
 	ColorSchemeID    int             `json:"color_scheme_id"`
 	IsAdmin          bool            `json:"is_admin"`
 	AvatarURL        string          `json:"avatar_url"`
@@ -58,9 +61,10 @@ type User struct {
 	LastSignInAt     *time.Time      `json:"last_sign_in_at"`
 	TwoFactorEnabled bool            `json:"two_factor_enabled"`
 	Identities       []*UserIdentity `json:"identities"`
+	External         bool            `json:"external"`
 }
 
-// UserIdentity represents a user identity
+// UserIdentity represents a user identity.
 type UserIdentity struct {
 	Provider  string `json:"provider"`
 	ExternUID string `json:"extern_uid"`
@@ -71,9 +75,14 @@ type UserIdentity struct {
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-users
 type ListUsersOptions struct {
 	ListOptions
-	Active   *bool   `url:"active,omitempty" json:"active,omitempty"`
-	Search   *string `url:"search,omitempty" json:"search,omitempty"`
-	Username *string `url:"username,omitempty" json:"username,omitempty"`
+	Active  *bool `url:"active,omitempty" json:"active,omitempty"`
+	Blocked *bool `url:"blocked,omitempty" json:"blocked,omitempty"`
+
+	// The options below are only available for admins.
+	Search        *string    `url:"search,omitempty" json:"search,omitempty"`
+	Username      *string    `url:"username,omitempty" json:"username,omitempty"`
+	ExternalUID   *string    `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
+	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty" `
 }
 
 // ListUsers gets a list of users.
@@ -126,13 +135,16 @@ type CreateUserOptions struct {
 	Linkedin         *string `url:"linkedin,omitempty" json:"linkedin,omitempty"`
 	Twitter          *string `url:"twitter,omitempty" json:"twitter,omitempty"`
 	WebsiteURL       *string `url:"website_url,omitempty" json:"website_url,omitempty"`
+	Organization     *string `url:"organization,omitempty" json:"organization,omitempty"`
 	ProjectsLimit    *int    `url:"projects_limit,omitempty" json:"projects_limit,omitempty"`
 	ExternUID        *string `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
 	Provider         *string `url:"provider,omitempty" json:"provider,omitempty"`
 	Bio              *string `url:"bio,omitempty" json:"bio,omitempty"`
+	Location         *string `url:"location,omitempty" json:"location,omitempty"`
 	Admin            *bool   `url:"admin,omitempty" json:"admin,omitempty"`
 	CanCreateGroup   *bool   `url:"can_create_group,omitempty" json:"can_create_group,omitempty"`
 	SkipConfirmation *bool   `url:"skip_confirmation,omitempty" json:"skip_confirmation,omitempty"`
+	External         *bool   `url:"external,omitempty" json:"external,omitempty"`
 }
 
 // CreateUser creates a new user. Note only administrators can create new users.
@@ -165,12 +177,15 @@ type ModifyUserOptions struct {
 	Linkedin       *string `url:"linkedin,omitempty" json:"linkedin,omitempty"`
 	Twitter        *string `url:"twitter,omitempty" json:"twitter,omitempty"`
 	WebsiteURL     *string `url:"website_url,omitempty" json:"website_url,omitempty"`
+	Organization   *string `url:"organization,omitempty" json:"organization,omitempty"`
 	ProjectsLimit  *int    `url:"projects_limit,omitempty" json:"projects_limit,omitempty"`
 	ExternUID      *string `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
 	Provider       *string `url:"provider,omitempty" json:"provider,omitempty"`
 	Bio            *string `url:"bio,omitempty" json:"bio,omitempty"`
+	Location       *string `url:"location,omitempty" json:"location,omitempty"`
 	Admin          *bool   `url:"admin,omitempty" json:"admin,omitempty"`
 	CanCreateGroup *bool   `url:"can_create_group,omitempty" json:"can_create_group,omitempty"`
+	External       *bool   `url:"external,omitempty" json:"external,omitempty"`
 }
 
 // ModifyUser modifies an existing user. Only administrators can change attributes
@@ -258,15 +273,21 @@ func (s *UsersService) ListSSHKeys(options ...OptionFunc) ([]*SSHKey, *Response,
 	return k, resp, err
 }
 
+// ListSSHKeysForUserOptions represents the available ListSSHKeysForUser() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/users.html#list-ssh-keys-for-user
+type ListSSHKeysForUserOptions ListOptions
+
 // ListSSHKeysForUser gets a list of a specified user's SSH keys. Available
 // only for admin
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/users.html#list-ssh-keys-for-user
-func (s *UsersService) ListSSHKeysForUser(user int, options ...OptionFunc) ([]*SSHKey, *Response, error) {
+func (s *UsersService) ListSSHKeysForUser(user int, opt *ListSSHKeysForUserOptions, options ...OptionFunc) ([]*SSHKey, *Response, error) {
 	u := fmt.Sprintf("users/%d/keys", user)
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -397,7 +418,7 @@ func (s *UsersService) BlockUser(user int, options ...OptionFunc) error {
 	}
 
 	switch resp.StatusCode {
-	case 200:
+	case 201:
 		return nil
 	case 403:
 		return errors.New("Cannot block a user that is already blocked by LDAP synchronization")
@@ -425,7 +446,7 @@ func (s *UsersService) UnblockUser(user int, options ...OptionFunc) error {
 	}
 
 	switch resp.StatusCode {
-	case 200:
+	case 201:
 		return nil
 	case 403:
 		return errors.New("Cannot unblock a user that is blocked by LDAP synchronization")
@@ -462,15 +483,21 @@ func (s *UsersService) ListEmails(options ...OptionFunc) ([]*Email, *Response, e
 	return e, resp, err
 }
 
+// ListEmailsForUserOptions represents the available ListEmailsForUser() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/users.html#list-emails-for-user
+type ListEmailsForUserOptions ListOptions
+
 // ListEmailsForUser gets a list of a specified user's Emails. Available
 // only for admin
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/users.html#list-emails-for-user
-func (s *UsersService) ListEmailsForUser(user int, options ...OptionFunc) ([]*Email, *Response, error) {
+func (s *UsersService) ListEmailsForUser(user int, opt *ListEmailsForUserOptions, options ...OptionFunc) ([]*Email, *Response, error) {
 	u := fmt.Sprintf("users/%d/emails", user)
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -595,7 +622,7 @@ type ImpersonationToken struct {
 	Scopes    []string   `json:"scopes"`
 	Revoked   bool       `json:"revoked"`
 	CreatedAt *time.Time `json:"created_at"`
-	ExpiresAt *time.Time `json:"expires_at"`
+	ExpiresAt *ISOTime   `json:"expires_at"`
 }
 
 // GetAllImpersonationTokensOptions represents the available
@@ -604,6 +631,7 @@ type ImpersonationToken struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/users.html#get-all-impersonation-tokens-of-a-user
 type GetAllImpersonationTokensOptions struct {
+	ListOptions
 	State *string `url:"state,omitempty" json:"state,omitempty"`
 }
 
@@ -694,4 +722,40 @@ func (s *UsersService) RevokeImpersonationToken(user, token int, options ...Opti
 	}
 
 	return s.client.Do(req, nil)
+}
+
+// UserActivity represents an entry in the user/activities response
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/users.html#get-user-activities-admin-only
+type UserActivity struct {
+	Username       string   `json:"username"`
+	LastActivityOn *ISOTime `json:"last_activity_on"`
+}
+
+// GetUserActivitiesOptions represents the options for GetUserActivities
+//
+// GitLap API docs:
+// https://docs.gitlab.com/ce/api/users.html#get-user-activities-admin-only
+type GetUserActivitiesOptions struct {
+	From *ISOTime `url:"from,omitempty" json:"from,omitempty"`
+}
+
+// GetUserActivities retrieves user activities (admin only)
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/users.html#get-user-activities-admin-only
+func (s *UsersService) GetUserActivities(opt *GetUserActivitiesOptions, options ...OptionFunc) ([]*UserActivity, *Response, error) {
+	req, err := s.client.NewRequest("GET", "user/activities", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var t []*UserActivity
+	resp, err := s.client.Do(req, &t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, err
 }

--- a/vendor/github.com/xanzy/go-gitlab/validate.go
+++ b/vendor/github.com/xanzy/go-gitlab/validate.go
@@ -1,0 +1,40 @@
+package gitlab
+
+// ValidateService handles communication with the validation related methods of
+// the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
+type ValidateService struct {
+	client *Client
+}
+
+// LintResult represents the linting results.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
+type LintResult struct {
+	Status string   `json:"status"`
+	Errors []string `json:"errors"`
+}
+
+// Lint validates .gitlab-ci.yml content.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
+func (s *ValidateService) Lint(content string, options ...OptionFunc) (*LintResult, *Response, error) {
+	var opts struct {
+		Content string `url:"content,omitempty" json:"content,omitempty"`
+	}
+	opts.Content = content
+
+	req, err := s.client.NewRequest("POST", "ci/lint", &opts, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l := new(LintResult)
+	resp, err := s.client.Do(req, l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, nil
+}

--- a/vendor/github.com/xanzy/go-gitlab/wikis.go
+++ b/vendor/github.com/xanzy/go-gitlab/wikis.go
@@ -1,0 +1,204 @@
+// Copyright 2017, Stany MARCEL
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// WikisService handles communication with the wikis related methods of
+// the Gitlab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/wikis.html
+type WikisService struct {
+	client *Client
+}
+
+// WikiFormat represents the available wiki formats.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/wikis.html
+type WikiFormat string
+
+// The available wiki formats.
+const (
+	WikiFormatMarkdown WikiFormat = "markdown"
+	WikiFormatRFoc     WikiFormat = "rdoc"
+	WikiFormatASCIIDoc WikiFormat = "asciidoc"
+)
+
+// Wiki represents a GitLab wiki.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/wikis.html
+type Wiki struct {
+	Content string     `json:"content"`
+	Format  WikiFormat `json:"format"`
+	Slug    string     `json:"slug"`
+	Title   string     `json:"title"`
+}
+
+func (w Wiki) String() string {
+	return Stringify(w)
+}
+
+// ListWikisOptions represents the available ListWikis options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/wikis.html#list-wiki-pages
+type ListWikisOptions struct {
+	WithContent *bool `url:"with_content,omitempty" json:"with_content,omitempty"`
+}
+
+// ListWikis lists all pages of the wiki of the given project id.
+// When with_content is set, it also returns the content of the pages.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/wikis.html#list-wiki-pages
+func (s *WikisService) ListWikis(pid interface{}, opt *ListWikisOptions, options ...OptionFunc) ([]*Wiki, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/wikis", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var w []*Wiki
+	resp, err := s.client.Do(req, &w)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return w, resp, err
+}
+
+// GetWikiPage gets a wiki page for a given project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/wikis.html#get-a-wiki-page
+func (s *WikisService) GetWikiPage(pid interface{}, slug string, options ...OptionFunc) (*Wiki, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/wikis/%s", url.QueryEscape(project), url.QueryEscape(slug))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var w *Wiki
+	resp, err := s.client.Do(req, &w)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return w, resp, err
+}
+
+// CreateWikiPageOptions represents options to CreateWikiPage.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/wikis.html#create-a-new-wiki-page
+type CreateWikiPageOptions struct {
+	Content *string `url:"content" json:"content"`
+	Title   *string `url:"title" json:"title"`
+	Format  *string `url:"format,omitempty" json:"format,omitempty"`
+}
+
+// CreateWikiPage creates a new wiki page for the given repository with
+// the given title, slug, and content.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/wikis.html#create-a-new-wiki-page
+func (s *WikisService) CreateWikiPage(pid interface{}, opt *CreateWikiPageOptions, options ...OptionFunc) (*Wiki, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/wikis", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	w := new(Wiki)
+	resp, err := s.client.Do(req, w)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return w, resp, err
+}
+
+// EditWikiPageOptions represents options to EditWikiPage.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/wikis.html#edit-an-existing-wiki-page
+type EditWikiPageOptions struct {
+	Content *string `url:"content" json:"content"`
+	Title   *string `url:"title" json:"title"`
+	Format  *string `url:"format,omitempty" json:"format,omitempty"`
+}
+
+// EditWikiPage Updates an existing wiki page. At least one parameter is
+// required to update the wiki page.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/wikis.html#edit-an-existing-wiki-page
+func (s *WikisService) EditWikiPage(pid interface{}, slug string, opt *EditWikiPageOptions, options ...OptionFunc) (*Wiki, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/wikis/%s", url.QueryEscape(project), url.QueryEscape(slug))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	w := new(Wiki)
+	resp, err := s.client.Do(req, w)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return w, resp, err
+}
+
+// DeleteWikiPage deletes a wiki page with a given slug.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/wikis.html#delete-a-wiki-page
+func (s *WikisService) DeleteWikiPage(pid interface{}, slug string, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/wikis/%s", url.QueryEscape(project), url.QueryEscape(slug))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -585,10 +585,10 @@
 			"revisionTime": "2016-09-27T10:08:44Z"
 		},
 		{
-			"checksumSHA1": "rBRMciteJAFVf9xWMXbMbXbJrzM=",
+			"checksumSHA1": "NZk5D25Na3CA5FX1N0EgHfe/sSg=",
 			"path": "github.com/xanzy/go-gitlab",
-			"revision": "d11d546f58c67430417f975b453f44f280474a4d",
-			"revisionTime": "2017-09-24T15:03:35Z"
+			"revision": "c00cef4b483bb262426d9b37bd252436dbccac55",
+			"revisionTime": "2018-04-06T12:10:38Z"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",
@@ -689,5 +689,5 @@
 			"versionExact": "v1.6.1"
 		}
 	],
-	"rootPath": "github.com/terraform-providers/terraform-provider-gitlab"
+	"rootPath": "github.com/claranet/terraform-provider-gitlab"
 }


### PR DESCRIPTION
Add new gitlab_users resource that returns a list of users. It takes optional arguments:
- order_by
- sort
- search
- active
- blocked
- extern_uid (must be set with provider)
- provider (must be set with extern_uid) (needs to be implemented in the gitlab go client)
- created_before
- created_after (needs to be implemented in the gitlab go client)
- options

Examples:
* Get all users
`data "gitlab_users" "all_users" {
}`
* Get users created before the 5th of April 2018 ordered by username
`data "gitlab_users" "username" {
  options {
    order_by = "username"
    created_before = "2018-04-05"
  }
}`