### PR TITLE
Fix project cluster acc test by adding a fake pem certificate

### DIFF
--- a/gitlab/resource_gitlab_project_cluster_test.go
+++ b/gitlab/resource_gitlab_project_cluster_test.go
@@ -28,6 +28,7 @@ func TestAccGitlabProjectCluster_basic(t *testing.T) {
 						Name:                        fmt.Sprintf("foo-cluster-%d", rInt),
 						EnvironmentScope:            "*",
 						KubernetesApiURL:            "https://123.123.123",
+						KubernetesCACert:            projectClusterFakeCert,
 						KubernetesAuthorizationType: "abac",
 					}),
 				),
@@ -41,7 +42,7 @@ func TestAccGitlabProjectCluster_basic(t *testing.T) {
 						Name:                        fmt.Sprintf("foo-cluster-%d", rInt),
 						EnvironmentScope:            "*",
 						KubernetesApiURL:            "https://124.124.124",
-						KubernetesCACert:            "some-cert",
+						KubernetesCACert:            projectClusterFakeCert,
 						KubernetesNamespace:         "changed-namespace",
 						KubernetesAuthorizationType: "abac",
 					}),
@@ -56,7 +57,7 @@ func TestAccGitlabProjectCluster_basic(t *testing.T) {
 						Name:                        fmt.Sprintf("foo-cluster-%d", rInt),
 						EnvironmentScope:            "*",
 						KubernetesApiURL:            "https://124.124.124",
-						KubernetesCACert:            "some-cert",
+						KubernetesCACert:            projectClusterFakeCert,
 						KubernetesNamespace:         "changed-namespace",
 						KubernetesAuthorizationType: "rbac",
 					}),
@@ -180,6 +181,12 @@ func testAccCheckGitlabProjectClusterAttributes(cluster *gitlab.ProjectCluster, 
 
 func testAccGitlabProjectClusterConfig(rInt int) string {
 	return fmt.Sprintf(`
+variable "cert" {
+  default = <<EOF
+%s
+EOF
+}
+
 resource "gitlab_project" "foo" {
   name = "foo-project-%d"
   description = "Terraform acceptance tests"
@@ -194,13 +201,20 @@ resource gitlab_project_cluster "foo" {
   name                          = "foo-cluster-%d"
   kubernetes_api_url            = "https://123.123.123"
   kubernetes_token              = "some-token"
+  kubernetes_ca_cert            = "${trimspace(var.cert)}"
   kubernetes_authorization_type = "abac"
 }
-`, rInt, rInt)
+`, projectClusterFakeCert, rInt, rInt)
 }
 
 func testAccGitlabProjectClusterUpdateConfig(rInt int, authType string) string {
 	return fmt.Sprintf(`
+variable "cert" {
+  default = <<EOF
+%s
+EOF
+}
+
 resource "gitlab_project" "foo" {
   name = "foo-project-%d"
   description = "Terraform acceptance tests"
@@ -215,9 +229,26 @@ resource gitlab_project_cluster "foo" {
   name                          = "foo-cluster-%d"
   kubernetes_api_url            = "https://124.124.124"
   kubernetes_token              = "some-token"
-  kubernetes_ca_cert            = "some-cert"
+  kubernetes_ca_cert            = "${trimspace(var.cert)}"
   kubernetes_namespace          = "changed-namespace"
   kubernetes_authorization_type = "%s"
 }
-`, rInt, rInt, authType)
+`, projectClusterFakeCert, rInt, rInt, authType)
 }
+
+var projectClusterFakeCert = `-----BEGIN CERTIFICATE-----
+MIICljCCAX4CCQDV7q2baHBlJjANBgkqhkiG9w0BAQsFADANMQswCQYDVQQGEwJV
+SzAeFw0xOTAzMjUxMTUxNTZaFw0xOTA0MjQxMTUxNTZaMA0xCzAJBgNVBAYTAlVL
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+bJAnlcGVMXjGdGcPFYf
+aAyAlJLdef22vmjFQUgUw8HvblpUrkHYjVxdvVvg5tNFGLvnCIBRITJ6CQfl3f2i
+ZL+SJCNZEWILt5TQTRQG09uab6An+ztm/XLJyHHUp0cEeI+aYifTuykB+cAxOLoA
++tWPq6i07Er+f/UcpntMxNi3b3LVpvdB5tcRvN6F2aXblLR3O7gvrmI4XA1u0Wba
+LwDRgbS5bLy/AkrrZm7XMuy4zlbWEAMI3tgRInS+ENYKPuY0Hl3cxJBsI5EQ+mFx
+aran+jYp7QQO/7VnrzRH7ZblWhcVKW9QoDFl78ZpT1sAwRif2ZFqMhw0sGiptLFb
+AwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCgVxkvDwQPtpmx0WNriKsr5WeMvb6r
+5DRhLOyyA7HncayAFCvAhk5M+x2wxWuuKzOPKsjSJpZDU0+2alVhZzzWbxSKoX7y
+oW8+2ioodyfrW5vCPLEMfyqg2VGh+0F8PadVL96GZL20WYxCJ3eCuM7NFXG2ZciB
+GJ48/0Tdc593QHg+19Jitq0xEL6V1dq5C5qhQxrikG3e3a+YYEZNCGwMj+2MhY2J
+Up9FUfSTZR1MzQFi/7Dr2zffyuzFZk7IXrvA0foBe0GKPtiWQJ0/JHqkZfbfAEYw
+c3fx6O/MhKijdlkbcpOanqD7PQEfUymTFLp2fZu2a1GRKIbfabGyyxGy
+-----END CERTIFICATE-----`


### PR DESCRIPTION
Fixes #111 

Related: https://about.gitlab.com/2019/03/22/gitlab-11-9-released/#validate-kubernetes-ca-certificate-format