### PR TITLE
Cleans up "project" resource schema and testing framework

### DIFF
--- a/gitlab/helper_test.go
+++ b/gitlab/helper_test.go
@@ -1,0 +1,38 @@
+package gitlab
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// testAccCompareGitLabAttribute compares an attribute in two ResourceData's for
+// equivalency.
+func testAccCompareGitLabAttribute(attr string, expected, received *schema.ResourceData) error {
+	e := expected.Get(attr)
+	r := received.Get(attr)
+	switch et := e.(type) {
+	case schema.Set:
+		if !et.Equal(r) {
+			return fmt.Errorf(`attribute set %s expected "%+v" received "%+v"`, attr, e, r)
+		}
+	default:
+		// Stringify to check because of type differences
+		if fmt.Sprintf("%v", e) != fmt.Sprintf("%v", r) {
+			return fmt.Errorf(`attribute %s expected "%+v" received "%+v"`, attr, e, r)
+		}
+	}
+	return nil
+}
+
+func testAccIsSkippedAttribute(needle string, haystack []string) bool {
+	if needle == "" {
+		return false
+	}
+	for _, hay := range haystack {
+		if hay == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -11,6 +11,134 @@ import (
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
+var resourceGitLabProjectSchema = map[string]*schema.Schema{
+	"name": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"path": {
+		Type:     schema.TypeString,
+		Optional: true,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			if new == "" {
+				return true
+			}
+			return old == new
+		},
+	},
+	"namespace_id": {
+		Type:     schema.TypeInt,
+		Optional: true,
+		ForceNew: true,
+		Computed: true,
+	},
+	"description": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"default_branch": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"issues_enabled": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+	},
+	"merge_requests_enabled": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+	},
+	"approvals_before_merge": {
+		Type:     schema.TypeInt,
+		Optional: true,
+		Default:  0,
+	},
+	"wiki_enabled": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+	},
+	"snippets_enabled": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+	},
+	"container_registry_enabled": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+	},
+	"visibility_level": {
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validation.StringInSlice([]string{"private", "internal", "public"}, true),
+		Default:      "private",
+	},
+	"merge_method": {
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validation.StringInSlice([]string{"merge", "rebase_merge", "ff"}, true),
+		Default:      "merge",
+	},
+	"only_allow_merge_if_pipeline_succeeds": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	},
+	"only_allow_merge_if_all_discussions_are_resolved": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	},
+	"ssh_url_to_repo": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"http_url_to_repo": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"web_url": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"runners_token": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"tags": {
+		Type:     schema.TypeSet,
+		Optional: true,
+		ForceNew: false,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+		Set:      schema.HashString,
+	},
+	"shared_with_groups": {
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"group_id": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"group_access_level": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"no one", "guest", "reporter", "developer", "maintainer"}, false),
+				},
+				"group_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	},
+}
+
 func resourceGitlabProject() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceGitlabProjectCreate,
@@ -20,134 +148,7 @@ func resourceGitlabProject() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"path": {
-				Type:     schema.TypeString,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if new == "" {
-						return true
-					}
-					return old == new
-				},
-			},
-			"namespace_id": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"default_branch": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"issues_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"merge_requests_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"approvals_before_merge": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  0,
-			},
-			"wiki_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"snippets_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"container_registry_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"visibility_level": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"private", "internal", "public"}, true),
-				Default:      "private",
-			},
-			"merge_method": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"merge", "rebase_merge", "ff"}, true),
-				Default:      "merge",
-			},
-			"only_allow_merge_if_pipeline_succeeds": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"only_allow_merge_if_all_discussions_are_resolved": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"ssh_url_to_repo": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"http_url_to_repo": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"web_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"runners_token": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"tags": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: false,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			"shared_with_groups": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"group_id": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						"group_access_level": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"no one", "guest", "reporter", "developer", "maintainer"}, false),
-						},
-						"group_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-		},
+		Schema: resourceGitLabProjectSchema,
 	}
 }
 
