### PR TITLE
Fix group description in docs

### DIFF
--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of this group.
 
-* `path` - (Required) The url of the hook to invoke.
+* `path` - (Required) The path of the group.
 
 * `description` - (Optional) The description of the group.
 


### PR DESCRIPTION
It looks like a line of documentation in `gitlab_group` was taken from [`gitlab_project_hook`](https://github.com/terraform-providers/terraform-provider-gitlab/blob/3156239e4238a0b4803aa6bafeed8866fb50365d/website/docs/r/project_hook.html.markdown) when the docs were being written. I changed it to match the surrounding lines.