### PR TITLE
provider: Enable request/response logging

### DIFF
--- a/gitlab/config.go
+++ b/gitlab/config.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -39,10 +40,11 @@ func (c *Config) Client() (interface{}, error) {
 		tlsConfig.InsecureSkipVerify = true
 	}
 
-	transport := &http.Transport{
+	t := &http.Transport{
 		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: tlsConfig,
 	}
+	transport := logging.NewTransport("GitLab", t)
 
 	httpClient := &http.Client{Transport: transport}
 


### PR DESCRIPTION
This makes debugging for developers & users of this provider easier by exposing all requests & responses in the log (when >`DEBUG` severity is set).

Example:
```
---[ REQUEST ]---------------------------------------
GET /api/v4/user HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: go-gitlab
Accept: application/json
Private-Token: ACCTEST
Accept-Encoding: gzip


-----------------------------------------------------
2019/02/23 00:47:49 [DEBUG] GitLab API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Content-Length: 714
Cache-Control: max-age=0, private, must-revalidate
Connection: keep-alive
Content-Type: application/json
Date: Sat, 23 Feb 2019 00:47:49 GMT
Etag: W/"2fb3928e98d70dbe9e8fe1b09573eab8"
Server: nginx
Strict-Transport-Security: max-age=31536000
Vary: Origin
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Request-Id: bTiJWuX5Se5
X-Runtime: 0.137501

{"id":1,"name":"Administrator","username":"root","state":"active","avatar_url":"https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon","web_url":"http://04e2294d82f2/root","created_at":"2019-02-23T00:46:48.473Z","bio":null,"location":null,"public_email":"","skype":"","linkedin":"","twitter":"","website_url":"","organization":null,"last_sign_in_at":null,"confirmed_at":"2019-02-23T00:46:48.381Z","last_activity_on":null,"email":"admin@example.com","theme_id":1,"color_scheme_id":1,"projects_limit":100000,"current_sign_in_at":null,"identities":[],"can_create_group":true,"can_create_project":true,"two_factor_enabled":false,"external":false,"private_profile":null,"is_admin":true}
-----------------------------------------------------
```