### PR TITLE
Allow Deploy Keys imports

### DIFF
--- a/gitlab/resource_gitlab_deploy_key.go
+++ b/gitlab/resource_gitlab_deploy_key.go
@@ -15,6 +15,9 @@ func resourceGitlabDeployKey() *schema.Resource {
 		Create: resourceGitlabDeployKeyCreate,
 		Read:   resourceGitlabDeployKeyRead,
 		Delete: resourceGitlabDeployKeyDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceGitlabDeployKeyStateImporter,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"project": {
@@ -108,4 +111,18 @@ func resourceGitlabDeployKeyDelete(d *schema.ResourceData, meta interface{}) err
 		return nil
 	}
 	return err
+}
+
+func resourceGitlabDeployKeyStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	s := strings.Split(d.Id(), ":")
+	if len(s) != 2 {
+		d.SetId("")
+		return nil, fmt.Errorf("Invalid Deploy Key import format; expected '{project_id}:{deploy_key_id}'")
+	}
+	project, id := s[0], s[1]
+
+	d.SetId(id)
+	d.Set("project", project)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/website/docs/r/deploy_key.html.markdown
+++ b/website/docs/r/deploy_key.html.markdown
@@ -32,3 +32,11 @@ The following arguments are supported:
 * `key` - (Required, string) The public ssh key body.
 
 * `can_push` - (Optional, boolean) Allow this deploy key to be used to push changes to the project.  Defaults to `false`. **NOTE::** this cannot currently be managed.
+
+## Import
+
+GitLab deploy keys can be imported using an id made up of `{project_id}:{deploy_key_id}`, e.g.
+
+```
+$ terraform import gitlab_deploy_key.test 1:3
+```


### PR DESCRIPTION
Hi,

This PR allows importing deploy keys using the following syntax:
```
$ terraform import gitlab_deploy_key.test {project_id}:{deploy_key_id}
```

It includes acceptance test and doc update.

Best,