### PR TITLE
Project Variable Resource

### DIFF
--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -54,6 +54,7 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_deploy_key":         resourceGitlabDeployKey(),
 			"gitlab_user":               resourceGitlabUser(),
 			"gitlab_project_membership": resourceGitlabProjectMembership(),
+			"gitlab_project_variable": 	 resourceGitlabProjectVariable(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -54,7 +54,7 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_deploy_key":         resourceGitlabDeployKey(),
 			"gitlab_user":               resourceGitlabUser(),
 			"gitlab_project_membership": resourceGitlabProjectMembership(),
-			"gitlab_project_variable": 	 resourceGitlabProjectVariable(),
+			"gitlab_project_variable":   resourceGitlabProjectVariable(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/gitlab/resource_gitlab_project_variable.go
+++ b/gitlab/resource_gitlab_project_variable.go
@@ -20,8 +20,9 @@ func resourceGitlabProjectVariable() *schema.Resource {
 				Required: true,
 			},
 			"key": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringIsGitlabVariableName(),
 			},
 			"value": {
 				Type:      schema.TypeString,

--- a/gitlab/resource_gitlab_project_variable.go
+++ b/gitlab/resource_gitlab_project_variable.go
@@ -1,0 +1,102 @@
+package gitlab
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/xanzy/go-gitlab"
+)
+
+func resourceGitlabProjectVariable() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabProjectVariableCreate,
+		Read:   resourceGitlabProjectVariableRead,
+		Update: resourceGitlabProjectVariableUpdate,
+		Delete: resourceGitlabProjectVariableDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"value": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"protected": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func resourceGitlabProjectVariableCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+	key := d.Get("key").(string)
+	options := &gitlab.CreateBuildVariableOptions{
+		Key:       gitlab.String(key),
+		Value:     gitlab.String(d.Get("value").(string)),
+		Protected: gitlab.Bool(d.Get("protected").(bool)),
+	}
+	log.Printf("[DEBUG] create gitlab project variable %s/%s", project, key)
+
+	_, _, err := client.BuildVariables.CreateBuildVariable(project, options)
+	if err != nil {
+		return err
+	}
+
+	return resourceGitlabProjectVariableRead(d, meta)
+}
+
+func resourceGitlabProjectVariableRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+	key := d.Get("key").(string)
+	log.Printf("[DEBUG] read gitlab project variable %s/%s", project, key)
+
+	v, _, err := client.BuildVariables.GetBuildVariable(project, key)
+	if err != nil {
+		return err
+	}
+
+	d.Set("value", v.Value)
+	d.Set("protected", v.Protected)
+	return nil
+}
+
+func resourceGitlabProjectVariableUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+	key := d.Get("key").(string)
+	options := &gitlab.UpdateBuildVariableOptions{
+		Key:       gitlab.String(d.Get("key").(string)),
+		Value:     gitlab.String(d.Get("value").(string)),
+		Protected: gitlab.Bool(d.Get("protected").(bool)),
+	}
+	log.Printf("[DEBUG] update gitlab project variable %s/%s", project, key)
+
+	_, _, err := client.BuildVariables.UpdateBuildVariable(project, key, options)
+	if err != nil {
+		return err
+	}
+
+	return resourceGitlabProjectVariableRead(d, meta)
+}
+
+func resourceGitlabProjectVariableDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+	key := d.Get("key").(string)
+	log.Printf("[DEBUG] Delete gitlab project variable %s/%s", project, key)
+
+	_, err := client.BuildVariables.RemoveBuildVariable(project, key)
+	return err
+}

