### PR TITLE
Implement gitlab service jira

### DIFF
--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -64,6 +64,7 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_group_variable":     resourceGitlabGroupVariable(),
 			"gitlab_project_cluster":    resourceGitlabProjectCluster(),
 			"gitlab_service_slack":      resourceGitlabServiceSlack(),
+			"gitlab_service_jira":       resourceGitlabServiceJira(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/gitlab/resource_gitlab_service_jira.go
+++ b/gitlab/resource_gitlab_service_jira.go
@@ -3,10 +3,8 @@ package gitlab
 import (
 	"fmt"
 	"log"
-	"regexp"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
@@ -45,7 +43,7 @@ func resourceGitlabServiceJira() *schema.Resource {
 			"url": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)`), "value must be a url"),
+				ValidateFunc: validateURLFunc(),
 			},
 			"project_key": {
 				Type:     schema.TypeString,

--- a/gitlab/resource_gitlab_service_jira.go
+++ b/gitlab/resource_gitlab_service_jira.go
@@ -1,0 +1,178 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func resourceGitlabServiceJira() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabServiceJiraCreate,
+		Read:   resourceGitlabServiceJiraRead,
+		Update: resourceGitlabServiceJiraUpdate,
+		Delete: resourceGitlabServiceJiraDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceGitlabServiceJiraImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"title": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"active": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"url": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)`), "value must be a url"),
+			},
+			"project_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"jira_issue_transition_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceGitlabServiceJiraCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	project := d.Get("project").(string)
+
+	jiraOptions, err := expandJiraOptions(d)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Create Gitlab Jira service")
+
+	_, setServiceErr := client.Services.SetJiraService(project, jiraOptions)
+	if err != nil {
+		return fmt.Errorf("[ERROR] Couldn't create Gitlab Jira service: %s", setServiceErr)
+	}
+
+	d.SetId(project)
+
+	return resourceGitlabServiceJiraRead(d, meta)
+}
+
+func resourceGitlabServiceJiraRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+
+	log.Printf("[DEBUG] Read Gitlab Jira service %s", d.Id())
+
+	jiraService, response, err := client.Services.GetJiraService(project)
+	if err != nil {
+		if response.StatusCode == 404 {
+			log.Printf("[WARN] removing Jira service from state because it no longer exists in Gitlab")
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	if v := jiraService.Properties.URL; v != nil {
+		d.Set("url", *v)
+	}
+	if v := jiraService.Properties.Username; v != nil {
+		d.Set("username", *v)
+	}
+	if v := jiraService.Properties.ProjectKey; v != nil {
+		d.Set("project_key", *v)
+	}
+	if v := jiraService.Properties.JiraIssueTransitionID; v != nil {
+		d.Set("jira_issue_transition_id", *v)
+	}
+
+	d.Set("title", jiraService.Title)
+	d.Set("created_at", jiraService.CreatedAt.String())
+	d.Set("updated_at", jiraService.UpdatedAt.String())
+	d.Set("active", jiraService.Active)
+	d.Set("push_events", jiraService.PushEvents)
+	d.Set("issues_events", jiraService.IssuesEvents)
+	d.Set("confidential_issues_events", jiraService.ConfidentialIssuesEvents)
+	d.Set("merge_requests_events", jiraService.MergeRequestsEvents)
+	d.Set("tag_push_events", jiraService.TagPushEvents)
+	d.Set("note_events", jiraService.NoteEvents)
+	d.Set("pipeline_events", jiraService.PipelineEvents)
+	d.Set("job_events", jiraService.JobEvents)
+	d.Set("wikiPage_events", jiraService.WikiPageEvents)
+	d.Set("confidentialNote_events", jiraService.ConfidentialNoteEvents)
+
+	return nil
+}
+
+func resourceGitlabServiceJiraUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceGitlabServiceJiraCreate(d, meta)
+}
+
+func resourceGitlabServiceJiraDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	project := d.Get("project").(string)
+
+	log.Printf("[DEBUG] Delete Gitlab Jira service %s", d.Id())
+
+	_, err := client.Services.DeleteJiraService(project)
+
+	return err
+}
+
+func expandJiraOptions(d *schema.ResourceData) (*gitlab.SetJiraServiceOptions, error) {
+	setJiraServiceOptions := gitlab.SetJiraServiceOptions{}
+
+	// Set required properties
+	setJiraServiceOptions.URL = gitlab.String(d.Get("url").(string))
+	setJiraServiceOptions.ProjectKey = gitlab.String(d.Get("project_key").(string))
+	setJiraServiceOptions.Username = gitlab.String(d.Get("username").(string))
+	setJiraServiceOptions.Password = gitlab.String(d.Get("password").(string))
+
+	// Set optional properties
+	if val := d.Get("jira_issue_transition_id"); val != nil {
+		setJiraServiceOptions.JiraIssueTransitionID = gitlab.Int(val.(int))
+	}
+
+	return &setJiraServiceOptions, nil
+}
+
+func resourceGitlabServiceJiraImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("project", d.Id())
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/gitlab/resource_gitlab_service_jira.go
+++ b/gitlab/resource_gitlab_service_jira.go
@@ -60,7 +60,7 @@ func resourceGitlabServiceJira() *schema.Resource {
 				Sensitive: true,
 			},
 			"jira_issue_transition_id": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 		},