@@ -216,11 +217,8 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if v, ok := d.GetOk("shared_with_groups"); ok {
-		options := expandSharedWithGroupsOptions(v)
-
-		for _, option := range options {
-			_, err := client.Projects.ShareProjectWithGroup(project.ID, option)
-			if err != nil {
+		for _, option := range expandSharedWithGroupsOptions(v) {
+			if _, err := client.Projects.ShareProjectWithGroup(project.ID, option); err != nil {
 				return err
 			}
 		}

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -11,43 +12,47 @@ import (
 )
 
 func TestAccGitlabProject_basic(t *testing.T) {
-	var project gitlab.Project
+	var received, defaults gitlab.Project
 	rInt := acctest.RandInt()
+
+	defaults = gitlab.Project{
+		Namespace:                        &gitlab.ProjectNamespace{ID: 0},
+		Name:                             fmt.Sprintf("foo-%d", rInt),
+		Path:                             fmt.Sprintf("foo.%d", rInt),
+		Description:                      "Terraform acceptance tests",
+		TagList:                          []string{"tag1"},
+		IssuesEnabled:                    true,
+		MergeRequestsEnabled:             true,
+		ApprovalsBeforeMerge:             0,
+		WikiEnabled:                      true,
+		SnippetsEnabled:                  true,
+		ContainerRegistryEnabled:         true,
+		Visibility:                       gitlab.PublicVisibility,
+		MergeMethod:                      gitlab.FastForwardMerge,
+		OnlyAllowMergeIfPipelineSucceeds: true,
+		OnlyAllowMergeIfAllDiscussionsAreResolved: true,
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
-			// Create a project with all the features on
+			// Step0 Create a project with all the features on
 			{
 				Config: testAccGitlabProjectConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
-					testAccCheckGitlabProjectAttributes(&project, &testAccGitlabProjectExpectedAttributes{
-						Name:                             fmt.Sprintf("foo-%d", rInt),
-						Path:                             fmt.Sprintf("foo.%d", rInt),
-						Description:                      "Terraform acceptance tests",
-						TagList:                          []string{"tag1"},
-						IssuesEnabled:                    true,
-						MergeRequestsEnabled:             true,
-						ApprovalsBeforeMerge:             0,
-						WikiEnabled:                      true,
-						SnippetsEnabled:                  true,
-						ContainerRegistryEnabled:         true,
-						Visibility:                       gitlab.PublicVisibility,
-						MergeMethod:                      gitlab.FastForwardMerge,
-						OnlyAllowMergeIfPipelineSucceeds: true,
-						OnlyAllowMergeIfAllDiscussionsAreResolved: true,
-					}),
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &received),
+					testAccCheckAggregateGitlabProject(&defaults, &received),
 				),
 			},
-			// Update the project to turn the features off
+			// Step1 Update the project to turn the features off
 			{
 				Config: testAccGitlabProjectUpdateConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
-					testAccCheckGitlabProjectAttributes(&project, &testAccGitlabProjectExpectedAttributes{
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &received),
+					testAccCheckAggregateGitlabProject(&gitlab.Project{
+						Namespace:                        &gitlab.ProjectNamespace{ID: 0},
 						Name:                             fmt.Sprintf("foo-%d", rInt),
 						Path:                             fmt.Sprintf("foo.%d", rInt),
 						Description:                      "Terraform acceptance tests!",
@@ -58,63 +63,57 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						MergeMethod:                      gitlab.FastForwardMerge,
 						OnlyAllowMergeIfPipelineSucceeds: true,
 						OnlyAllowMergeIfAllDiscussionsAreResolved: true,
-					}),
+					}, &received),
 				),
 			},
-			// Update the project to turn the features on again
+			// Step2 Update the project to turn the features on again
 			{
 				Config: testAccGitlabProjectConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
-					testAccCheckGitlabProjectAttributes(&project, &testAccGitlabProjectExpectedAttributes{
-						Name:                             fmt.Sprintf("foo-%d", rInt),
-						Path:                             fmt.Sprintf("foo.%d", rInt),
-						Description:                      "Terraform acceptance tests",
-						IssuesEnabled:                    true,
-						MergeRequestsEnabled:             true,
-						ApprovalsBeforeMerge:             0,
-						WikiEnabled:                      true,
-						SnippetsEnabled:                  true,
-						ContainerRegistryEnabled:         true,
-						Visibility:                       gitlab.PublicVisibility,
-						MergeMethod:                      gitlab.FastForwardMerge,
-						OnlyAllowMergeIfPipelineSucceeds: true,
-						OnlyAllowMergeIfAllDiscussionsAreResolved: true,
-					}),
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &received),
+					testAccCheckAggregateGitlabProject(&defaults, &received),
 				),
 			},
