### PR TITLE
Add users datasource

### DIFF
--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -1,0 +1,103 @@
+package gitlab
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func dataSourceGitlabUsers() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGitlabUsersRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "all_users",
+			},
+			"users": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"username": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"email": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_admin": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"can_create_group": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"can_create_project": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"projects_limit": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGitlabUsersRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	users, _, err := client.Users.ListUsers(nil)
+	if err != nil {
+		return err
+	}
+
+	d.Set("users", flattenGitlabUsers(users))
+	d.SetId(d.Get("name").(string))
+
+	return nil
+}
+
+func flattenGitlabUsers(users []*gitlab.User) []interface{} {
+	usersList := []interface{}{}
+
+	for _, user := range users {
+		values := map[string]interface{}{
+			"username":           user.Username,
+			"email":              user.Email,
+			"name":               user.Name,
+			"is_admin":           user.IsAdmin,
+			"can_create_group":   user.CanCreateGroup,
+			"can_create_project": user.CanCreateProject,
+			"projects_limit":     user.ProjectsLimit,
+			"state":              user.State,
+		}
+
+		if user.CreatedAt != nil {
+			values["created_at"] = user.CreatedAt.String()
+		}
+
+		usersList = append(usersList, values)
+	}
+
+	return usersList
+}

--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -215,7 +215,7 @@ func expandGitlabUsersOptions(d *schema.ResourceData) (*gitlab.ListUsersOptions,
 	optionsHash += ","
 	if data, ok := d.GetOk("identities_provider"); ok {
 		provider := data.(string)
-		// listUsersOptions.Provider = &provider
+		listUsersOptions.Provider = &provider
 		optionsHash += provider
 	}
 	optionsHash += ","
@@ -231,11 +231,11 @@ func expandGitlabUsersOptions(d *schema.ResourceData) (*gitlab.ListUsersOptions,
 	optionsHash += ","
 	if data, ok := d.GetOk("created_after"); ok {
 		createdAfter := data.(string)
-		// date, err := time.Parse("2006-01-02", createdAfter)
-		// if err != nil {
-		// 	return nil, 0, fmt.Errorf("created_after must be in yyyy-mm-dd format")
-		// }
-		// listUsersOptions.CreatedAfter = &date
+		date, err := time.Parse("2006-01-02", createdAfter)
+		if err != nil {
+			return nil, 0, fmt.Errorf("created_after must be in yyyy-mm-dd format")
+		}
+		listUsersOptions.CreatedAfter = &date
 		optionsHash += createdAfter
 	}
 

--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -182,36 +182,43 @@ func expandGitlabUsersOptions(d *schema.ResourceData) (*gitlab.ListUsersOptions,
 		listUsersOptions.OrderBy = &orderBy
 		optionsHash += orderBy
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("sort"); ok {
 		sort := data.(string)
 		listUsersOptions.Sort = &sort
 		optionsHash += sort
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("search"); ok {
 		search := data.(string)
 		listUsersOptions.Search = &search
 		optionsHash += search
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("active"); ok {
 		active := data.(bool)
 		listUsersOptions.Active = &active
 		optionsHash += strconv.FormatBool(active)
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("blocked"); ok {
 		blocked := data.(bool)
 		listUsersOptions.Blocked = &blocked
 		optionsHash += strconv.FormatBool(blocked)
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("identities_extern_uid"); ok {
 		externalUID := data.(string)
 		listUsersOptions.ExternalUID = &externalUID
 		optionsHash += externalUID
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("identities_provider"); ok {
 		provider := data.(string)
 		// listUsersOptions.Provider = &provider
 		optionsHash += provider
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("created_before"); ok {
 		createdBefore := data.(string)
 		date, err := time.Parse("2006-01-02", createdBefore)
@@ -221,6 +228,7 @@ func expandGitlabUsersOptions(d *schema.ResourceData) (*gitlab.ListUsersOptions,
 		listUsersOptions.CreatedBefore = &date
 		optionsHash += createdBefore
 	}
+	optionsHash += ","
 	if data, ok := d.GetOk("created_after"); ok {
 		createdAfter := data.(string)
 		// date, err := time.Parse("2006-01-02", createdAfter)

--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -1,6 +1,11 @@
 package gitlab
 
 import (
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -11,25 +16,62 @@ func dataSourceGitlabUsers() *schema.Resource {
 		Read: dataSourceGitlabUsersRead,
 
 		Schema: map[string]*schema.Schema{
-			"order_by": {
-				Type:     schema.TypeString,
+			"options": {
+				Type:     schema.TypeList,
 				Optional: true,
-				Default:  "id",
-				ValidateFunc: validation.StringInSlice([]string{"id", "name",
-					"username", "created_at"}, true),
-			},
-			"sort": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "desc",
-				ValidateFunc: validation.StringInSlice([]string{"desc", "asc"}, true),
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"order_by": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "id",
+							ValidateFunc: validation.StringInSlice([]string{"id", "name",
+								"username", "created_at"}, true),
+						},
+						"sort": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "desc",
+							ValidateFunc: validation.StringInSlice([]string{"desc", "asc"}, true),
+						},
+						"search": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"active": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"blocked": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"extern_uid": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"provider": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"created_before": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"created_after": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
 			},
 			"users": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": {
+						"user_id": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
@@ -73,6 +115,18 @@ func dataSourceGitlabUsers() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"extern_uid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"organization": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"two_factor_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -83,21 +137,20 @@ func dataSourceGitlabUsers() *schema.Resource {
 func dataSourceGitlabUsersRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
-	orderBy := d.Get("order_by").(string)
-	sort := d.Get("sort").(string)
-	listUsersOptions := &gitlab.ListUsersOptions{
-		OrderBy: &orderBy,
-		Sort:    &sort,
+	listUsersOptions, id, err := expandGitlabUsersOptions(d.Get("options").([]interface{}))
+	if err != nil {
+		return err
 	}
-
+	log.Printf("\n\n\nListOptions\n%v\n\n\n", listUsersOptions)
 	users, _, err := client.Users.ListUsers(listUsersOptions)
+	log.Printf("\n\n\nListUsers\n%v\n\n\n", users)
+
 	if err != nil {
 		return err
 	}
 
 	d.Set("users", flattenGitlabUsers(users))
-	id := "all_users_" + orderBy + "_" + sort
-	d.SetId(id)
+	d.SetId(fmt.Sprintf("%d", id))
 
 	return nil
 }
@@ -107,7 +160,7 @@ func flattenGitlabUsers(users []*gitlab.User) []interface{} {
 
 	for _, user := range users {
 		values := map[string]interface{}{
-			"id":                 user.ID,
+			"user_id":            user.ID,
 			"username":           user.Username,
 			"email":              user.Email,
 			"name":               user.Name,
@@ -117,14 +170,76 @@ func flattenGitlabUsers(users []*gitlab.User) []interface{} {
 			"projects_limit":     user.ProjectsLimit,
 			"state":              user.State,
 			"external":           user.External,
+			"extern_uid":         user.ExternUID,
+			"organization":       user.Organization,
+			"two_factor_enabled": user.TwoFactorEnabled,
 		}
 
 		if user.CreatedAt != nil {
-			values["created_at"] = user.CreatedAt.String()
+			values["created_at"] = user.CreatedAt
 		}
 
 		usersList = append(usersList, values)
 	}
 
 	return usersList
+}
+
+func expandGitlabUsersOptions(d []interface{}) (*gitlab.ListUsersOptions, int, error) {
+	if len(d) == 0 {
+		return nil, 0, nil
+	}
+
+	data := d[0].(map[string]interface{})
+	listUsersOptions := &gitlab.ListUsersOptions{}
+	options := ""
+
+	if orderBy := data["order_by"].(string); orderBy != "" {
+		listUsersOptions.OrderBy = &orderBy
+		options += orderBy
+	}
+	if sort := data["sort"].(string); sort != "" {
+		listUsersOptions.Sort = &sort
+		options += sort
+	}
+	if search := data["search"].(string); search != "" {
+		listUsersOptions.Search = &search
+		options += search
+	}
+	if active := data["active"].(bool); active != false {
+		listUsersOptions.Active = &active
+		options += strconv.FormatBool(active)
+	}
+	if blocked := data["blocked"].(bool); blocked != false {
+		listUsersOptions.Blocked = &blocked
+		options += strconv.FormatBool(blocked)
+	}
+	if externalUID := data["extern_uid"].(string); externalUID != "" {
+		listUsersOptions.ExternalUID = &externalUID
+		options += externalUID
+	}
+	if provider := data["provider"].(string); provider != "" {
+		// listUsersOptions.Provider = &provider
+		options += provider
+	}
+	if createdBefore := data["created_before"].(string); createdBefore != "" {
+		date, err := time.Parse("2006-01-02", createdBefore)
+		if err != nil {
+			return nil, 0, fmt.Errorf("created_before must be in yyyy-mm-dd format")
+		}
+		listUsersOptions.CreatedBefore = &date
+		options += createdBefore
+	}
+	if createdAfter := data["created_after"].(string); createdAfter != "" {
+		// date, err := time.Parse("2006-01-02", createdAfter)
+		// if err != nil {
+		// 	return nil, 0, fmt.Errorf("created_after must be in yyyy-mm-dd format")
+		// }
+		// listUsersOptions.CreatedAfter = &date
+		options += createdAfter
+	}
+
+	id := schema.HashString(options)
+
+	return listUsersOptions, id, nil
 }

--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -20,7 +20,7 @@ func dataSourceGitlabUsers() *schema.Resource {
 				Optional: true,
 				Default:  "id",
 				ValidateFunc: validation.StringInSlice([]string{"id", "name",
-					"username", "created_at"}, true),
+					"username", "created_at", "updated_at"}, true),
 			},
 			"sort": {
 				Type:         schema.TypeString,

--- a/gitlab/data_source_gitlab_users_test.go
+++ b/gitlab/data_source_gitlab_users_test.go
@@ -1,0 +1,27 @@
+package gitlab
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceGitlabUsers_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeLbIpRangesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.gitlab_users.test",
+						"users.#", regexp.MustCompile("^[1-9]*$"))),
+			},
+		},
+	})
+}
+
+const testAccComputeLbIpRangesConfig = `
+data "gitlab_users" "test" {}
+`

--- a/gitlab/data_source_gitlab_users_test.go
+++ b/gitlab/data_source_gitlab_users_test.go
@@ -1,27 +1,114 @@
 package gitlab
 
 import (
-	"regexp"
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccDataSourceGitlabUsers_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+	rInt2 := acctest.RandInt()
+	user2 := fmt.Sprintf("user%d@test.test", rInt2)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccComputeLbIpRangesConfig,
+			{
+				Config: testAccDataSourceGitlabUsersConfig(rInt, rInt2),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.gitlab_users.test",
-						"users.#", regexp.MustCompile("^[1-9]*$"))),
+					resource.TestCheckResourceAttr("gitlab_user.foo", "name", "footest1"),
+					resource.TestCheckResourceAttr("gitlab_user.foo2", "name", "footest2"),
+				),
+			},
+			{
+				Config: testAccDataSourceGitlabUsersConfigSort(rInt, rInt2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.gitlab_users.foo", "users.#", "2"),
+					resource.TestCheckResourceAttr("data.gitlab_users.foo", "users.0.email", user2),
+					resource.TestCheckResourceAttr("data.gitlab_users.foo", "users.0.projects_limit", "2"),
+				),
+			},
+			{
+				Config: testAccDataSourceGitlabUsersConfigSearch(rInt, rInt2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.gitlab_users.foo", "users.#", "1"),
+					// resource.TestCheckResourceAttr("data.gitlab_users.foo", "users.0.email", user2),
+				),
 			},
 		},
 	})
 }
 
