### PR TITLE
add container_registry_enabled to project

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -75,6 +75,11 @@ func resourceGitlabProject() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"container_registry_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 			"visibility_level": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -157,6 +162,7 @@ func resourceGitlabProjectSetToState(d *schema.ResourceData, project *gitlab.Pro
 	d.Set("approvals_before_merge", project.ApprovalsBeforeMerge)
 	d.Set("wiki_enabled", project.WikiEnabled)
 	d.Set("snippets_enabled", project.SnippetsEnabled)
+	d.Set("container_registry_enabled", project.ContainerRegistryEnabled)
 	d.Set("visibility_level", string(project.Visibility))
 	d.Set("merge_method", string(project.MergeMethod))
 	d.Set("only_allow_merge_if_pipeline_succeeds", project.OnlyAllowMergeIfPipelineSucceeds)
@@ -179,6 +185,7 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 		ApprovalsBeforeMerge:             gitlab.Int(d.Get("approvals_before_merge").(int)),
 		WikiEnabled:                      gitlab.Bool(d.Get("wiki_enabled").(bool)),
 		SnippetsEnabled:                  gitlab.Bool(d.Get("snippets_enabled").(bool)),
+		ContainerRegistryEnabled:         gitlab.Bool(d.Get("container_registry_enabled").(bool)),
 		Visibility:                       stringToVisibilityLevel(d.Get("visibility_level").(string)),
 		MergeMethod:                      stringToMergeMethod(d.Get("merge_method").(string)),
 		OnlyAllowMergeIfPipelineSucceeds: gitlab.Bool(d.Get("only_allow_merge_if_pipeline_succeeds").(bool)),
@@ -302,6 +309,10 @@ func resourceGitlabProjectUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("tags") {
 		options.TagList = stringSetToStringSlice(d.Get("tags").(*schema.Set))
+	}
+
+	if d.HasChange("container_registry_enabled") {
+		options.ContainerRegistryEnabled = gitlab.Bool(d.Get("container_registry_enabled").(bool))
 	}
 
 	if *options != (gitlab.EditProjectOptions{}) {

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -34,6 +34,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						ApprovalsBeforeMerge:             0,
 						WikiEnabled:                      true,
 						SnippetsEnabled:                  true,
+						ContainerRegistryEnabled:         true,
 						Visibility:                       gitlab.PublicVisibility,
 						MergeMethod:                      gitlab.FastForwardMerge,
 						OnlyAllowMergeIfPipelineSucceeds: true,
@@ -52,6 +53,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						Description:                      "Terraform acceptance tests!",
 						TagList:                          []string{"tag1", "tag2"},
 						ApprovalsBeforeMerge:             0,
+						ContainerRegistryEnabled:         false,
 						Visibility:                       gitlab.PublicVisibility,
 						MergeMethod:                      gitlab.FastForwardMerge,
 						OnlyAllowMergeIfPipelineSucceeds: true,
@@ -73,6 +75,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						ApprovalsBeforeMerge:             0,
 						WikiEnabled:                      true,
 						SnippetsEnabled:                  true,
+						ContainerRegistryEnabled:         true,
 						Visibility:                       gitlab.PublicVisibility,
 						MergeMethod:                      gitlab.FastForwardMerge,
 						OnlyAllowMergeIfPipelineSucceeds: true,
@@ -93,6 +96,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						MergeRequestsEnabled:             true,
 						WikiEnabled:                      true,
 						SnippetsEnabled:                  true,
+						ContainerRegistryEnabled:         true,
 						Visibility:                       gitlab.PublicVisibility,
 						MergeMethod:                      gitlab.FastForwardMerge,
 						OnlyAllowMergeIfPipelineSucceeds: false,
@@ -118,6 +122,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						MergeRequestsEnabled:             true,
 						WikiEnabled:                      true,
 						SnippetsEnabled:                  true,
+						ContainerRegistryEnabled:         true,
 						Visibility:                       gitlab.PublicVisibility,
 						MergeMethod:                      gitlab.FastForwardMerge,
 						OnlyAllowMergeIfPipelineSucceeds: false,
@@ -143,6 +148,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						MergeRequestsEnabled:             true,
 						WikiEnabled:                      true,
 						SnippetsEnabled:                  true,
+						ContainerRegistryEnabled:         true,
 						Visibility:                       gitlab.PublicVisibility,
 						MergeMethod:                      gitlab.FastForwardMerge,
 						OnlyAllowMergeIfPipelineSucceeds: true,
@@ -231,6 +237,7 @@ type testAccGitlabProjectExpectedAttributes struct {
 	ApprovalsBeforeMerge                      int
 	WikiEnabled                               bool
 	SnippetsEnabled                           bool
+	ContainerRegistryEnabled                  bool
 	Visibility                                gitlab.VisibilityValue
 	MergeMethod                               gitlab.MergeMethodValue
 	OnlyAllowMergeIfPipelineSucceeds          bool
@@ -277,6 +284,10 @@ func testAccCheckGitlabProjectAttributes(project *gitlab.Project, want *testAccG
 
 		if project.SnippetsEnabled != want.SnippetsEnabled {
 			return fmt.Errorf("got snippets_enabled %t; want %t", project.SnippetsEnabled, want.SnippetsEnabled)
+		}
+
+		if project.ContainerRegistryEnabled != want.ContainerRegistryEnabled {
+			return fmt.Errorf("got container_registry_enabled %t; want %t", project.ContainerRegistryEnabled, want.ContainerRegistryEnabled)
 		}
 
 		if project.Visibility != want.Visibility {
@@ -399,6 +410,7 @@ resource "gitlab_project" "foo" {
   approvals_before_merge = 0
   wiki_enabled = false
   snippets_enabled = false
+  container_registry_enabled = false
 }
 	`, rInt, rInt)
 }

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -50,6 +50,8 @@ The following arguments are supported:
 
 * `snippets_enabled` - (Optional) Enable snippets for the project.
 
+* `container_registry_enabled` - (Optional) Enable container registry for the project.
+
 * `visibility_level` - (Optional) Set to `public` to create a public project.
   Valid values are `private`, `internal`, `public`.
   Repositories are created as private by default.


### PR DESCRIPTION
Implemented the `container_registry_enabled` attribute for the `gitlab_project` resource.