@@ -105,17 +105,17 @@ func resourceGitlabServiceJiraRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	if v := jiraService.Properties.URL; v != nil {
-		d.Set("url", *v)
+	if v := jiraService.Properties.URL; v != "" {
+		d.Set("url", v)
 	}
-	if v := jiraService.Properties.Username; v != nil {
-		d.Set("username", *v)
+	if v := jiraService.Properties.Username; v != "" {
+		d.Set("username", v)
 	}
-	if v := jiraService.Properties.ProjectKey; v != nil {
-		d.Set("project_key", *v)
+	if v := jiraService.Properties.ProjectKey; v != "" {
+		d.Set("project_key", v)
 	}
-	if v := jiraService.Properties.JiraIssueTransitionID; v != nil {
-		d.Set("jira_issue_transition_id", *v)
+	if v := jiraService.Properties.JiraIssueTransitionID; v != "" {
+		d.Set("jira_issue_transition_id", v)
 	}
 
 	d.Set("title", jiraService.Title)
@@ -124,14 +124,11 @@ func resourceGitlabServiceJiraRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("active", jiraService.Active)
 	d.Set("push_events", jiraService.PushEvents)
 	d.Set("issues_events", jiraService.IssuesEvents)
-	d.Set("confidential_issues_events", jiraService.ConfidentialIssuesEvents)
 	d.Set("merge_requests_events", jiraService.MergeRequestsEvents)
 	d.Set("tag_push_events", jiraService.TagPushEvents)
 	d.Set("note_events", jiraService.NoteEvents)
 	d.Set("pipeline_events", jiraService.PipelineEvents)
 	d.Set("job_events", jiraService.JobEvents)
-	d.Set("wikiPage_events", jiraService.WikiPageEvents)
-	d.Set("confidentialNote_events", jiraService.ConfidentialNoteEvents)
 
 	return nil
 }
@@ -163,7 +160,7 @@ func expandJiraOptions(d *schema.ResourceData) (*gitlab.SetJiraServiceOptions, e
 
 	// Set optional properties
 	if val := d.Get("jira_issue_transition_id"); val != nil {
-		setJiraServiceOptions.JiraIssueTransitionID = gitlab.Int(val.(int))
+		setJiraServiceOptions.JiraIssueTransitionID = gitlab.String(val.(string))
 	}
 
 	return &setJiraServiceOptions, nil

--- a/gitlab/resource_gitlab_service_jira_test.go
+++ b/gitlab/resource_gitlab_service_jira_test.go
@@ -1,0 +1,179 @@
+package gitlab
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func TestAccGitlabServiceJira_basic(t *testing.T) {
+	var jiraService gitlab.JiraService
+	rInt := acctest.RandInt()
+	jiraResourceName := "gitlab_service_jira.jira"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabServiceJiraDestroy,
+		Steps: []resource.TestStep{
+			// Create a project and a jira service
+			{
+				Config: testAccGitlabServiceJiraConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabServiceJiraExists(jiraResourceName, &jiraService),
+					resource.TestCheckResourceAttr(jiraResourceName, "url", "https://test.com"),
+					resource.TestCheckResourceAttr(jiraResourceName, "username", "user1"),
+					resource.TestCheckResourceAttr(jiraResourceName, "password", "mypass"),
+				),
+			},
+			// Update the jira service
+			{
+				Config: testAccGitlabServiceJiraUpdateConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabServiceJiraExists(jiraResourceName, &jiraService),
+					resource.TestCheckResourceAttr(jiraResourceName, "url", "https://testurl.com"),
+					resource.TestCheckResourceAttr(jiraResourceName, "username", "user2"),
+					resource.TestCheckResourceAttr(jiraResourceName, "password", "mypass_update"),
+				),
+			},
+			// Update the jira service to get back to previous settings
+			{
+				Config: testAccGitlabServiceJiraConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabServiceJiraExists(jiraResourceName, &jiraService),
+					resource.TestCheckResourceAttr(jiraResourceName, "url", "https://test.com"),
+					resource.TestCheckResourceAttr(jiraResourceName, "username", "user1"),
+					resource.TestCheckResourceAttr(jiraResourceName, "password", "mypass"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGitlabServiceJira_import(t *testing.T) {
+	jiraResourceName := "gitlab_service_jira.jira"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabServiceJiraDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabServiceJiraConfig(rInt),
+			},
+			{
+				ResourceName:      jiraResourceName,
+				ImportStateIdFunc: getJiraProjectID(jiraResourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckGitlabServiceJiraExists(n string, service *gitlab.JiraService) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		project := rs.Primary.Attributes["project"]
+		if project == "" {
+			return fmt.Errorf("No project ID is set")
+		}
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		jiraService, _, err := conn.Services.GetJiraService(project)
+		if err != nil {
+			return fmt.Errorf("Jira service does not exist in project %s: %v", project, err)
+		}
+		*service = *jiraService
+
+		return nil
+	}
+}
+
+func testAccCheckGitlabServiceJiraDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_project" {
+			continue
+		}
+
+		gotRepo, resp, err := conn.Projects.GetProject(rs.Primary.ID, nil)
+		if err == nil {
+			if gotRepo != nil && fmt.Sprintf("%d", gotRepo.ID) == rs.Primary.ID {
+				return fmt.Errorf("Repository still exists")
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func getJiraProjectID(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not Found: %s", n)
+		}
+
+		project := rs.Primary.Attributes["project"]
+		if project == "" {
+			return "", fmt.Errorf("No project ID is set")
+		}
+
+		return project, nil
+	}
+}
+
+func testAccGitlabServiceJiraConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name        = "foo-%d"
+  description = "Terraform acceptance tests"
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource "gitlab_service_jira" "jira" {
+  project  = "${gitlab_project.foo.id}"
+  url      = "https://test.com"
+  username = "user1"
+  password = "mypass"
+}
+`, rInt)
+}
+
+func testAccGitlabServiceJiraUpdateConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name        = "foo-%d"
+  description = "Terraform acceptance tests"
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource "gitlab_service_jira" "jira" {
+  project  = "${gitlab_project.foo.id}"
+  url      = "https://testurl.com"
+  username = "user2"
+  password = "mypass_update"
+}
+`, rInt)
+}

--- a/gitlab/resource_gitlab_service_jira_test.go
+++ b/gitlab/resource_gitlab_service_jira_test.go
@@ -38,6 +38,7 @@ func TestAccGitlabServiceJira_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(jiraResourceName, "url", "https://testurl.com"),
 					resource.TestCheckResourceAttr(jiraResourceName, "username", "user2"),
 					resource.TestCheckResourceAttr(jiraResourceName, "password", "mypass_update"),
+					resource.TestCheckResourceAttr(jiraResourceName, "jira_issue_transition_id", "3"),
 				),
 			},
 			// Update the jira service to get back to previous settings
@@ -174,6 +175,7 @@ resource "gitlab_service_jira" "jira" {
   url      = "https://testurl.com"
   username = "user2"
   password = "mypass_update"
+  jira_issue_transition_id = "3"
 }
 `, rInt)
 }

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -2,13 +2,13 @@ package gitlab
 
 import (
 	"fmt"
-
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/xanzy/go-gitlab"
+	gitlab "github.com/xanzy/go-gitlab"
 )
 
 var accessLevelNameToValue = map[string]gitlab.AccessLevelValue{
@@ -59,6 +59,20 @@ func validateDateFunc() schema.SchemaValidateFunc {
 		if e != nil {
 			errors = append(errors, fmt.Errorf("%s is not valid for format YYYY-MM-DD", value))
 		}
+		return
+	}
+}
+
+func validateURLFunc() schema.SchemaValidateFunc {
+	return func(v interface{}, k string) (s []string, errors []error) {
+		value := v.(string)
+		url, err := url.Parse(value)
+
+		if err != nil || url.Host == "" || url.Scheme == "" {
+			errors = append(errors, fmt.Errorf("%s is not a valid URL", value))
+			return
+		}
+
 		return
 	}
 }

--- a/gitlab/util_test.go
+++ b/gitlab/util_test.go
@@ -3,7 +3,7 @@ package gitlab
 import (
 	"testing"
 
-	"github.com/xanzy/go-gitlab"
+	gitlab "github.com/xanzy/go-gitlab"
 )
 
 func TestGitlab_validation(t *testing.T) {
@@ -60,6 +60,44 @@ func TestGitlab_visbilityHelpers(t *testing.T) {
 		sv := string(tc.Level)
 		if sv == "" || sv != tc.String {
 			t.Fatalf("got %v expected %v", sv, tc.String)
+		}
+	}
+}
+
+func TestValidateURLFunc(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "invalid_url",
+			ErrCount: 1,
+		},
+		{
+			Value:    "invalid_url.com",
+			ErrCount: 1,
+		},
+		{
+			Value:    "/relative/path",
+			ErrCount: 1,
+		},
+		{
+			Value:    "https://valid_url.com",
+			ErrCount: 0,
+		},
+		{
+			Value:    "http://www.valid_url.com",
+			ErrCount: 0,
+		},
+	}
+
+	validationFunc := validateURLFunc()
+
+	for _, tc := range cases {
+		_, errors := validationFunc(tc.Value, "test_arg")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected 1 validation error")
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/ulikunitz/xz v0.5.6 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
-	github.com/xanzy/go-gitlab v0.17.0
+	github.com/xanzy/go-gitlab v0.18.0
 	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f // indirect
 	golang.org/x/net v0.0.0-20190522155817-f3200d17e092 // indirect
 	golang.org/x/oauth2 v0.0.0-20190517181255-950ef44c6e07 // indirect

--- a/go.sum
+++ b/go.sum
@@ -353,6 +353,8 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/xanzy/go-gitlab v0.17.0 h1:+ajmfVENiehiK8FgQXb0v/XEsYPAdf9vVE53iQ2fiGM=
 github.com/xanzy/go-gitlab v0.17.0/go.mod h1:LSfUQ9OPDnwRqulJk2HcWaAiFfCzaknyeGvjQI67MbE=
+github.com/xanzy/go-gitlab v0.18.0 h1:LybNSWSIw8BK+GnxuETAhUXEzzh5rHsHjopqVkGJXRE=
+github.com/xanzy/go-gitlab v0.18.0/go.mod h1:LSfUQ9OPDnwRqulJk2HcWaAiFfCzaknyeGvjQI67MbE=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/vendor/github.com/xanzy/go-gitlab/.gitignore
+++ b/vendor/github.com/xanzy/go-gitlab/.gitignore
@@ -6,7 +6,6 @@
 # Folders
 _obj
 _test
-.idea
 
 # Architecture specific extensions/prefixes
 *.[568vq]
@@ -23,3 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# IDE specific files and folders
+.idea
+*.iml

--- a/vendor/github.com/xanzy/go-gitlab/README.md
+++ b/vendor/github.com/xanzy/go-gitlab/README.md
@@ -24,7 +24,6 @@ to add new and/or missing endpoints. Currently the following services are suppor
 - [ ] Epic Issues
 - [ ] Epics
 - [ ] Geo Nodes
-- [ ] Project import/export
 - [x] Award Emojis
 - [x] Branches
 - [x] Broadcast Messages
@@ -35,14 +34,14 @@ to add new and/or missing endpoints. Currently the following services are suppor
 - [x] Deployments
 - [x] Environments
 - [x] Events
-- [x] Feature flags
-- [x] GitLab CI Config templates
-- [x] Gitignores templates
+- [x] Feature Flags
+- [x] GitLab CI Config Templates
+- [x] Gitignores Templates
 - [x] Group Access Requests
 - [x] Group Issue Boards
 - [x] Group Members
 - [x] Group Milestones
-- [x] Group-level Variables
+- [x] Group-Level Variables
 - [x] Groups
 - [x] Issue Boards
 - [x] Issues
@@ -54,19 +53,20 @@ to add new and/or missing endpoints. Currently the following services are suppor
 - [x] Merge Requests
 - [x] Namespaces
 - [x] Notes (comments)
-- [x] Notification settings
-- [x] Open source license templates
+- [x] Notification Settings
+- [x] Open Source License Templates
 - [x] Pages Domains
 - [x] Pipeline Schedules
 - [x] Pipeline Triggers
 - [x] Pipelines
 - [x] Project Access Requests
+- [x] Project Badges
 - [x] Project Clusters
+- [x] Project Import/export
 - [x] Project Members
 - [x] Project Milestones
 - [x] Project Snippets
-- [x] Project badges
-- [x] Project-level Variables
+- [x] Project-Level Variables
 - [x] Projects (including setting Webhooks)
 - [x] Protected Branches
 - [x] Protected Tags
@@ -76,12 +76,12 @@ to add new and/or missing endpoints. Currently the following services are suppor
 - [x] Search
 - [x] Services
 - [x] Settings
-- [x] Sidekiq metrics
+- [x] Sidekiq Metrics
 - [x] System Hooks
 - [x] Tags
 - [x] Todos
 - [x] Users
-- [x] Validate CI configuration
+- [x] Validate CI Configuration
 - [x] Version
 - [x] Wikis
 

--- a/vendor/github.com/xanzy/go-gitlab/branches.go
+++ b/vendor/github.com/xanzy/go-gitlab/branches.go
@@ -37,6 +37,7 @@ type Branch struct {
 	Name               string  `json:"name"`
 	Protected          bool    `json:"protected"`
 	Merged             bool    `json:"merged"`
+	Default            bool    `json:"default"`
 	DevelopersCanPush  bool    `json:"developers_can_push"`
 	DevelopersCanMerge bool    `json:"developers_can_merge"`
 }

--- a/vendor/github.com/xanzy/go-gitlab/event_types.go
+++ b/vendor/github.com/xanzy/go-gitlab/event_types.go
@@ -17,6 +17,9 @@
 package gitlab
 
 import (
+	"encoding/json"
+	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -82,6 +85,7 @@ type TagEvent struct {
 	UserName    string `json:"user_name"`
 	UserAvatar  string `json:"user_avatar"`
 	ProjectID   int    `json:"project_id"`
+	Message     string `json:"message"`
 	Project     struct {
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
@@ -161,13 +165,21 @@ type IssueEvent struct {
 		Username  string `json:"username"`
 		AvatarURL string `json:"avatar_url"`
 	} `json:"assignee"`
-	Labels []Label `json:"labels"`
+	Assignees []struct {
+		Name      string `json:"name"`
+		Username  string `json:"username"`
+		AvatarURL string `json:"avatar_url"`
+	} `json:"assignees"`
+	Labels  []Label `json:"labels"`
 	Changes struct {
 		Labels struct {
 			Previous []Label `json:"previous"`
 			Current  []Label `json:"current"`
 		} `json:"labels"`
-		UpdatedByID []int `json:"updated_by_id"`
+		UpdatedByID struct {
+			Previous int `json:"previous"`
+			Current  int `json:"current"`
+		} `json:"updated_by_id"`
 	} `json:"changes"`
 }
 
@@ -407,7 +419,31 @@ type IssueCommentEvent struct {
 		StDiff       []*Diff `json:"st_diff"`
 		URL          string  `json:"url"`
 	} `json:"object_attributes"`
-	Issue *Issue `json:"issue"`
+	Issue struct {
+		ID                  int      `json:"id"`
+		IID                 int      `json:"iid"`
+		ProjectID           int      `json:"project_id"`
+		MilestoneID         int      `json:"milestone_id"`
+		AuthorID            int      `json:"author_id"`
+		Description         string   `json:"description"`
+		State               string   `json:"state"`
+		Title               string   `json:"title"`
+		LastEditedAt        string   `json:"last_edit_at"`
+		LastEditedByID      int      `json:"last_edited_by_id"`
+		UpdatedAt           string   `json:"updated_at"`
+		UpdatedByID         int      `json:"updated_by_id"`
+		CreatedAt           string   `json:"created_at"`
+		ClosedAt            string   `json:"closed_at"`
+		DueDate             *ISOTime `json:"due_date"`
+		URL                 string   `json:"url"`
+		TimeEstimate        int      `json:"time_estimate"`
+		Confidential        bool     `json:"confidential"`
+		TotalTimeSpent      int      `json:"total_time_spent"`
+		HumanTotalTimeSpent int      `json:"human_total_time_spent"`
+		HumanTimeEstimate   int      `json:"human_time_estimate"`
+		AssigneeIDs         []int    `json:"assignee_ids"`
+		AssigneeID          int      `json:"assignee_id"`
+	} `json:"issue"`
 }
 
 // SnippetCommentEvent represents a comment on a snippet event.
@@ -479,41 +515,39 @@ type MergeEvent struct {
 		Visibility        VisibilityValue `json:"visibility"`
 	} `json:"project"`
 	ObjectAttributes struct {
-		ID              int       `json:"id"`
-		TargetBranch    string    `json:"target_branch"`
-		SourceBranch    string    `json:"source_branch"`
-		SourceProjectID int       `json:"source_project_id"`
-		AuthorID        int       `json:"author_id"`
-		AssigneeID      int       `json:"assignee_id"`
-		Title           string    `json:"title"`
-		CreatedAt       string    `json:"created_at"` // Should be *time.Time (see Gitlab issue #21468)
-		UpdatedAt       string    `json:"updated_at"` // Should be *time.Time (see Gitlab issue #21468)
-		StCommits       []*Commit `json:"st_commits"`
-		StDiffs         []*Diff   `json:"st_diffs"`
-		MilestoneID     int       `json:"milestone_id"`
-		State           string    `json:"state"`
-		MergeStatus     string    `json:"merge_status"`
-		TargetProjectID int       `json:"target_project_id"`
-		IID             int       `json:"iid"`
-		Description     string    `json:"description"`
-		Position        int       `json:"position"`
-		LockedAt        string    `json:"locked_at"`
-		UpdatedByID     int       `json:"updated_by_id"`
-		MergeError      string    `json:"merge_error"`
-		MergeParams     struct {
-			ForceRemoveSourceBranch string `json:"force_remove_source_branch"`
-		} `json:"merge_params"`
-		MergeWhenBuildSucceeds   bool        `json:"merge_when_build_succeeds"`
-		MergeUserID              int         `json:"merge_user_id"`
-		MergeCommitSHA           string      `json:"merge_commit_sha"`
-		DeletedAt                string      `json:"deleted_at"`
-		ApprovalsBeforeMerge     string      `json:"approvals_before_merge"`
-		RebaseCommitSHA          string      `json:"rebase_commit_sha"`
-		InProgressMergeCommitSHA string      `json:"in_progress_merge_commit_sha"`
-		LockVersion              int         `json:"lock_version"`
-		TimeEstimate             int         `json:"time_estimate"`
-		Source                   *Repository `json:"source"`
-		Target                   *Repository `json:"target"`
+		ID                       int          `json:"id"`
+		TargetBranch             string       `json:"target_branch"`
+		SourceBranch             string       `json:"source_branch"`
+		SourceProjectID          int          `json:"source_project_id"`
+		AuthorID                 int          `json:"author_id"`
+		AssigneeID               int          `json:"assignee_id"`
+		Title                    string       `json:"title"`
+		CreatedAt                string       `json:"created_at"` // Should be *time.Time (see Gitlab issue #21468)
+		UpdatedAt                string       `json:"updated_at"` // Should be *time.Time (see Gitlab issue #21468)
+		StCommits                []*Commit    `json:"st_commits"`
+		StDiffs                  []*Diff      `json:"st_diffs"`
+		MilestoneID              int          `json:"milestone_id"`
+		State                    string       `json:"state"`
+		MergeStatus              string       `json:"merge_status"`
+		TargetProjectID          int          `json:"target_project_id"`
+		IID                      int          `json:"iid"`
+		Description              string       `json:"description"`
+		Position                 int          `json:"position"`
+		LockedAt                 string       `json:"locked_at"`
+		UpdatedByID              int          `json:"updated_by_id"`
+		MergeError               string       `json:"merge_error"`
+		MergeParams              *MergeParams `json:"merge_params"`
+		MergeWhenBuildSucceeds   bool         `json:"merge_when_build_succeeds"`
+		MergeUserID              int          `json:"merge_user_id"`
+		MergeCommitSHA           string       `json:"merge_commit_sha"`
+		DeletedAt                string       `json:"deleted_at"`
+		ApprovalsBeforeMerge     string       `json:"approvals_before_merge"`
+		RebaseCommitSHA          string       `json:"rebase_commit_sha"`
+		InProgressMergeCommitSHA string       `json:"in_progress_merge_commit_sha"`
+		LockVersion              int          `json:"lock_version"`
+		TimeEstimate             int          `json:"time_estimate"`
+		Source                   *Repository  `json:"source"`
+		Target                   *Repository  `json:"target"`
 		LastCommit               struct {
 			ID        string     `json:"id"`
 			Message   string     `json:"message"`
@@ -540,7 +574,7 @@ type MergeEvent struct {
 		Username  string `json:"username"`
 		AvatarURL string `json:"avatar_url"`
 	} `json:"assignee"`
-	Labels []Label `json:"labels"`
+	Labels  []Label `json:"labels"`
 	Changes struct {
 		AssigneeID struct {
 			Previous int `json:"previous"`
@@ -554,8 +588,50 @@ type MergeEvent struct {
 			Previous []Label `json:"previous"`
 			Current  []Label `json:"current"`
 		} `json:"labels"`
-		UpdatedByID []int `json:"updated_by_id"`
+		UpdatedByID struct {
+			Previous int `json:"previous"`
+			Current  int `json:"current"`
+		} `json:"updated_by_id"`
 	} `json:"changes"`
+}
+
+// MergeParams represents the merge params.
+type MergeParams struct {
+	ForceRemoveSourceBranch bool `json:"force_remove_source_branch"`
+}
+
+// UnmarshalJSON decodes the merge parameters
+//
+// This allows support of ForceRemoveSourceBranch for both type bool (>11.9) and string (<11.9)
+func (p *MergeParams) UnmarshalJSON(b []byte) error {
+	type Alias MergeParams
+	raw := struct {
+		*Alias
+		ForceRemoveSourceBranch interface{} `json:"force_remove_source_branch"`
+	}{
+		Alias: (*Alias)(p),
+	}
+
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return err
+	}
+
+	switch v := raw.ForceRemoveSourceBranch.(type) {
+	case nil:
+		// No action needed.
+	case bool:
+		p.ForceRemoveSourceBranch = v
+	case string:
+		p.ForceRemoveSourceBranch, err = strconv.ParseBool(v)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("failed to unmarshal ForceRemoveSourceBranch of type: %T", v)
+	}
+
+	return nil
 }
 
 // WikiPageEvent represents a wiki page event.

--- a/vendor/github.com/xanzy/go-gitlab/gitlab.go
+++ b/vendor/github.com/xanzy/go-gitlab/gitlab.go
@@ -330,6 +330,7 @@ type Client struct {
 	Pipelines             *PipelinesService
 	ProjectBadges         *ProjectBadgesService
 	ProjectCluster        *ProjectClustersService
+	ProjectImportExport   *ProjectImportExportService
 	ProjectMembers        *ProjectMembersService
 	ProjectSnippets       *ProjectSnippetsService
 	ProjectVariables      *ProjectVariablesService
@@ -478,6 +479,7 @@ func newClient(httpClient *http.Client) *Client {
 	c.Pipelines = &PipelinesService{client: c}
 	c.ProjectBadges = &ProjectBadgesService{client: c}
 	c.ProjectCluster = &ProjectClustersService{client: c}
+	c.ProjectImportExport = &ProjectImportExportService{client: c}
 	c.ProjectMembers = &ProjectMembersService{client: c}
 	c.ProjectSnippets = &ProjectSnippetsService{client: c}
 	c.ProjectVariables = &ProjectVariablesService{client: c}

--- a/vendor/github.com/xanzy/go-gitlab/pipeline_schedules.go
+++ b/vendor/github.com/xanzy/go-gitlab/pipeline_schedules.go
@@ -227,11 +227,6 @@ func (s *PipelineSchedulesService) DeletePipelineSchedule(pid interface{}, sched
 		return nil, err
 	}
 
-	req, err = s.client.NewRequest("DELETE", u, nil, options)
-	if err != nil {
-		return nil, err
-	}
-
 	return s.client.Do(req, nil)
 }
 

--- a/vendor/github.com/xanzy/go-gitlab/project_clusters.go
+++ b/vendor/github.com/xanzy/go-gitlab/project_clusters.go
@@ -118,6 +118,7 @@ type AddClusterOptions struct {
 	Name               *string                       `url:"name,omitempty" json:"name,omitempty"`
 	Domain             *string                       `url:"domain,omitempty" json:"domain,omitempty"`
 	Enabled            *bool                         `url:"enabled,omitempty" json:"enabled,omitempty"`
+	Managed            *bool                         `url:"managed,omitempty" json:"managed,omitempty"`
 	EnvironmentScope   *string                       `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 	PlatformKubernetes *AddPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
 }

