### PR TITLE
Add support for gitlab project cluster

### DIFF
--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -59,6 +59,7 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_group_membership":   resourceGitlabGroupMembership(),
 			"gitlab_project_variable":   resourceGitlabProjectVariable(),
 			"gitlab_group_variable":     resourceGitlabGroupVariable(),
+			"gitlab_project_cluster":    resourceGitlabProjectCluster(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/gitlab/resource_gitlab_project_cluster.go
+++ b/gitlab/resource_gitlab_project_cluster.go
@@ -34,6 +34,7 @@ func resourceGitlabProjectCluster() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+				ForceNew: true,
 			},
 			"created_at": {
 				Type:     schema.TypeString,

--- a/gitlab/resource_gitlab_project_cluster.go
+++ b/gitlab/resource_gitlab_project_cluster.go
@@ -1,0 +1,245 @@
+package gitlab
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/xanzy/go-gitlab"
+	"log"
+	"strconv"
+)
+
+func resourceGitlabProjectCluster() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabProjectClusterCreate,
+		Read:   resourceGitlabProjectClusterRead,
+		Update: resourceGitlabProjectClusterUpdate,
+		Delete: resourceGitlabProjectClusterDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"provider_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"platform_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"environment_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "*",
+			},
+			"cluster_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kubernetes_api_url": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"kubernetes_token": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"kubernetes_ca_cert": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"kubernetes_namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"kubernetes_authorization_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "rbac",
+				ValidateFunc: validation.StringInSlice([]string{"rbac", "abac", "unknown_authorization"}, false),
+			},
+		},
+	}
+}
+
+func resourceGitlabProjectClusterCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+
+	pk := gitlab.AddPlatformKubernetesOptions{
+		APIURL: gitlab.String(d.Get("kubernetes_api_url").(string)),
+		Token:  gitlab.String(d.Get("kubernetes_token").(string)),
+	}
+
+	if v, ok := d.GetOk("kubernetes_ca_cert"); ok {
+		pk.CaCert = gitlab.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("kubernetes_namespace"); ok {
+		pk.Namespace = gitlab.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("kubernetes_authorization_type"); ok {
+		pk.AuthorizationType = gitlab.String(v.(string))
+	}
+
+	options := &gitlab.AddClusterOptions{
+		Name:               gitlab.String(d.Get("name").(string)),
+		Enabled:            gitlab.Bool(d.Get("enabled").(bool)),
+		PlatformKubernetes: &pk,
+	}
+
+	if v, ok := d.GetOk("environment_scope"); ok {
+		options.EnvironmentScope = gitlab.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] create gitlab project cluster %q/%q", project, *options.Name)
+
+	cluster, _, err := client.ProjectCluster.AddCluster(project, options)
+
+	if err != nil {
+		return err
+	}
+
+	clusterIdString := fmt.Sprintf("%d", cluster.ID)
+	d.SetId(buildTwoPartID(&project, &clusterIdString))
+
+	return resourceGitlabProjectClusterRead(d, meta)
+}
+
+func resourceGitlabProjectClusterRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	project, clusterId, err := projectIdAndClusterIdFromId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] read gitlab project cluster %q/%d", project, clusterId)
+
+	cluster, response, err := client.ProjectCluster.GetCluster(project, clusterId)
+	if err != nil {
+		if response.StatusCode == 404 {
+			log.Printf("[WARN] removing project cluster %s/%d from state because it no longer exists in gitlab", project, clusterId)
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("project", project)
+	d.Set("name", cluster.Name)
+	d.Set("created_at", cluster.CreatedAt.String())
+	d.Set("provider_type", cluster.ProviderType)
+	d.Set("platform_type", cluster.PlatformType)
+	d.Set("environment_scope", cluster.EnvironmentScope)
+	d.Set("cluster_type", cluster.ClusterType)
+
+	d.Set("kubernetes_api_url", cluster.PlatformKubernetes.APIURL)
+	d.Set("kubernetes_ca_cert", cluster.PlatformKubernetes.CaCert)
+	d.Set("kubernetes_namespace", cluster.PlatformKubernetes.Namespace)
+	d.Set("kubernetes_authorization_type", cluster.PlatformKubernetes.AuthorizationType)
+
+	return nil
+}
+
+func resourceGitlabProjectClusterUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	project, clusterId, err := projectIdAndClusterIdFromId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	options := &gitlab.EditClusterOptions{}
+
+	if d.HasChange("name") {
+		options.Name = gitlab.String(d.Get("name").(string))
+	}
+
+	if d.HasChange("environment_scope") {
+		options.EnvironmentScope = gitlab.String(d.Get("environment_scope").(string))
+	}
+
+	pk := &gitlab.EditPlatformKubernetesOptions{}
+
+	if d.HasChange("kubernetes_api_url") {
+		pk.APIURL = gitlab.String(d.Get("kubernetes_api_url").(string))
+	}
+
+	if d.HasChange("kubernetes_token") {
+		pk.Token = gitlab.String(d.Get("kubernetes_token").(string))
+	}
+
+	if d.HasChange("kubernetes_ca_cert") {
+		pk.CaCert = gitlab.String(d.Get("kubernetes_ca_cert").(string))
+	}
+
+	if d.HasChange("kubernetes_namespace") {
+		pk.Namespace = gitlab.String(d.Get("kubernetes_namespace").(string))
+	}
+
+	if *pk != (gitlab.EditPlatformKubernetesOptions{}) {
+		options.PlatformKubernetes = pk
+	}
+
+	if *options != (gitlab.EditClusterOptions{}) {
+		log.Printf("[DEBUG] update gitlab project cluster %q/%d", project, clusterId)
+		_, _, err := client.ProjectCluster.EditCluster(project, clusterId, options)
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourceGitlabProjectClusterRead(d, meta)
+}
+
+func resourceGitlabProjectClusterDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project, clusterId, err := projectIdAndClusterIdFromId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] delete gitlab project cluster %q/%d", project, clusterId)
+
+	_, err = client.ProjectCluster.DeleteCluster(project, clusterId)
+
+	return err
+}
+
+func projectIdAndClusterIdFromId(id string) (string, int, error) {
+	project, clusterIdString, err := parseTwoPartID(id)
+	if err != nil {
+		return "", 0, err
+	}
+
+	clusterId, err := strconv.Atoi(clusterIdString)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to get clusterId: %v", err)
+	}
+
+	return project, clusterId, nil
+}