-const testAccComputeLbIpRangesConfig = `
-data "gitlab_users" "test" {}
-`
+func testAccDataSourceGitlabUsersConfig(rInt int, rInt2 int) string {
+	return fmt.Sprintf(`
+resource "gitlab_user" "foo" {
+  name             = "footest1"
+  username         = "listest%d"
+  password         = "test%dtt"
+  email            = "user%d@test.test"
+  projects_limit   = 3
+}
+
+resource "gitlab_user" "foo2" {
+  name             = "footest2"
+  username         = "listest%d"
+  password         = "test%dtt"
+  email            = "user%d@test.test"
+  projects_limit   = 2
+}
+	`, rInt, rInt, rInt, rInt2, rInt2, rInt2)
+}
+
+func testAccDataSourceGitlabUsersConfigSort(rInt int, rInt2 int) string {
+	return fmt.Sprintf(`
+resource "gitlab_user" "foo" {
+  name             = "footest1"
+  username         = "listest%d"
+  password         = "test%dtt"
+  email            = "user%d@test.test"
+  projects_limit   = 3
+}
+
+resource "gitlab_user" "foo2" {
+  name             = "footest2"
+  username         = "listest%d"
+  password         = "test%dtt"
+  email            = "user%d@test.test"
+  projects_limit   = 2
+}
+
+data "gitlab_users" "foo" {
+  sort = "desc"
+  search = "footest"
+  order_by = "name"
+}
+	`, rInt, rInt, rInt, rInt2, rInt2, rInt2)
+}
+
+func testAccDataSourceGitlabUsersConfigSearch(rInt int, rInt2 int) string {
+	return fmt.Sprintf(`
+resource "gitlab_user" "foo" {
+  name             = "footest1"
+  username         = "listest%d"
+  password         = "test%dtt"
+  email            = "user%d@test.test"
+  projects_limit   = 3
+}
+
+resource "gitlab_user" "foo2" {
+  name             = "footest2"
+  username         = "listest%d"
+  password         = "test%dtt"
+  email            = "user%d@test.test"
+  projects_limit   = 2
+}
+
+data "gitlab_users" "foo" {
+  search = "user%d@test.test"
+}
+	`, rInt, rInt, rInt, rInt2, rInt2, rInt2, rInt2)
+}

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -44,6 +44,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"gitlab_project": dataSourceGitlabProject(),
 			"gitlab_user":    dataSourceGitlabUser(),