--- a/gitlab/resource_gitlab_project_variable_test.go
+++ b/gitlab/resource_gitlab_project_variable_test.go
@@ -24,17 +24,15 @@ func TestAccGitlabProjectVariable_basic(t *testing.T) {
 				Config: testAccGitlabProjectVariableConfig(rString),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabProjectVariableExists("gitlab_project_variable.foo", &projectVariable),
-					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
-						Key:   fmt.Sprintf("key-%s", rString),
-						Value: fmt.Sprintf("value-%s", rString),
-					}),
+					resource.TestCheckResourceAttr("gitlab_project_variable.foo", "Key", fmt.Sprintf("key-%s", rString)),
+					resource.TestCheckResourceAttr("gitlab_project_variable.foo", "Value", fmt.Sprintf("value-%s", rString)),
 				),
 			},
 			// Update the project variable to toggle all the values to their inverse
 			{
 				Config: testAccGitlabProjectVariableUpdateConfig(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectVariableExists("gitlab_project_hook.foo", &projectVariable),
+					testAccCheckGitlabProjectVariableExists("gitlab_project_variable.foo", &projectVariable),
 					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
 						Key:       fmt.Sprintf("key-%s", rString),
 						Value:     fmt.Sprintf("value-inverse-%s", rString),
@@ -46,7 +44,7 @@ func TestAccGitlabProjectVariable_basic(t *testing.T) {
 			{
 				Config: testAccGitlabProjectVariableConfig(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectVariableExists("gitlab_project_hook.foo", &projectVariable),
+					testAccCheckGitlabProjectVariableExists("gitlab_project_variable.foo", &projectVariable),
 					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
 						Key:       fmt.Sprintf("key-%s", rString),
 						Value:     fmt.Sprintf("value-%s", rString),

--- a/gitlab/resource_gitlab_project_variable_test.go
+++ b/gitlab/resource_gitlab_project_variable_test.go
@@ -1,0 +1,170 @@
+package gitlab
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/xanzy/go-gitlab"
+)
+
+func TestAccGitlabProjectVariable_basic(t *testing.T) {
+	var projectVariable gitlab.BuildVariable
+	rString := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabProjectVariableDestroy,
+		Steps: []resource.TestStep{
+			// Create a project and variable with default options
+			{
+				Config: testAccGitlabProjectVariableConfig(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectVariableExists("gitlab_project_variable.foo", &projectVariable),
+					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
+						Key:   fmt.Sprintf("key-%s", rString),
+						Value: fmt.Sprintf("value-%s", rString),
+					}),
+				),
+			},
+			// Update the project variable to toggle all the values to their inverse
+			{
+				Config: testAccGitlabProjectVariableUpdateConfig(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectVariableExists("gitlab_project_hook.foo", &projectVariable),
+					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
+						Key:       fmt.Sprintf("key-%s", rString),
+						Value:     fmt.Sprintf("value-inverse-%s", rString),
+						Protected: true,
+					}),
+				),
+			},
+			// Update the project variable to toggle the options back
+			{
+				Config: testAccGitlabProjectVariableConfig(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectVariableExists("gitlab_project_hook.foo", &projectVariable),
+					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
+						Key:       fmt.Sprintf("key-%s", rString),
+						Value:     fmt.Sprintf("value-%s", rString),
+						Protected: false,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGitlabProjectVariableExists(n string, projectVariable *gitlab.BuildVariable) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		repoName := rs.Primary.Attributes["project"]
+		if repoName == "" {
+			return fmt.Errorf("No project ID is set")
+		}
+		key := rs.Primary.Attributes["key"]
+		if key == "" {
+			return fmt.Errorf("No variable key is set")
+		}
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		gotVariable, _, err := conn.BuildVariables.GetBuildVariable(repoName, key)
+		if err != nil {
+			return err
+		}
+		*projectVariable = *gotVariable
+		return nil
+	}
+}
+
+type testAccGitlabProjectVariableExpectedAttributes struct {
+	Key       string
+	Value     string
+	Protected bool
+}
+
+func testAccCheckGitlabProjectVariableAttributes(variable *gitlab.BuildVariable, want *testAccGitlabProjectVariableExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if variable.Key != want.Key {
+			return fmt.Errorf("got key %s; want %s", variable.Key, want.Key)
+		}
+
+		if variable.Value != want.Value {
+			return fmt.Errorf("got value %s; value %s", variable.Value, want.Value)
+		}
+
+		if variable.Protected != want.Protected {
+			return fmt.Errorf("got protected %t; want %t", variable.Protected, want.Protected)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGitlabProjectVariableDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_project" {
+			continue
+		}
+
+		gotRepo, resp, err := conn.Projects.GetProject(rs.Primary.ID)
+		if err == nil {
+			if gotRepo != nil && fmt.Sprintf("%d", gotRepo.ID) == rs.Primary.ID {
+				return fmt.Errorf("Repository still exists")
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccGitlabProjectVariableConfig(rString string) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name = "foo-%s"
+  description = "Terraform acceptance tests"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource "gitlab_project_variable" "foo" {
+  project = "${gitlab_project.foo.id}"
+  key = "key-%s"
+  value = "value-%s"
+}
+	`, rString, rString, rString)
+}
+
+func testAccGitlabProjectVariableUpdateConfig(rString string) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name = "foo-%s"
+  description = "Terraform acceptance tests"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource "gitlab_project_variable" "foo" {
+  project = "${gitlab_project.foo.id}"
+  key = "key-%s"
+  value = "value-%s"
+  protected = true
+}
+	`, rString, rString, rString)
+}

--- a/gitlab/resource_gitlab_project_variable_test.go
+++ b/gitlab/resource_gitlab_project_variable_test.go
@@ -24,8 +24,10 @@ func TestAccGitlabProjectVariable_basic(t *testing.T) {
 				Config: testAccGitlabProjectVariableConfig(rString),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabProjectVariableExists("gitlab_project_variable.foo", &projectVariable),
-					resource.TestCheckResourceAttr("gitlab_project_variable.foo", "Key", fmt.Sprintf("key-%s", rString)),
-					resource.TestCheckResourceAttr("gitlab_project_variable.foo", "Value", fmt.Sprintf("value-%s", rString)),
+					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
+						Key:   fmt.Sprintf("key-%s", rString),
+						Value: fmt.Sprintf("value-%s", rString),
+					}),
 				),
 			},
 			// Update the project variable to toggle all the values to their inverse

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	gitlab "github.com/xanzy/go-gitlab"
+	"github.com/xanzy/go-gitlab"
+	"regexp"
 )
 
 // copied from ../github/util.go