--- a/gitlab/resource_gitlab_project_cluster.go
+++ b/gitlab/resource_gitlab_project_cluster.go
@@ -2,11 +2,12 @@ package gitlab
 
 import (
 	"fmt"
+	"log"
+	"strconv"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/xanzy/go-gitlab"
-	"log"
-	"strconv"
 )
 
 func resourceGitlabProjectCluster() *schema.Resource {

--- a/gitlab/resource_gitlab_project_cluster_test.go
+++ b/gitlab/resource_gitlab_project_cluster_test.go
@@ -2,11 +2,12 @@ package gitlab
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/xanzy/go-gitlab"
-	"testing"
 )
 
 func TestAccGitlabProjectCluster_basic(t *testing.T) {

--- a/gitlab/resource_gitlab_project_cluster_test.go
+++ b/gitlab/resource_gitlab_project_cluster_test.go
@@ -66,6 +66,27 @@ func TestAccGitlabProjectCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccGitlabProjectCluster_import(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabProjectClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabProjectClusterConfig(rInt),
+			},
+			{
+				ResourceName:            "gitlab_project_cluster.foo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"enabled", "kubernetes_token"},
+			},
+		},
+	})
+}
+
 type testAccGitlabProjectClusterExpectedAttributes struct {
 	Name                        string
 	EnvironmentScope            string

--- a/gitlab/resource_gitlab_project_cluster_test.go
+++ b/gitlab/resource_gitlab_project_cluster_test.go
@@ -1,0 +1,201 @@
+package gitlab
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/xanzy/go-gitlab"
+	"testing"
+)
+
+func TestAccGitlabProjectCluster_basic(t *testing.T) {
+	var cluster gitlab.ProjectCluster
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabProjectClusterDestroy,
+		Steps: []resource.TestStep{
+			// Create a project and cluster with default options
+			{
+				Config: testAccGitlabProjectClusterConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectClusterExists("gitlab_project_cluster.foo", &cluster),
+					testAccCheckGitlabProjectClusterAttributes(&cluster, &testAccGitlabProjectClusterExpectedAttributes{
+						Name:                        fmt.Sprintf("foo-cluster-%d", rInt),
+						EnvironmentScope:            "*",
+						KubernetesApiURL:            "https://123.123.123",
+						KubernetesAuthorizationType: "abac",
+					}),
+				),
+			},
+			// Update cluster
+			{
+				Config: testAccGitlabProjectClusterUpdateConfig(rInt, "abac"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectClusterExists("gitlab_project_cluster.foo", &cluster),
+					testAccCheckGitlabProjectClusterAttributes(&cluster, &testAccGitlabProjectClusterExpectedAttributes{
+						Name:                        fmt.Sprintf("foo-cluster-%d", rInt),
+						EnvironmentScope:            "*",
+						KubernetesApiURL:            "https://124.124.124",
+						KubernetesCACert:            "some-cert",
+						KubernetesNamespace:         "changed-namespace",
+						KubernetesAuthorizationType: "abac",
+					}),
+				),
+			},
+			// Update authorization type cluster
+			{
+				Config: testAccGitlabProjectClusterUpdateConfig(rInt, "rbac"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectClusterExists("gitlab_project_cluster.foo", &cluster),
+					testAccCheckGitlabProjectClusterAttributes(&cluster, &testAccGitlabProjectClusterExpectedAttributes{
+						Name:                        fmt.Sprintf("foo-cluster-%d", rInt),
+						EnvironmentScope:            "*",
+						KubernetesApiURL:            "https://124.124.124",
+						KubernetesCACert:            "some-cert",
+						KubernetesNamespace:         "changed-namespace",
+						KubernetesAuthorizationType: "rbac",
+					}),
+				),
+			},
+		},
+	})
+}
+
+type testAccGitlabProjectClusterExpectedAttributes struct {
+	Name                        string
+	EnvironmentScope            string
+	KubernetesApiURL            string
+	KubernetesCACert            string
+	KubernetesNamespace         string
+	KubernetesAuthorizationType string
+}
+
+func testAccCheckGitlabProjectClusterExists(n string, cluster *gitlab.ProjectCluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %q", n)
+		}
+
+		project, clusterID, err := projectIdAndClusterIdFromId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		gotCluster, _, err := conn.ProjectCluster.GetCluster(project, clusterID)
+		if err != nil {
+			return err
+		}
+
+		*cluster = *gotCluster
+
+		return nil
+	}
+}
+
+func testAccCheckGitlabProjectClusterDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_project_cluster" {
+			continue
+		}
+
+		project, clusterID, err := projectIdAndClusterIdFromId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		gotCluster, resp, err := conn.ProjectCluster.GetCluster(project, clusterID)
+		if err == nil {
+			if gotCluster != nil && fmt.Sprintf("%d", gotCluster.ID) == project {
+				return fmt.Errorf("project cluster still exists")
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckGitlabProjectClusterAttributes(cluster *gitlab.ProjectCluster, want *testAccGitlabProjectClusterExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if cluster.Name != want.Name {
+			return fmt.Errorf("got name %q; want %q", cluster.Name, want.Name)
+		}
+
+		if cluster.EnvironmentScope != want.EnvironmentScope {
+			return fmt.Errorf("got environment scope %q; want %q", cluster.EnvironmentScope, want.EnvironmentScope)
+		}
+
+		if cluster.PlatformKubernetes.APIURL != want.KubernetesApiURL {
+			return fmt.Errorf("got kubernetes api url %q; want %q", cluster.PlatformKubernetes.APIURL, want.KubernetesApiURL)
+		}
+
+		if cluster.PlatformKubernetes.CaCert != want.KubernetesCACert {
+			return fmt.Errorf("got kubernetes ca cert %q; want %q", cluster.PlatformKubernetes.CaCert, want.KubernetesCACert)
+		}
+
+		if cluster.PlatformKubernetes.Namespace != want.KubernetesNamespace {
+			return fmt.Errorf("got kubernetes namespace %q; want %q", cluster.PlatformKubernetes.Namespace, want.KubernetesNamespace)
+		}
+
+		if cluster.PlatformKubernetes.AuthorizationType != want.KubernetesAuthorizationType {
+			return fmt.Errorf("got kubernetes authorization type %q; want %q", cluster.PlatformKubernetes.AuthorizationType, want.KubernetesAuthorizationType)
+		}
+
+		return nil
+	}
+}
+
+func testAccGitlabProjectClusterConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name = "foo-project-%d"
+  description = "Terraform acceptance tests"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource gitlab_project_cluster "foo" {
+  project                       = "${gitlab_project.foo.id}"
+  name                          = "foo-cluster-%d"
+  kubernetes_api_url            = "https://123.123.123"
+  kubernetes_token              = "some-token"
+  kubernetes_authorization_type = "abac"
+}
+`, rInt, rInt)
+}
+
+func testAccGitlabProjectClusterUpdateConfig(rInt int, authType string) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name = "foo-project-%d"
+  description = "Terraform acceptance tests"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource gitlab_project_cluster "foo" {
+  project                       = "${gitlab_project.foo.id}"
+  name                          = "foo-cluster-%d"
+  kubernetes_api_url            = "https://124.124.124"
+  kubernetes_token              = "some-token"
+  kubernetes_ca_cert            = "some-cert"
+  kubernetes_namespace          = "changed-namespace"
+  kubernetes_authorization_type = "%s"
+}
+`, rInt, rInt, authType)
+}


### PR DESCRIPTION
## Terraform resource for adding project cluster.

API Documentation: https://docs.gitlab.com/ee/api/project_clusters.html  

Solves #46 

## Example usage
```hcl
resource "gitlab_project" "foo" {
  name = "foo-project-1"
}

resource gitlab_project_cluster "foo" {
  project                       = "${gitlab_project.foo.id}"
  name                          = "foo-cluster-1"
  kubernetes_api_url            = "https://124.124.124"
  kubernetes_token              = "some-token"
  environment_scope             = "*"
  kubernetes_ca_cert            = "some-cert"
  kubernetes_namespace          = "changed-namespace"
  kubernetes_authorization_type = "abac"
}
```

The documentation has not yet been added, since I would like to receive feedback first.

There is currently an issue with `enabled` field, which has been already reported to GitLab: https://gitlab.com/gitlab-org/gitlab-ce/issues/57300