### PR TITLE
Add GitLab Data Group

### DIFF
--- a/gitlab/data_source_gitlab_group.go
+++ b/gitlab/data_source_gitlab_group.go
@@ -1,0 +1,112 @@
+package gitlab
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/xanzy/go-gitlab"
+	"log"
+)
+
+func dataSourceGitlabGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGitlabGroupRead,
+		Schema: map[string]*schema.Schema{
+			"group_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+				Optional: true,
+				ConflictsWith: []string{
+					"full_path",
+				},
+			},
+			"full_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ConflictsWith: []string{
+					"name",
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"full_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"web_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"lfs_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"request_access_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"visibility_level": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"parent_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGitlabGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	var group *gitlab.Group
+	var err error
+
+	log.Printf("[INFO] Reading Gitlab group")
+
+	groupIDData, groupIDOk := d.GetOk("group_id")
+	fullPathData, fullPathOk := d.GetOk("full_path")
+
+	if groupIDOk {
+		// Get group by id
+		group, _, err = client.Groups.GetGroup(groupIDData.(int))
+		if err != nil {
+			return err
+		}
+	} else if fullPathOk {
+		// Get group by full path
+		group, _, err = client.Groups.GetGroup(fullPathData.(string))
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("one and only one of group_id or full_path must be set")
+	}
+
+	d.Set("group_id", group.ID)
+	d.Set("full_path", group.FullPath)
+	d.Set("name", group.Name)
+	d.Set("full_name", group.FullName)
+	d.Set("web_url", group.WebURL)
+	d.Set("path", group.Path)
+	d.Set("description", group.Description)
+	d.Set("lfs_enabled", group.LFSEnabled)
+	d.Set("request_access_enabled", group.RequestAccessEnabled)
+	d.Set("visibility_level", group.Visibility)
+	d.Set("parent_id", group.ParentID)
+
+	d.SetId(fmt.Sprintf("%d", group.ID))
+
+	return nil
+}

