### PR TITLE
website: make example server URL non-clickable

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported in the `provider` block:
   it can also be sourced from the `GITLAB_TOKEN` environment variable.
 
 * `base_url` - (Optional) This is the target GitLab base API endpoint. Providing a value is a
-  requirement when working with GitLab CE or GitLab Enterprise e.g. https://my.gitlab.server/api/v4/.
+  requirement when working with GitLab CE or GitLab Enterprise e.g. `https://my.gitlab.server/api/v4/`.
   It is optional to provide this value and it can also be sourced from the `GITLAB_BASE_URL` environment variable.
   The value must end with a slash.
 


### PR DESCRIPTION
The site's markdown processor tries to automatically turn URLs into links, but this one
doesn't go anywhere, so let's style it as a code span.