### PR TITLE
Add support for managed clusters

### DIFF
--- a/gitlab/resource_gitlab_project_cluster.go
+++ b/gitlab/resource_gitlab_project_cluster.go
@@ -40,6 +40,12 @@ func resourceGitlabProjectCluster() *schema.Resource {
 				Default:  true,
 				ForceNew: true,
 			},
+			"managed": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
 			"created_at": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -113,6 +119,7 @@ func resourceGitlabProjectClusterCreate(d *schema.ResourceData, meta interface{}
 	options := &gitlab.AddClusterOptions{
 		Name:               gitlab.String(d.Get("name").(string)),
 		Enabled:            gitlab.Bool(d.Get("enabled").(bool)),
+		Managed:            gitlab.Bool(d.Get("managed").(bool)),
 		PlatformKubernetes: &pk,
 	}
 

--- a/gitlab/resource_gitlab_project_cluster_test.go
+++ b/gitlab/resource_gitlab_project_cluster_test.go
@@ -85,7 +85,7 @@ func TestAccGitlabProjectCluster_import(t *testing.T) {
 				ResourceName:            "gitlab_project_cluster.foo",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"enabled", "kubernetes_token"},
+				ImportStateVerifyIgnore: []string{"enabled", "kubernetes_token", "managed"},
 			},
 		},
 	})

--- a/website/docs/r/project_cluster.html.markdown
+++ b/website/docs/r/project_cluster.html.markdown
@@ -44,16 +44,18 @@ The following arguments are supported:
 
 * `domain` - (Optional, string) The base domain of the cluster.
 
-* `enabled` - (Optional, boolean) Determines if cluster is active or not. Defaults to `true`.
+* `enabled` - (Optional, boolean) Determines if cluster is active or not. Defaults to `true`. This attribute cannot be read.
+
+* `managed` - (Optional, boolean) Determines if cluster is managed by gitlab or not. Defaults to `true`. This attribute cannot be read.
 
 * `kubernetes_api_url` - (Required, string) The URL to access the Kubernetes API.
 
 * `kubernetes_token` - (Required, string) The token to authenticate against Kubernetes.
- 
+
 * `kubernetes_ca_cert` - (Optional, string) TLS certificate (needed if API is using a self-signed TLS certificate).
- 
+
 * `kubernetes_namespace` - (Optional, string) The unique namespace related to the project.
- 
+
 * `kubernetes_authorization_type` - (Optional, string) The cluster authorization type. Valid values are `rbac`, `abac`, `unknown_authorization`. Defaults to `rbac`.
 
 * `environment_scope` - (Optional, string) The associated environment to the cluster. Defaults to `*`.


### PR DESCRIPTION
The gitlab api has a "managed" field to disable cluster management features when adding a kubernetes cluster. This implements that field. Default is true if you don't supply it.

This can only be toggled at cluster creation time, so changes will delete and readd the integration.

https://docs.gitlab.com/ee/api/project_clusters.html#add-existing-cluster-to-project

This also upgrades go-gitlab to an unreleased version that includes this field, which may be problematic.

I've run this fork for a few days successfully, and it has behaved as I expect it to.