+			"gitlab_users":   dataSourceGitlabUsers(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/users.html.markdown
+++ b/website/docs/d/users.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "gitlab"
+page_title: "GitLab: gitlab_users"
+sidebar_current: "docs-gitlab-data-source-users"
+description: |-
+  Looks up gitlab users
+---
+
+# gitlab\_users
+
+Provides details about a list of users in the gitlab provider. The results include id, username, email, name and more about the requested users. Users can also be sorted and filtered using several options.
+
+## Example Usage
+
+```hcl
+data "gitlab_users" "example" {
+  sort = "desc"
+  order_by = "name"
+  created_before = "2019-01-01"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `search` - (Optional) Search users by username, name or email.
+
+* `active` - (Optional) Filter users that are active.
+
+* `blocked` - (Optional) Filter users that are blocked.
+
+* `order_by` - (Optional) Order the users' list by `id`, `name`, `username`, `created_at` or `updated_at`. (Requires administrator privileges)
+
+* `sort` - (Optional) Sort users' list in asc or desc order. (Requires administrator privileges)
+
+* `identities_extern_uid` - (Optional) Lookup users by external UID. (Requires administrator privileges)
+
+* `identities_provider` - (Optional) Lookup users by external provider. (Requires administrator privileges)
+
+* `created_before` - (Optional) Search for users created before a specific date. (Requires administrator privileges)
+
+* `created_after` - (Optional)  Search for users created after a specific date. (Requires administrator privileges)
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `users` - The list of users.
+  * `id` - The unique id assigned to the user by the gitlab server.
+  * `username` - The username of the user.
+  * `email` - The e-mail address of the user.
+  * `name` - The name of the user.
+  * `is_admin` - Whether the user is an admin.
+  * `can_create_group` - Whether the user can create groups.
+  * `can_create_project` - Whether the user can create projects.
+  * `projects_limit` - Number of projects the user can create.
+  * `created_at` - Date the user was created at.
+  * `state` - Whether the user is active or blocked.
+  * `external` - Whether the user is external.
+  * `extern_uid` - The external UID of the user.
+  * `organization` - The organization of the user.
+  * `two_factor_enabled` - Whether user's two factor auth is enabled.
+
+

--- a/website/gitlab.erb
+++ b/website/gitlab.erb
@@ -19,6 +19,9 @@
                 <li<%= sidebar_current("docks-gitlab-data-source-user") %>>
                     <a href="/docs/providers/gitlab/d/user.html">gitlab_user</a>
                 </li>
+                <li<%= sidebar_current("docks-gitlab-data-source-users") %>>
+                    <a href="/docs/providers/gitlab/d/users.html">gitlab_users</a>
+                </li>
             </ul>
         </li>
 


### PR DESCRIPTION
Add new `gitlab_users` datasource that returns a list of users.

It takes optional arguments such as `order_by`, `sort` and `search`, full list in the included documentation.

Examples:
* Get all users
```
data "gitlab_users" "all_users" {
}
```
* Get users created before the 5th of April 2018 ordered by username in ascendant order
```
data "gitlab_users" "username" {
    order_by = "username"
    sort = "asc"
    created_before = "2018-04-05"
}
```