### PR TITLE
Add shared_runners_enabled flag in project

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -113,6 +113,11 @@ func resourceGitlabProject() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"shared_runners_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 			"shared_with_groups": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -159,6 +164,7 @@ func resourceGitlabProjectSetToState(d *schema.ResourceData, project *gitlab.Pro
 	d.Set("http_url_to_repo", project.HTTPURLToRepo)
 	d.Set("web_url", project.WebURL)
 	d.Set("runners_token", project.RunnersToken)
+	d.Set("shared_runners_enabled", project.SharedRunnersEnabled)
 	d.Set("shared_with_groups", flattenSharedWithGroupsOptions(project))
 }
 
@@ -175,6 +181,7 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 		MergeMethod:                      stringToMergeMethod(d.Get("merge_method").(string)),
 		OnlyAllowMergeIfPipelineSucceeds: gitlab.Bool(d.Get("only_allow_merge_if_pipeline_succeeds").(bool)),
 		OnlyAllowMergeIfAllDiscussionsAreResolved: gitlab.Bool(d.Get("only_allow_merge_if_all_discussions_are_resolved").(bool)),
+		SharedRunnersEnabled:                      gitlab.Bool(d.Get("shared_runners_enabled").(bool)),
 	}
 
 	if v, ok := d.GetOk("path"); ok {
@@ -286,6 +293,10 @@ func resourceGitlabProjectUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("snippets_enabled") {
 		options.SnippetsEnabled = gitlab.Bool(d.Get("snippets_enabled").(bool))
+	}
+
+	if d.HasChange("shared_runners_enabled") {
+		options.SharedRunnersEnabled = gitlab.Bool(d.Get("shared_runners_enabled").(bool))
 	}
 
 	if *options != (gitlab.EditProjectOptions{}) {

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -153,6 +153,25 @@ func TestAccGitlabProject_basic(t *testing.T) {
 					}),
 				),
 			},
+			// Disable shared runners in project
+			{
+				Config: testAccGitlabProjectDisableSharedRunners(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
+					testAccCheckGitlabProjectAttributes(&project, &testAccGitlabProjectExpectedAttributes{
+						Name:                 fmt.Sprintf("foo-%d", rInt),
+						Path:                 fmt.Sprintf("foo.%d", rInt),
+						Description:          "Terraform acceptance tests",
+						IssuesEnabled:        true,
+						MergeRequestsEnabled: true,
+						WikiEnabled:          true,
+						SnippetsEnabled:      true,
+						Visibility:           gitlab.PublicVisibility,
+						MergeMethod:          gitlab.FastForwardMerge,
+						SharedRunnersEnabled: false,
+					}),
+				),
+			},
 		},
 	})
 }
@@ -232,6 +251,7 @@ type testAccGitlabProjectExpectedAttributes struct {
 	Visibility                                gitlab.VisibilityValue
 	MergeMethod                               gitlab.MergeMethodValue
 	OnlyAllowMergeIfPipelineSucceeds          bool
+	SharedRunnersEnabled                      bool
 	OnlyAllowMergeIfAllDiscussionsAreResolved bool
 	SharedWithGroups                          []struct {
 		GroupID          int
@@ -456,4 +476,18 @@ resource "gitlab_group" "foo2" {
   visibility_level = "public"
 }
 	`, rInt, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccGitlabProjectDisableSharedRunners(rInt int) string {
+	return fmt.Sprintf(`
+		resource "gitlab_project" "foo" {
+  name = "foo-%d"
+  path = "foo.%d"
+  description = "Terraform acceptance tests"
+  visibility_level = "public"
+  merge_method = "ff"
+
+  shared_runners_enabled = false
+}
+	`, rInt, rInt)
 }

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -60,6 +60,8 @@ The following arguments are supported:
 
 * `only_allow_merge_if_all_discussions_are_resolved` - (Optional) Set to true if you want allow merges only if all discussions are resolved.
 
+* `shared_runners_enabled` - (Optional) Set to false to disable shared runners usage in the project ci pipelines.
+
 * `shared_with_groups` - (Optional) Enable sharing the project with a list of groups (maps).
   * `group_id` - (Required) Group id of the group you want to share the project with.
   * `group_access_level` - (Optional) Group's sharing permissions. See [group members permission][group_members_permissions] for more info.


### PR DESCRIPTION
Add new flag to enable/disable shared runners in a project. This PR doesn't require any dependency updates.