### PR TITLE
Fix incorrect link names in documentation.

### DIFF
--- a/website/gitlab.erb
+++ b/website/gitlab.erb
@@ -35,10 +35,10 @@
             <a href="/docs/providers/gitlab/r/group.html">gitlab_group</a>
           </li>
           <li<%= sidebar_current("docs-gitlab-resource-group_membership") %>>
-            <a href="/docs/providers/gitlab/r/group_membership.html">gitlab_group</a>
+            <a href="/docs/providers/gitlab/r/group_membership.html">gitlab_group_membership</a>
           </li>
           <li<%= sidebar_current("docs-gitlab-resource-group_variable") %>>
-            <a href="/docs/providers/gitlab/r/group_variable.html">gitlab_group</a>
+            <a href="/docs/providers/gitlab/r/group_variable.html">gitlab_group_variable</a>
           </li>
           <li<%= sidebar_current("docs-gitlab-resource-label") %>>
             <a href="/docs/providers/gitlab/r/label.html">gitlab_label</a>


### PR DESCRIPTION
Two of the resources added in the latest release have incorrect labels in the documentation's navigation sidebar.