@@ -38,4 +39,23 @@ func stringToVisibilityLevel(s string) *gitlab.VisibilityValue {
 		return nil
 	}
 	return &value
+}
+
+func StringIsGitlabVariableName() schema.SchemaValidateFunc {
+	return func(v interface{}, k string) (s []string, es []error) {
+		value, ok := v.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+		if len(value) < 1 || len(value) > 255 {
+			es = append(es, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, 1, 255, v))
+		}
+
+		match, _ := regexp.MatchString("[a-zA-Z0-9_]+", value)
+		if !match {
+			es = append(es, fmt.Errorf("%s is an invalid value for argument %s. Only A-Z, a-z, 0-9, and _ are allowed", value, k))
+		}
+		return
+	}
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -33,6 +33,13 @@ resource "gitlab_project_hook" "sample_project_hook" {
     url = "https://example.com/project_hook"
 }
 
+# Add a variable to the project
+resource "gitlab_project_variable" "sample_project_variable" {
+    project = "${gitlab_project.sample_project.id}"
+    key = "project_variable_key"
+    value = "project_variable_value"
+}
+
 # Add a deploy key to the project
 resource "gitlab_deploy_key" "sample_deploy_key" {
     project = "${gitlab_project.sample_project.id}"

--- a/website/docs/r/project_variable.html.markdown
+++ b/website/docs/r/project_variable.html.markdown
@@ -35,7 +35,3 @@ The following arguments are supported:
 * `value` - (Required, string) The value of the variable.
 
 * `protected` - (Optional, boolean) If set to `true`, the variable will be passed only to pipelines running on protected branches and tags. Defaults to `false`.
-
-## Attributes Reference
-
-This resource does not currently export any attribute.

--- a/website/docs/r/project_variable.html.markdown
+++ b/website/docs/r/project_variable.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "gitlab"
+page_title: "GitLab: gitlab_project_variable"
+sidebar_current: "docs-gitlab-resource-project-variable"
+description: |-
+  Creates and manages CI/CD variables for GitLab projects
+---
+
+# gitlab\_project\_variable
+
+This resource allows you to create and manage CI/CD variables for your GitLab projects.
+For further information on variables, consult the [gitlab
+documentation](https://docs.gitlab.com/ce/ci/variables/README.html).
+
+
+## Example Usage
+
+```hcl
+resource "gitlab_project_variable" "example" {
+   project   = "example/project_with_variables"
+   key       = "project_variable_key"
+   value     = "project_variable_value"
+   protected = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Required, string) The name or id of the project to add the hook to.
+
+* `key` - (Required, string) The name of the variable.
+
+* `value` - (Required, string) The value of the variable.
+
+* `protected` - (Optional, boolean) If set to `true`, the variable will be passed only to pipelines running on protected branches and tags. Defaults to `false`.
+
+## Attributes Reference
+
+This resource does not currently export any attribute.

--- a/website/gitlab.erb
+++ b/website/gitlab.erb
@@ -46,6 +46,9 @@
           <li<%= sidebar_current("docs-gitlab-resource-user") %>>
             <a href="/docs/providers/gitlab/r/user.html">gitlab_user</a>
           </li>
+          <li<%= sidebar_current("docs-gitlab-resource-project-variable") %>>
+            <a href="/docs/providers/gitlab/r/project_variable.html">gitlab_project_variable</a>
+          </li>
         </ul>
         </li>
       </ul>


### PR DESCRIPTION
Adds a resource in Gitlab provider in order to manage project build variables.

The declaration looks like:
```
+resource "gitlab_project_variable" "sample_project_variable" {
    project   = "${gitlab_project.sample_project.id}"
    key       = "project_variable_key"
    value     = "project_variable_value"
    protected = false
}
```
