### PR TITLE
Update user datasource: allow searching by id and add attributes

### DIFF
--- a/gitlab/data_source_gitlab_user.go
+++ b/gitlab/data_source_gitlab_user.go
@@ -13,13 +13,124 @@ func dataSourceGitlabUser() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGitlabUserRead,
 		Schema: map[string]*schema.Schema{
-			"email": {
-				Type:     schema.TypeString,
+			"user_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
 				Optional: true,
+				ConflictsWith: []string{
+					"username",
+					"email",
+				},
 			},
 			"username": {
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
+				ConflictsWith: []string{
+					"user_id",
+					"email",
+				},
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ConflictsWith: []string{
+					"user_id",
+					"username",
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_admin": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"can_create_group": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"can_create_project": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"projects_limit": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"external": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"extern_uid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"organization": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"two_factor_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"user_provider": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"avatar_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bio": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"location": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"skype": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"linkedin": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"twitter": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"website_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"theme_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"color_scheme_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"last_sign_in_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"current_sign_in_at": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -28,48 +139,77 @@ func dataSourceGitlabUser() *schema.Resource {
 func dataSourceGitlabUserRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
+	var user *gitlab.User
+	var err error
+
 	log.Printf("[INFO] Reading Gitlab user")
 
-	searchEmail := strings.ToLower(d.Get("email").(string))
-	userName := strings.ToLower(d.Get("username").(string))
-	var q *string
-	if searchEmail != "" {
-		q = &searchEmail
-	} else {
-		q = &userName
-	}
-	query := &gitlab.ListUsersOptions{
-		Search: q,
-	}
-	users, _, err := client.Users.ListUsers(query)
-	if err != nil {
-		return err
-	}
+	userIDData, userIDOk := d.GetOk("user_id")
+	usernameData, usernameOk := d.GetOk("username")
+	emailData, emailOk := d.GetOk("email")
 
-	var found *gitlab.User
-
-	if searchEmail != "" {
-		for _, user := range users {
-			if strings.ToLower(user.Email) == searchEmail {
-				found = user
-				break
-			}
+	if userIDOk {
+		// Get user by id
+		user, _, err = client.Users.GetUser(userIDData.(int))
+		if err != nil {
+			return err
 		}
-	} else {
-		for _, user := range users {
-			if strings.ToLower(user.Username) == userName {
-				found = user
-				break
-			}
+	} else if usernameOk || emailOk {
+		username := strings.ToLower(usernameData.(string))
+		email := strings.ToLower(emailData.(string))
+
+		listUsersOptions := &gitlab.ListUsersOptions{}
+		if usernameOk {
+			// Get user by username
+			listUsersOptions.Username = gitlab.String(username)
+		} else {
+			// Get user by email
+			listUsersOptions.Search = gitlab.String(email)
 		}
+
+		var users []*gitlab.User
+		users, _, err = client.Users.ListUsers(listUsersOptions)
+		if err != nil {
+			return err
+		}
+
+		if len(users) == 0 {
+			return fmt.Errorf("couldn't find a user matching: %s%s", username, email)
+		} else if len(users) != 1 {
+			return fmt.Errorf("more than one user found matching: %s%s", username, email)
+		}
+
+		user = users[0]
+	} else {
+		return fmt.Errorf("one and only one of user_id, username or email must be set")
 	}
 
-	if found == nil {
-		return fmt.Errorf("The email '%s' does not match any user email", searchEmail)
-	}
-	d.SetId(fmt.Sprintf("%d", found.ID))
-	d.Set("name", found.Name)
-	d.Set("username", found.Username)
-	d.Set("email", found.Email)
+	d.Set("user_id", user.ID)
+	d.Set("username", user.Username)
+	d.Set("email", user.Email)
+	d.Set("name", user.Name)
+	d.Set("is_admin", user.IsAdmin)
+	d.Set("can_create_group", user.CanCreateGroup)
+	d.Set("can_create_project", user.CanCreateProject)
+	d.Set("projects_limit", user.ProjectsLimit)
+	d.Set("state", user.State)
+	d.Set("external", user.External)
+	d.Set("extern_uid", user.ExternUID)
+	d.Set("created_at", user.CreatedAt)
+	d.Set("organization", user.Organization)
+	d.Set("two_factor_enabled", user.TwoFactorEnabled)
+	d.Set("provider", user.Provider)
+	d.Set("avatar_url", user.AvatarURL)
+	d.Set("bio", user.Bio)
+	d.Set("location", user.Location)
+	d.Set("skype", user.Skype)
+	d.Set("linkedin", user.Linkedin)
+	d.Set("twitter", user.Twitter)
+	d.Set("website_url", user.WebsiteURL)
+	d.Set("theme_id", user.ThemeID)
+	d.Set("color_scheme_id", user.ColorSchemeID)
+
+	d.SetId(fmt.Sprintf("%d", user.ID))
+
 	return nil
 }

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -14,7 +14,7 @@ Provides details about a specific user in the gitlab provider. Especially the ab
 
 ```hcl
 data "gitlab_user" "example" {
-	email = "test@aaa.com"
+  username = "myuser"
 }
 ```
 
@@ -26,18 +26,64 @@ The following arguments are supported:
 
 * `username` - (Optional) The username of the user.
 
-If both are given only e-mail is used.
+* `user_id` - (Optional) The ID of the user.
+
+**Note**: only one of email, user_id or username must be provided.
 
 ## Attributes Reference
 
-The following attributes are exported:
-
-* `name` - The name of the user.
+* `id` - The unique id assigned to the user by the gitlab server.
 
 * `username` - The username of the user.
 
 * `email` - The e-mail address of the user.
 
-* `id` - The unique id assigned to the user by the gitlab server.
+* `name` - The name of the user.
 
+* `is_admin` - Whether the user is an admin.
 
+* `can_create_group` - Whether the user can create groups.
+
+* `can_create_project` - Whether the user can create projects.
+
+* `projects_limit` - Number of projects the user can create.
+
+* `created_at` - Date the user was created at.
+
+* `state` - Whether the user is active or blocked.
+
+* `external` - Whether the user is external.
+
+* `extern_uid` - The external UID of the user.
+
+* `user_provider` - The UID provider of the user.
+
+* `organization` - The organization of the user.
+
+* `two_factor_enabled` - Whether user's two factor auth is enabled.
+
+* `avatar_url` - The avatar URL of the user.
+
+* `bio` - The bio of the user.
+
+* `location` - The location of the user.
+
+* `skype` - Skype username of the user.
+
+* `linkedin` - Linkedin profile of the user.
+
+* `twitter` - Twitter username of the user.
+
+* `website_url` - User's website URL.
+
+* `theme_id` - User's theme ID.
+
+* `color_scheme_id` - User's color scheme ID.
+
+* `last_sign_in_at` - Last user's sign-in date.
+
+* `current_sign_in_at` - Current user's sign-in date.
+
+**Note**: some attributes might not be returned depending on if you're an admin or not. Please refer to [doc][doc] for more details.
+
+[doc]: https://docs.gitlab.com/ce/api/users.html#single-user


### PR DESCRIPTION
Hi,

This PR updates the *user* datasource.

It allows searching by id:
```hcl
data "gitlab_user" "foo" {
  user_id = "2387"
}
```

It also adds more attributes and better handles the search parameters to avoid using multiple ones at the same time.

**Note**: the search by id parameter is called `user_id` because `id` is a Terraform reserved keyword. Same goes for the `provider` attribute renamed into `user_provider`. I'm willing to change this if you have better suggestions.

Best,