-			//Update the project to share the project with a group
+			// Step3 Update the project to share the project with a group
 			{
 				Config: testAccGitlabProjectSharedWithGroup(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
-					testAccCheckGitlabProjectAttributes(&project, &testAccGitlabProjectExpectedAttributes{
-						Name:                             fmt.Sprintf("foo-%d", rInt),
-						Path:                             fmt.Sprintf("foo.%d", rInt),
-						Description:                      "Terraform acceptance tests",
-						IssuesEnabled:                    true,
-						MergeRequestsEnabled:             true,
-						WikiEnabled:                      true,
-						SnippetsEnabled:                  true,
-						ContainerRegistryEnabled:         true,
-						Visibility:                       gitlab.PublicVisibility,
-						MergeMethod:                      gitlab.FastForwardMerge,
-						OnlyAllowMergeIfPipelineSucceeds: false,
-						OnlyAllowMergeIfAllDiscussionsAreResolved: false,
-						SharedWithGroups: []struct {
-							GroupID          int
-							GroupName        string
-							GroupAccessLevel int
-						}{{0, fmt.Sprintf("foo-name-%d", rInt), 30}},
-					}),
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &received),
+					testAccCheckAggregateGitlabProject(
+						&gitlab.Project{
+							Namespace:                        &gitlab.ProjectNamespace{ID: 0},
+							Name:                             fmt.Sprintf("foo-%d", rInt),
+							Path:                             fmt.Sprintf("foo.%d", rInt),
+							Description:                      "Terraform acceptance tests",
+							IssuesEnabled:                    true,
+							MergeRequestsEnabled:             true,
+							WikiEnabled:                      true,
+							SnippetsEnabled:                  true,
+							ContainerRegistryEnabled:         true,
+							Visibility:                       gitlab.PublicVisibility,
+							MergeMethod:                      gitlab.FastForwardMerge,
+							OnlyAllowMergeIfPipelineSucceeds: false,
+							OnlyAllowMergeIfAllDiscussionsAreResolved: false,
+							TagList:              []string{},
+							ApprovalsBeforeMerge: 0,
+							SharedWithGroups: []struct {
+								GroupID          int    `json:"group_id"`
+								GroupName        string `json:"group_name"`
+								GroupAccessLevel int    `json:"group_access_level"`
+							}{
+								{0, fmt.Sprintf("foo-name-%d", rInt), 30},
+							},
+						},
+						&received),
 				),
 			},
-			//Update the project to share the project with more groups
+			// Step4 Update the project to share the project with more groups
 			{
 				Config: testAccGitlabProjectSharedWithGroup2(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
-					testAccCheckGitlabProjectAttributes(&project, &testAccGitlabProjectExpectedAttributes{
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &received),
+					testAccCheckAggregateGitlabProject(&gitlab.Project{
+						Namespace:                        &gitlab.ProjectNamespace{ID: 0},
 						Name:                             fmt.Sprintf("foo-%d", rInt),
 						Path:                             fmt.Sprintf("foo.%d", rInt),
 						Description:                      "Terraform acceptance tests",
@@ -128,37 +127,77 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						OnlyAllowMergeIfPipelineSucceeds: false,
 						OnlyAllowMergeIfAllDiscussionsAreResolved: false,
 						SharedWithGroups: []struct {
-							GroupID          int
-							GroupName        string
-							GroupAccessLevel int
-						}{{0, fmt.Sprintf("foo-name-%d", rInt), 10}, {0, fmt.Sprintf("foo2-name-%d", rInt), 30}},
-					}),
+							GroupID          int    `json:"group_id"`
+							GroupName        string `json:"group_name"`
+							GroupAccessLevel int    `json:"group_access_level"`
+						}{
+							{0, fmt.Sprintf("foo-name-%d", rInt), 10},
+							{0, fmt.Sprintf("foo2-name-%d", rInt), 30},
+						},
+					}, &received),
 				),
 			},