--- a/gitlab/data_source_gitlab_group.go
+++ b/gitlab/data_source_gitlab_group.go
@@ -24,7 +24,7 @@ func dataSourceGitlabGroup() *schema.Resource {
 				Computed: true,
 				Optional: true,
 				ConflictsWith: []string{
-					"name",
+					"group_id",
 				},
 			},
 			"name": {

--- a/gitlab/data_source_gitlab_group_test.go
+++ b/gitlab/data_source_gitlab_group_test.go
@@ -1,0 +1,111 @@
+package gitlab
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceGitlabGroup_basic(t *testing.T) {
+	rString := fmt.Sprintf("%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Get group using its ID
+			{
+				Config: testAccDataGitlabGroupByID(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceGitlabGroup("gitlab_group.foo", "data.gitlab_group.foo"),
+				),
+			},
+			// Get group using its full path
+			{
+				Config: testAccDataGitlabGroupByFullPath(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceGitlabGroup("gitlab_group.sub_foo", "data.gitlab_group.sub_foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGitlabGroup(src, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		group := s.RootModule().Resources[src]
+		groupResource := group.Primary.Attributes
+
+		search := s.RootModule().Resources[n]
+		searchResource := search.Primary.Attributes
+
+		testAttributes := []string{
+			"id",
+			"full_path",
+			"name",
+			"full_name",
+			"web_url",
+			"path",
+			"description",
+			"lfs_enabled",
+			"request_access_enabled",
+			"visibility_level",
+			"parent_id",
+		}
+
+		for _, attribute := range testAttributes {
+			if searchResource[attribute] != groupResource[attribute] {
+				return fmt.Errorf("expected group's parameter `%s` to be: %s, but got: `%s`", attribute, groupResource[attribute], searchResource[attribute])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDataGitlabGroupByID(rString string) string {
+	return fmt.Sprintf(`
+%s
+
+data "gitlab_group" "foo" {
+  group_id = "${gitlab_group.foo.id}"
+}
+`, testAccDataGitlabGroupSetup(rString))
+}
+
+func testAccDataGitlabGroupByFullPath(rString string) string {
+	return fmt.Sprintf(`
+%s
+
+data "gitlab_group" "sub_foo" {
+  full_path = "${gitlab_group.foo.path}/${gitlab_group.sub_foo.path}"
+}
+`, testAccDataGitlabGroupSetup(rString))
+}
+
+func testAccDataGitlabGroupSetup(rString string) string {
+	return fmt.Sprintf(`
+resource "gitlab_group" "foo" {
+  name = "foo-name-%[1]s"
+  path = "foo-path-%[1]s"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource "gitlab_group" "sub_foo" {
+  name      = "sub-foo-name-%[1]s"
+  path      = "sub-foo-path-%[1]s"
+  parent_id = "${gitlab_group.foo.id}"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+  `, rString)
+}

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -42,6 +42,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"gitlab_group":   dataSourceGitlabGroup(),
 			"gitlab_project": dataSourceGitlabProject(),
 			"gitlab_user":    dataSourceGitlabUser(),
 			"gitlab_users":   dataSourceGitlabUsers(),

--- a/gitlab/resource_gitlab_group.go
+++ b/gitlab/resource_gitlab_group.go
@@ -30,6 +30,18 @@ func resourceGitlabGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"full_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"full_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"web_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -108,6 +120,9 @@ func resourceGitlabGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(fmt.Sprintf("%d", group.ID))
 	d.Set("name", group.Name)
 	d.Set("path", group.Path)
+	d.Set("full_path", group.FullPath)
+	d.Set("full_name", group.FullName)
+	d.Set("web_url", group.WebURL)
 	d.Set("description", group.Description)
 	d.Set("lfs_enabled", group.LFSEnabled)
 	d.Set("request_access_enabled", group.RequestAccessEnabled)

--- a/website/docs/d/group.html.markdown
+++ b/website/docs/d/group.html.markdown
@@ -1,0 +1,67 @@
+---
+layout: "gitlab"
+page_title: "GitLab: gitlab_group"
+sidebar_current: "docs-gitlab-data-source-group"
+description: |-
+  Looks up a gitlab group
+---
+
+# gitlab\_group
+
+Provides details about a specific group in the gitlab provider.
+
+## Example Usage
+
+**By group's ID**
+
+```hcl
+data "gitlab_group" "foo" {
+  group_id = 123
+}
+```
+
+**By group's full path**
+
+```hcl
+data "gitlab_group" "foo" {
+  full_path = "foo/bar"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `group_id` - (Optional) The ID of the group.
+
+* `full_path` - (Optional) The full path of the group.
+
+**Note**: exactly one of group_id or full_path must be provided.
+
+## Attributes Reference
+
+The resource exports the following attributes:
+
+* `id` - The unique ID assigned to the group.
+
+* `name` - The name of this group.
+
+* `path` - The path of the group.
+
+* `description` - The description of the group.
+
+* `lfs_enabled` - Boolean, is LFS enabled for projects in this group.
+
+* `request_access_enabled` - Boolean, is request for access enabled to the group.
+
+* `visibility_level` - Visibility level of the group. Possible values are `private`, `internal`, `public`.
+
+* `parent_id` - Integer, ID of the parent group.
+  
+* `full_path` - The full path of the group.
+
+* `full_name` - The full name of the group.
+
+* `web_url` - Web URL of the group.
+
+[doc]: https://docs.gitlab.com/ee/api/groups.html#details-of-a-group

--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -56,6 +56,12 @@ The resource exports the following attributes:
 
 * `id` - The unique id assigned to the group by the GitLab server.  Serves as a
   namespace id where one is needed.
+  
+* `full_path` - The full path of the group.
+
+* `full_name` - The full name of the group.
+
+* `web_url` - Web URL of the group.
 
 ## Importing groups
 

--- a/website/gitlab.erb
+++ b/website/gitlab.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current("docs-gitlab-data-source") %>>
             <a href="#">Data Sources</a>
             <ul class="nav nav-visible">
+                <li<%= sidebar_current("docs-gitlab-data-source-group") %>>
+                    <a href="/docs/providers/gitlab/d/group.html">gitlab_group</a>
+                </li>
                 <li<%= sidebar_current("docs-gitlab-data-source-project") %>>
                     <a href="/docs/providers/gitlab/d/project.html">gitlab_project</a>
                 </li>


### PR DESCRIPTION
This PR adds a new data resource `gitlab_group`.
You can access GitLab group via `group_id` or `full_path`.

Fixes #103 

```hcl
data "gitlab_group" "foo1" {
  full_path = "foo/bar"
}
```
```hcl
data "gitlab_group" "foo2" {
  group_id = 123
}
```