--- a/vendor/github.com/xanzy/go-gitlab/project_import_export.go
+++ b/vendor/github.com/xanzy/go-gitlab/project_import_export.go
@@ -1,0 +1,196 @@
+package gitlab
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+)
+
+// ProjectImportExportService handles communication with the project
+// import/export related methods of the GitLab API.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/user/project/settings/import_export.html
+type ProjectImportExportService struct {
+	client *Client
+}
+
+// ImportStatus represents a project import status.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/project_import_export.html#import-status
+type ImportStatus struct {
+	ID                int        `json:"id"`
+	Description       string     `json:"description"`
+	Name              string     `json:"name"`
+	NameWithNamespace string     `json:"name_with_namespace"`
+	Path              string     `json:"path"`
+	PathWithNamespace string     `json:"path_with_namespace"`
+	CreateAt          *time.Time `json:"create_at"`
+	ImportStatus      string     `json:"import_status"`
+}
+
+func (s ImportStatus) String() string {
+	return Stringify(s)
+}
+
+// ExportStatus represents a project export status.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/project_import_export.html#export-status
+type ExportStatus struct {
+	ID                int        `json:"id"`
+	Description       string     `json:"description"`
+	Name              string     `json:"name"`
+	NameWithNamespace string     `json:"name_with_namespace"`
+	Path              string     `json:"path"`
+	PathWithNamespace string     `json:"path_with_namespace"`
+	CreatedAt         *time.Time `json:"created_at"`
+	ExportStatus      string     `json:"export_status"`
+	Message           string     `json:"message"`
+	Links             struct {
+		APIURL string `json:"api_url"`
+		WebURL string `json:"web_url"`
+	} `json:"_links"`
+}
+
+func (s ExportStatus) String() string {
+	return Stringify(s)
+}
+
+// ScheduleExportOptions represents the available ScheduleExport() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/project_import_export.html#schedule-an-export
+type ScheduleExportOptions struct {
+	Description *string `url:"description,omitempty" json:"description,omitempty"`
+	Upload      struct {
+		URL        *string `url:"url,omitempty" json:"url,omitempty"`
+		HTTPMethod *string `url:"http_method,omitempty" json:"http_method,omitempty"`
+	} `url:"upload,omitempty" json:"upload,omitempty"`
+}
+
+// ScheduleExport schedules a project export.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/project_import_export.html#schedule-an-export
+func (s *ProjectImportExportService) ScheduleExport(pid interface{}, opt *ScheduleExportOptions, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/export", pathEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// ExportStatus get the status of export.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/project_import_export.html#export-status
+func (s *ProjectImportExportService) ExportStatus(pid interface{}, options ...OptionFunc) (*ExportStatus, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/export", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	es := new(ExportStatus)
+	resp, err := s.client.Do(req, es)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return es, resp, err
+}
+
+// ExportDownload download the finished export.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/project_import_export.html#export-download
+func (s *ProjectImportExportService) ExportDownload(pid interface{}, options ...OptionFunc) ([]byte, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/export/download", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var b bytes.Buffer
+	resp, err := s.client.Do(req, &b)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return b.Bytes(), resp, err
+}
+
+// ImportFileOptions represents the available ImportFile() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/project_import_export.html#import-a-file
+type ImportFileOptions struct {
+	Namespace      *string               `url:"namespace,omitempty" json:"namespace,omitempty"`
+	File           *string               `url:"file,omitempty" json:"file,omitempty"`
+	Path           *string               `url:"path,omitempty" json:"path,omitempty"`
+	Overwrite      *bool                 `url:"overwrite,omitempty" json:"overwrite,omitempty"`
+	OverrideParams *CreateProjectOptions `url:"override_params,omitempty" json:"override_params,omitempty"`
+}
+
+// ImportProject import the project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/project_import_export.html#import-a-file
+func (s *ProjectImportExportService) ImportProject(opt *ImportFileOptions, options ...OptionFunc) (*ImportStatus, *Response, error) {
+	req, err := s.client.NewRequest("POST", "/projects/import", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	is := new(ImportStatus)
+	resp, err := s.client.Do(req, is)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return is, resp, err
+}
+
+// ImportStatus get the status of an import.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/project_import_export.html#import-status
+func (s *ProjectImportExportService) ImportStatus(pid interface{}, options ...OptionFunc) (*ImportStatus, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/import", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	is := new(ImportStatus)
+	resp, err := s.client.Do(req, is)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return is, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/projects.go
+++ b/vendor/github.com/xanzy/go-gitlab/projects.go
@@ -557,18 +557,27 @@ func (s *ProjectsService) EditProject(pid interface{}, opt *EditProjectOptions, 
 	return p, resp, err
 }
 
+// ForkProjectOptions represents the available ForkProject() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#fork-project
+type ForkProjectOptions struct {
+	Namespace *string `url:"namespace,omitempty" json:"namespace,omitempty"`
+	Name      *string `url:"name,omitempty" json:"name,omitempty" `
+	Path      *string `url:"path,omitempty" json:"path,omitempty"`
+}
+
 // ForkProject forks a project into the user namespace of the authenticated
 // user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#fork-project
-func (s *ProjectsService) ForkProject(pid interface{}, options ...OptionFunc) (*Project, *Response, error) {
+func (s *ProjectsService) ForkProject(pid interface{}, opt *ForkProjectOptions, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/fork", pathEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, nil, options)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/xanzy/go-gitlab/protected_tags.go
+++ b/vendor/github.com/xanzy/go-gitlab/protected_tags.go
@@ -72,7 +72,7 @@ func (s *ProtectedTagsService) GetProtectedTag(pid interface{}, tag string, opti
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/protected_tags/%s", pathEscape(project), tag)
+	u := fmt.Sprintf("projects/%s/protected_tags/%s", pathEscape(project), pathEscape(tag))
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -134,7 +134,7 @@ func (s *ProtectedTagsService) UnprotectRepositoryTags(pid interface{}, tag stri
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/protected_tags/%s", pathEscape(project), tag)
+	u := fmt.Sprintf("projects/%s/protected_tags/%s", pathEscape(project), pathEscape(tag))
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/services.go
+++ b/vendor/github.com/xanzy/go-gitlab/services.go
@@ -17,7 +17,9 @@
 package gitlab
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -261,20 +263,20 @@ type SlackServiceProperties struct {
 	// We need to handle this, until the bug will be fixed.
 	// Ref: https://gitlab.com/gitlab-org/gitlab-ce/issues/50122
 
-	NotifyOnlyBrokenPipelines BoolValue `url:"notify_only_broken_pipelines,omitempty" json:"notify_only_broken_pipelines,omitempty"`
-	NotifyOnlyDefaultBranch   BoolValue `url:"notify_only_default_branch,omitempty" json:"notify_only_default_branch,omitempty"`
-	WebHook                   string    `url:"webhook,omitempty" json:"webhook,omitempty"`
-	Username                  string    `url:"username,omitempty" json:"username,omitempty"`
-	Channel                   string    `url:"channel,omitempty" json:"channel,omitempty"`
-	PushChannel               string    `url:"push_channel,omitempty" json:"push_channel,omitempty"`
-	IssueChannel              string    `url:"issue_channel,omitempty" json:"issue_channel,omitempty"`
-	ConfidentialIssueChannel  string    `url:"confidential_issue_channel,omitempty" json:"confidential_issue_channel,omitempty"`
-	MergeRequestChannel       string    `url:"merge_request_channel,omitempty" json:"merge_request_channel,omitempty"`
-	NoteChannel               string    `url:"note_channel,omitempty" json:"note_channel,omitempty"`
-	ConfidentialNoteChannel   string    `url:"confidential_note_channel,omitempty" json:"confidential_note_channel,omitempty"`
-	TagPushChannel            string    `url:"tag_push_channel,omitempty" json:"tag_push_channel,omitempty"`
-	PipelineChannel           string    `url:"pipeline_channel,omitempty" json:"pipeline_channel,omitempty"`
-	WikiPageChannel           string    `url:"wiki_page_channel,omitempty" json:"wiki_page_channel,omitempty"`
+	NotifyOnlyBrokenPipelines BoolValue `json:"notify_only_broken_pipelines,omitempty"`
+	NotifyOnlyDefaultBranch   BoolValue `json:"notify_only_default_branch,omitempty"`
+	WebHook                   string    `json:"webhook,omitempty"`
+	Username                  string    `json:"username,omitempty"`
+	Channel                   string    `json:"channel,omitempty"`
+	PushChannel               string    `json:"push_channel,omitempty"`
+	IssueChannel              string    `json:"issue_channel,omitempty"`
+	ConfidentialIssueChannel  string    `json:"confidential_issue_channel,omitempty"`
+	MergeRequestChannel       string    `json:"merge_request_channel,omitempty"`
+	NoteChannel               string    `json:"note_channel,omitempty"`
+	ConfidentialNoteChannel   string    `json:"confidential_note_channel,omitempty"`
+	TagPushChannel            string    `json:"tag_push_channel,omitempty"`
+	PipelineChannel           string    `json:"pipeline_channel,omitempty"`
+	WikiPageChannel           string    `json:"wiki_page_channel,omitempty"`
 }
 
 // GetSlackService gets Slack service settings for a project.
@@ -388,11 +390,42 @@ type JiraService struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#jira
 type JiraServiceProperties struct {
-	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
-	ProjectKey            *string `url:"project_key,omitempty" json:"project_key,omitempty" `
-	Username              *string `url:"username,omitempty" json:"username,omitempty" `
-	Password              *string `url:"password,omitempty" json:"password,omitempty" `
-	JiraIssueTransitionID *int    `url:"jira_issue_transition_id,omitempty" json:"jira_issue_transition_id,omitempty"`
+	URL                   string `json:"url,omitempty"`
+	APIURL                string `json:"api_url,omitempty"`
+	ProjectKey            string `json:"project_key,omitempty" `
+	Username              string `json:"username,omitempty" `
+	Password              string `json:"password,omitempty" `
+	JiraIssueTransitionID string `json:"jira_issue_transition_id,omitempty"`
+}
+
+// UnmarshalJSON decodes the Jira Service Properties.
+//
+// This allows support of JiraIssueTransitionID for both type string (>11.9) and float64 (<11.9)
+func (p *JiraServiceProperties) UnmarshalJSON(b []byte) error {
+	type Alias JiraServiceProperties
+	raw := struct {
+		*Alias
+		JiraIssueTransitionID interface{} `json:"jira_issue_transition_id"`
+	}{
+		Alias: (*Alias)(p),
+	}
+
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+
+	switch id := raw.JiraIssueTransitionID.(type) {
+	case nil:
+		// No action needed.
+	case string:
+		p.JiraIssueTransitionID = id
+	case float64:
+		p.JiraIssueTransitionID = strconv.Itoa(int(id))
+	default:
+		return fmt.Errorf("failed to unmarshal JiraTransitionID of type: %T", id)
+	}
+
+	return nil
 }
 
 // GetJiraService gets Jira service settings for a project.
@@ -425,7 +458,14 @@ func (s *ServicesService) GetJiraService(pid interface{}, options ...OptionFunc)
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#edit-jira-service
-type SetJiraServiceOptions JiraServiceProperties
+type SetJiraServiceOptions struct {
+	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
+	APIURL                *string `url:"api_url,omitempty" json:"api_url,omitempty"`
+	ProjectKey            *string `url:"project_key,omitempty" json:"project_key,omitempty" `
+	Username              *string `url:"username,omitempty" json:"username,omitempty" `
+	Password              *string `url:"password,omitempty" json:"password,omitempty" `
+	JiraIssueTransitionID *string `url:"jira_issue_transition_id,omitempty" json:"jira_issue_transition_id,omitempty"`
+}
 
 // SetJiraService sets Jira service for a project
 //
@@ -479,9 +519,9 @@ type JenkinsCIService struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/services.html#jenkins-ci
 type JenkinsCIServiceProperties struct {
-	URL         *string `url:"jenkins_url,omitempty" json:"jenkins_url,omitempty"`
-	ProjectName *string `url:"project_name,omitempty" json:"project_name,omitempty"`
-	Username    *string `url:"username,omitempty" json:"username,omitempty"`
+	URL         string `json:"jenkins_url,omitempty"`
+	ProjectName string `json:"project_name,omitempty"`
+	Username    string `json:"username,omitempty"`
 }
 
 // GetJenkinsCIService gets Jenkins CI service settings for a project.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/ulikunitz/xz/internal/hash
 # github.com/vmihailenco/msgpack v4.0.4+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/xanzy/go-gitlab v0.17.0
+# github.com/xanzy/go-gitlab v0.18.0
 github.com/xanzy/go-gitlab
 # github.com/zclconf/go-cty v0.0.0-20190516203816-4fecf87372ec
 github.com/zclconf/go-cty/cty

--- a/website/docs/r/service_jira.html.markdown
+++ b/website/docs/r/service_jira.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "gitlab"
+page_title: "GitLab: gitlab_service_jira"
+sidebar_current: "docs-gitlab-resource-service_jira"
+description: |-
+  Manage Jira integration that allows to receive event notifications in Jira
+---
+
+# gitlab\_service\_jira
+
+This resource allows you to manage Jira integration.
+
+## Example Usage
+
+```hcl
+resource "gitlab_project" "awesome_project" {
+  name = "awesome_project"
+  description = "My awesome project."
+  visibility_level = "public"
+}
+
+resource "gitlab_service_jira" "jira" {
+  project  = "${gitlab_project.awesome_project.id}"
+  url      = "https://jira.example.com"
+  username = "user"
+  password = "mypass"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Required) ID of the project you want to activate integration on.
+
+* `url` - (Required) The URL to the JIRA project which is being linked to this GitLab project. For example, https://jira.example.com.
+
+* `username` - (Required) The username of the user created to be used with GitLab/JIRA.
+
+* `password` - (Required) The password of the user created to be used with GitLab/JIRA.
+
+* `project_key` - (Required) The short identifier for your JIRA project, all uppercase, e.g., PROJ.
+
+* `jira_issue_transition_id` - (Optional) The ID of a transition that moves issues to a closed state. You can find this number under the JIRA workflow administration (Administration > Issues > Workflows) by selecting View under Operations of the desired workflow of your project. By default, this ID is set to 2.
+
+## Importing Jira service
+
+ You can import a service_jira state using `terraform import <resource> <project_id>`:
+
+```bash
+$ terraform import gitlab_service_jira.jira 1
+```

--- a/website/gitlab.erb
+++ b/website/gitlab.erb
@@ -64,6 +64,9 @@
           <li<%= sidebar_current("docs-gitlab-resource-project_variable") %>>
           <a href="/docs/providers/gitlab/r/project_variable.html">gitlab_project_variable</a>
           </li>
+          <li<%= sidebar_current("docs-gitlab-resource-service_jira") %>>
+            <a href="/docs/providers/gitlab/r/service_jira.html">gitlab_service_jira</a>
+          </li>
           <li<%= sidebar_current("docs-gitlab-resource-user") %>>
             <a href="/docs/providers/gitlab/r/user.html">gitlab_user</a>
           </li>


### PR DESCRIPTION
Hi,

I'd like to add the Jira's integration implementation (see [doc.](https://docs.gitlab.com/ce/api/services.html#jira)).

Here's a sample of how it can be used:
```hcl
resource "gitlab_project" "awesome_project" {
  name             = "awesome_project"
  description      = "My awesome project."
  visibility_level = "public"
}

resource "gitlab_service_jira" "jira" {
  project  = "${gitlab_project.awesome_project.id}"
  url      = "https://jira.example.com"
  username = "user"
  password = "mypass"
}
```

It includes documentation and acceptance tests.

**Note**: there's currently an issue with the `jira_issue_transition_id` parameter preventing it to work properly (see https://gitlab.com/gitlab-org/gitlab-ce/issues/55109). But the integration still can be used. I'll make the necessary updates to both Gitlab Go client and Terraform provider when the fix is released (probably v11.9)

Thanks,

-------
Edit:
- [ ] Requires PR #143 to be merged