-			//Update the project to unshare the project
+			// Step5 Update the project to unshare the project
 			{
 				Config: testAccGitlabProjectConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
-					testAccCheckGitlabProjectAttributes(&project, &testAccGitlabProjectExpectedAttributes{
-						Name:                             fmt.Sprintf("foo-%d", rInt),
-						Path:                             fmt.Sprintf("foo.%d", rInt),
-						Description:                      "Terraform acceptance tests",
-						IssuesEnabled:                    true,
-						MergeRequestsEnabled:             true,
-						WikiEnabled:                      true,
-						SnippetsEnabled:                  true,
-						ContainerRegistryEnabled:         true,
-						Visibility:                       gitlab.PublicVisibility,
-						MergeMethod:                      gitlab.FastForwardMerge,
-						OnlyAllowMergeIfPipelineSucceeds: true,
-						OnlyAllowMergeIfAllDiscussionsAreResolved: true,
-						SharedWithGroups: []struct {
-							GroupID          int
-							GroupName        string
-							GroupAccessLevel int
-						}{},
-					}),
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &received),
+					testAccCheckAggregateGitlabProject(&defaults, &received),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGitlabProject_willError(t *testing.T) {
+	var received, defaults gitlab.Project
+	rInt := acctest.RandInt()
+	defaults = gitlab.Project{
+		Namespace:                        &gitlab.ProjectNamespace{ID: 0},
+		Name:                             fmt.Sprintf("foo-%d", rInt),
+		Path:                             fmt.Sprintf("foo.%d", rInt),
+		Description:                      "Terraform acceptance tests",
+		TagList:                          []string{"tag1"},
+		IssuesEnabled:                    true,
+		MergeRequestsEnabled:             true,
+		ApprovalsBeforeMerge:             0,
+		WikiEnabled:                      true,
+		SnippetsEnabled:                  true,
+		ContainerRegistryEnabled:         true,
+		Visibility:                       gitlab.PublicVisibility,
+		MergeMethod:                      gitlab.FastForwardMerge,
+		OnlyAllowMergeIfPipelineSucceeds: true,
+		OnlyAllowMergeIfAllDiscussionsAreResolved: true,
+	}
+	willError := defaults
+	willError.TagList = []string{"notatag"}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabProjectDestroy,
+		Steps: []resource.TestStep{
+			// Step0 Create a project
+			{
+				Config: testAccGitlabProjectConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &received),
+					testAccCheckAggregateGitlabProject(&defaults, &received),
+				),
+			},
+			// Step1 Verify that passing bad values will fail.
+			{
+				Config:      testAccGitlabProjectConfig(rInt),
+				ExpectError: regexp.MustCompile(`\stags\sexpected\s.+notatag.+\sreceived`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAggregateGitlabProject(&willError, &received),
+				),
+			},
+			// Step2 Reset
+			{
+				Config: testAccGitlabProjectConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &received),
+					testAccCheckAggregateGitlabProject(&defaults, &received),
 				),
 			},
 		},
