### PR TITLE
Add approvals_before_merge to Project

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -60,6 +60,11 @@ func resourceGitlabProject() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"approvals_before_merge": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
 			"wiki_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -142,6 +147,7 @@ func resourceGitlabProjectSetToState(d *schema.ResourceData, project *gitlab.Pro
 	d.Set("default_branch", project.DefaultBranch)
 	d.Set("issues_enabled", project.IssuesEnabled)
 	d.Set("merge_requests_enabled", project.MergeRequestsEnabled)
+	d.Set("approvals_before_merge", project.ApprovalsBeforeMerge)
 	d.Set("wiki_enabled", project.WikiEnabled)
 	d.Set("snippets_enabled", project.SnippetsEnabled)
 	d.Set("visibility_level", string(project.Visibility))
@@ -162,6 +168,7 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 		Name:                             gitlab.String(d.Get("name").(string)),
 		IssuesEnabled:                    gitlab.Bool(d.Get("issues_enabled").(bool)),
 		MergeRequestsEnabled:             gitlab.Bool(d.Get("merge_requests_enabled").(bool)),
+		ApprovalsBeforeMerge:             gitlab.Int(d.Get("approvals_before_merge").(int)),
 		WikiEnabled:                      gitlab.Bool(d.Get("wiki_enabled").(bool)),
 		SnippetsEnabled:                  gitlab.Bool(d.Get("snippets_enabled").(bool)),
 		Visibility:                       stringToVisibilityLevel(d.Get("visibility_level").(string)),
@@ -267,6 +274,10 @@ func resourceGitlabProjectUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("merge_requests_enabled") {
 		options.MergeRequestsEnabled = gitlab.Bool(d.Get("merge_requests_enabled").(bool))
+	}
+
+	if d.HasChange("approvals_before_merge") {
+		options.ApprovalsBeforeMerge = gitlab.Int(d.Get("approvals_before_merge").(int))
 	}
 
 	if d.HasChange("wiki_enabled") {

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -30,6 +30,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						Description:                      "Terraform acceptance tests",
 						IssuesEnabled:                    true,
 						MergeRequestsEnabled:             true,
+						ApprovalsBeforeMerge:             0,
 						WikiEnabled:                      true,
 						SnippetsEnabled:                  true,
 						Visibility:                       gitlab.PublicVisibility,
@@ -48,6 +49,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						Name:                             fmt.Sprintf("foo-%d", rInt),
 						Path:                             fmt.Sprintf("foo.%d", rInt),
 						Description:                      "Terraform acceptance tests!",
+						ApprovalsBeforeMerge:             0,
 						Visibility:                       gitlab.PublicVisibility,
 						MergeMethod:                      gitlab.FastForwardMerge,
 						OnlyAllowMergeIfPipelineSucceeds: true,
@@ -66,6 +68,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						Description:                      "Terraform acceptance tests",
 						IssuesEnabled:                    true,
 						MergeRequestsEnabled:             true,
+						ApprovalsBeforeMerge:             0,
 						WikiEnabled:                      true,
 						SnippetsEnabled:                  true,
 						Visibility:                       gitlab.PublicVisibility,
@@ -223,6 +226,7 @@ type testAccGitlabProjectExpectedAttributes struct {
 	DefaultBranch                             string
 	IssuesEnabled                             bool
 	MergeRequestsEnabled                      bool
+	ApprovalsBeforeMerge                      int
 	WikiEnabled                               bool
 	SnippetsEnabled                           bool
 	Visibility                                gitlab.VisibilityValue
@@ -258,6 +262,10 @@ func testAccCheckGitlabProjectAttributes(project *gitlab.Project, want *testAccG
 
 		if project.MergeRequestsEnabled != want.MergeRequestsEnabled {
 			return fmt.Errorf("got merge_requests_enabled %t; want %t", project.MergeRequestsEnabled, want.MergeRequestsEnabled)
+		}
+
+		if project.ApprovalsBeforeMerge != want.ApprovalsBeforeMerge {
+			return fmt.Errorf("got approvals_before_merge %d; want %d", project.ApprovalsBeforeMerge, want.ApprovalsBeforeMerge)
 		}
 
 		if project.WikiEnabled != want.WikiEnabled {
@@ -376,6 +384,7 @@ resource "gitlab_project" "foo" {
 
   issues_enabled = false
   merge_requests_enabled = false
+  approvals_before_merge = 0
   wiki_enabled = false
   snippets_enabled = false
 }

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -42,6 +42,8 @@ The following arguments are supported:
 
 * `merge_requests_enabled` - (Optional) Enable merge requests for the project.
 
+* `approvals_before_merge` - (Optional) Number of merge request approvals required for merging. Default is 0.
+
 * `wiki_enabled` - (Optional) Enable wiki for the project.
 
 * `snippets_enabled` - (Optional) Enable snippets for the project.


### PR DESCRIPTION
I ended up implementing this attribute because for some reason, when updating a simple field on a project, the `approvals_before_merge` key was sent in the JSON with a null value. I guess this showed up when updating the gitlab dependency. Either way, a new attribute :)

I left the tests with `0` that is the default because this feature is available under the Bronze tier. Calling the api to update the number will always return `0` in the community edition. 