### PR TITLE
Add `tags` attribute for gitlab project

### DIFF
--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -28,6 +28,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						Name:                             fmt.Sprintf("foo-%d", rInt),
 						Path:                             fmt.Sprintf("foo.%d", rInt),
 						Description:                      "Terraform acceptance tests",
+						TagList:                          []string{"tag1"},
 						IssuesEnabled:                    true,
 						MergeRequestsEnabled:             true,
 						ApprovalsBeforeMerge:             0,
@@ -49,6 +50,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						Name:                             fmt.Sprintf("foo-%d", rInt),
 						Path:                             fmt.Sprintf("foo.%d", rInt),
 						Description:                      "Terraform acceptance tests!",
+						TagList:                          []string{"tag1", "tag2"},
 						ApprovalsBeforeMerge:             0,
 						Visibility:                       gitlab.PublicVisibility,
 						MergeMethod:                      gitlab.FastForwardMerge,
@@ -233,6 +235,7 @@ type testAccGitlabProjectExpectedAttributes struct {
 	MergeMethod                               gitlab.MergeMethodValue
 	OnlyAllowMergeIfPipelineSucceeds          bool
 	OnlyAllowMergeIfAllDiscussionsAreResolved bool
+	TagList                                   []string
 	SharedWithGroups                          []struct {
 		GroupID          int
 		GroupName        string
@@ -358,6 +361,10 @@ resource "gitlab_project" "foo" {
   path = "foo.%d"
   description = "Terraform acceptance tests"
 
+  tags = [
+	"tag1",
+  ]
+
   # So that acceptance tests can be run in a gitlab organization
   # with no billing
   visibility_level = "public"
@@ -374,6 +381,11 @@ resource "gitlab_project" "foo" {
   name = "foo-%d"
   path = "foo.%d"
   description = "Terraform acceptance tests!"
+
+  tags = [
+	"tag1",
+	"tag2",
+  ]
 
   # So that acceptance tests can be run in a gitlab organization
   # with no billing

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -145,3 +145,14 @@ var accessLevel = map[gitlab.AccessLevelValue]string{
 	gitlab.MaintainerPermissions: "maintainer",
 	gitlab.OwnerPermission:       "owner",
 }
+
+func stringSetToStringSlice(stringSet *schema.Set) *[]string {
+	ret := []string{}
+	if stringSet == nil {
+		return &ret
+	}
+	for _, envVal := range stringSet.List() {
+		ret = append(ret, envVal.(string))
+	}
+	return &ret
+}

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -36,6 +36,8 @@ The following arguments are supported:
 
 * `description` - (Optional) A description of the project.
 
+* `tags` - (Optional) Tags (topics) of the project.
+
 * `default_branch` - (Optional) The default branch for the project.
 
 * `issues_enabled` - (Optional) Enable issue tracking for the project.


### PR DESCRIPTION
This PR adds `tags` attribute to project resource.

**NOTE**: Project update won't work due to internal service error mentioned here https://github.com/terraform-providers/terraform-provider-gitlab/pull/105