@@ -167,7 +206,6 @@ func TestAccGitlabProject_basic(t *testing.T) {
 
 func TestAccGitlabProject_import(t *testing.T) {
 	rInt := acctest.RandInt()
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -187,7 +225,6 @@ func TestAccGitlabProject_import(t *testing.T) {
 
 func TestAccGitlabProject_nestedImport(t *testing.T) {
 	rInt := acctest.RandInt()
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -207,130 +244,29 @@ func TestAccGitlabProject_nestedImport(t *testing.T) {
 
 func testAccCheckGitlabProjectExists(n string, project *gitlab.Project) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		var err error
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not Found: %s", n)
 		}
-
 		repoName := rs.Primary.ID
 		if repoName == "" {
 			return fmt.Errorf("No project ID is set")
 		}
 		conn := testAccProvider.Meta().(*gitlab.Client)
-
-		gotProject, _, err := conn.Projects.GetProject(repoName, nil)
-		if err != nil {
-			return err
+		if g, _, err := conn.Projects.GetProject(repoName, nil); err == nil {
+			*project = *g
 		}
-		*project = *gotProject
-		return nil
-	}
-}
-
-type testAccGitlabProjectExpectedAttributes struct {
-	Name                                      string
-	Path                                      string
-	Description                               string
-	DefaultBranch                             string
-	IssuesEnabled                             bool
-	MergeRequestsEnabled                      bool
-	ApprovalsBeforeMerge                      int
-	WikiEnabled                               bool
-	SnippetsEnabled                           bool
-	ContainerRegistryEnabled                  bool
-	Visibility                                gitlab.VisibilityValue
-	MergeMethod                               gitlab.MergeMethodValue
-	OnlyAllowMergeIfPipelineSucceeds          bool
-	OnlyAllowMergeIfAllDiscussionsAreResolved bool
-	TagList                                   []string
-	SharedWithGroups                          []struct {
-		GroupID          int
-		GroupName        string
-		GroupAccessLevel int
-	}
-}
-
-func testAccCheckGitlabProjectAttributes(project *gitlab.Project, want *testAccGitlabProjectExpectedAttributes) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if project.Name != want.Name {
-			return fmt.Errorf("got repo %q; want %q", project.Name, want.Name)
-		}
-		if project.Path != want.Path {
-			return fmt.Errorf("got repo %q; want %q", project.Path, want.Path)
-		}
-		if project.Description != want.Description {
-			return fmt.Errorf("got description %q; want %q", project.Description, want.Description)
-		}
-
-		if project.DefaultBranch != want.DefaultBranch {
-			return fmt.Errorf("got default_branch %q; want %q", project.DefaultBranch, want.DefaultBranch)
-		}
-
-		if project.IssuesEnabled != want.IssuesEnabled {
-			return fmt.Errorf("got issues_enabled %t; want %t", project.IssuesEnabled, want.IssuesEnabled)
-		}
-
-		if project.MergeRequestsEnabled != want.MergeRequestsEnabled {
-			return fmt.Errorf("got merge_requests_enabled %t; want %t", project.MergeRequestsEnabled, want.MergeRequestsEnabled)
-		}
-
-		if project.ApprovalsBeforeMerge != want.ApprovalsBeforeMerge {
-			return fmt.Errorf("got approvals_before_merge %d; want %d", project.ApprovalsBeforeMerge, want.ApprovalsBeforeMerge)
-		}
-
-		if project.WikiEnabled != want.WikiEnabled {
-			return fmt.Errorf("got wiki_enabled %t; want %t", project.WikiEnabled, want.WikiEnabled)
-		}
-
-		if project.SnippetsEnabled != want.SnippetsEnabled {
-			return fmt.Errorf("got snippets_enabled %t; want %t", project.SnippetsEnabled, want.SnippetsEnabled)
-		}
-
-		if project.ContainerRegistryEnabled != want.ContainerRegistryEnabled {
-			return fmt.Errorf("got container_registry_enabled %t; want %t", project.ContainerRegistryEnabled, want.ContainerRegistryEnabled)
-		}
-
-		if project.Visibility != want.Visibility {
-			return fmt.Errorf("got visibility %q; want %q", project.Visibility, want.Visibility)
-		}
-
-		groupsToCheck := want.SharedWithGroups
-		for _, group := range project.SharedWithGroups {
-			for i, groupToCheck := range groupsToCheck {
-				if group.GroupName == groupToCheck.GroupName && group.GroupAccessLevel == groupToCheck.GroupAccessLevel {
-					groupsToCheck = append(groupsToCheck[:i], groupsToCheck[i+1:]...)
-					break
-				}
-			}
-		}
-		if len(groupsToCheck) != 0 {
-			return fmt.Errorf("got shared with groups: %v; want %v", project.SharedWithGroups, want.SharedWithGroups)
-		}
-
-		if project.MergeMethod != want.MergeMethod {
-			return fmt.Errorf("got merge_method %q; want %q", project.MergeMethod, want.MergeMethod)
-		}
-
-		if project.OnlyAllowMergeIfPipelineSucceeds != want.OnlyAllowMergeIfPipelineSucceeds {
-			return fmt.Errorf("got only_allow_merge_if_pipeline_succeeds %t; want %t", project.OnlyAllowMergeIfPipelineSucceeds, want.OnlyAllowMergeIfPipelineSucceeds)
-		}
-
-		if project.OnlyAllowMergeIfAllDiscussionsAreResolved != want.OnlyAllowMergeIfAllDiscussionsAreResolved {
-			return fmt.Errorf("got only_allow_merge_if_all_discussions_are_resolved %t; want %t", project.OnlyAllowMergeIfAllDiscussionsAreResolved, want.OnlyAllowMergeIfAllDiscussionsAreResolved)
-		}
-
-		return nil
+		return err
 	}
 }
 
 func testAccCheckGitlabProjectDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*gitlab.Client)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gitlab_project" {
 			continue
 		}
-
 		gotRepo, resp, err := conn.Projects.GetProject(rs.Primary.ID, nil)
 		if err == nil {
 			if gotRepo != nil && fmt.Sprintf("%d", gotRepo.ID) == rs.Primary.ID {
@@ -343,6 +279,66 @@ func testAccCheckGitlabProjectDestroy(s *terraform.State) error {
 		return nil
 	}
 	return nil
+}
+
+// testAccSkipGitLabProjectAttributes are Resource attributes that should be
+// skipped and handled another way, e.g. shared_with_groups
+var testAccSkipGitLabProjectAttributes = []string{
+	"shared_with_groups",
+}
+
+func testAccCheckAggregateGitlabProject(expected, received *gitlab.Project) resource.TestCheckFunc {
+	checks := []resource.TestCheckFunc{
+		testAccCheckGitLabProjectGroups(expected, received),
+	}
+	testResource := resourceGitlabProject()
+	expectedData := testResource.TestResourceData()
+	receivedData := testResource.TestResourceData()
+	for a, v := range testResource.Schema {
+		attribute := a
+		attrValue := v
+		checks = append(checks, func(_ *terraform.State) error {
+			if testAccIsSkippedAttribute(attribute, testAccSkipGitLabProjectAttributes) {
+				return nil // skipping because we said so.
+			}
+			if attrValue.Computed {
+				if attrDefault, err := attrValue.DefaultValue(); err == nil {
+					if attrDefault == nil {
+						return nil // Skipping because we have no way of pre-computing computed vars
+					}
+				} else {
+					return err
+				}
+
+			}
+			resourceGitlabProjectSetToState(expectedData, expected)
+			resourceGitlabProjectSetToState(receivedData, received)
+			return testAccCompareGitLabAttribute(attribute, expectedData, receivedData)
+		})
+	}
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+func testAccCheckGitLabProjectGroups(expected, received *gitlab.Project) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		groupsToCheck := expected.SharedWithGroups
+		for _, group := range received.SharedWithGroups {
+			for i, groupToCheck := range groupsToCheck {
+				if group.GroupName == groupToCheck.GroupName &&
+					group.GroupAccessLevel == groupToCheck.GroupAccessLevel {
+					groupsToCheck = append(groupsToCheck[:i], groupsToCheck[i+1:]...)
+					break
+				}
+			}
+		}
+		if len(groupsToCheck) != 0 {
+			return fmt.Errorf(
+				`attribute shared_with_groups expected "%v" received "%v"`,
+				received.SharedWithGroups,
+				expected.SharedWithGroups)
+		}
+		return nil
+	}
 }
 
 func testAccGitlabProjectInGroupConfig(rInt int) string {

--- a/scripts/generate-access-token.rb
+++ b/scripts/generate-access-token.rb
@@ -1,3 +1,0 @@
-terraform_token = PersonalAccessToken.create(user_id: 1, scopes: [:api, :read_user], name: :terraform)
-terraform_token.set_token(:ACCTEST)
-terraform_token.save!

--- a/scripts/start-gitlab.sh
+++ b/scripts/start-gitlab.sh
@@ -1,16 +1,31 @@
 #!/bin/bash -e
-if [[ $MAKE_TARGET != "testacc" ]]; then echo "not starting gitlab!"; exit 0; fi
+test "$MAKE_TARGET" == "testacc" || { echo "not starting gitlab!"; exit 0; }
 echo "Starting gitlab container..."
-docker run -d -e GITLAB_ROOT_PASSWORD=adminadmin --rm -p 127.0.0.1:8080:80 --name gitlab gitlab/gitlab-ce
+docker run -d --rm --name gitlab \
+  -e GITLAB_ROOT_PASSWORD=adminadmin \
+  -p 127.0.0.1:8080:80 \
+  gitlab/gitlab-ce
+
 echo -n "Waiting for gitlab to be ready "
 i=1
-until wget -t 1 127.0.0.1:8080 -O /dev/null -q 
+until wget -t 1 127.0.0.1:8080 -O /dev/null -q
 do
     sleep 1
     echo -n .
     if [[ $((i%3)) == 0 ]]; then echo -n ' '; fi
-    let i++
+    (( i++ ))
 done
+
 echo
 echo "Creating access token"
-docker exec -i gitlab gitlab-rails console < scripts/generate-access-token.rb
+(
+  echo -n 'terraform_token = PersonalAccessToken.create('
+  echo -n 'user_id: 1, '
+  echo -n 'scopes: [:api, :read_user], '
+  echo -n 'name: :terraform);'
+  echo -n "terraform_token.set_token('${GITLAB_TOKEN:=ACCTEST}');"
+  echo -n 'terraform_token.save!;'
+) |
+docker exec -i gitlab gitlab-rails console
+
+


### PR DESCRIPTION
Uses the *gitlab.Project struct and resource Schema to test the resulting values.

Removes the extra generate access token file and updates the access token value to be generated from a variable (with a default).