### PR TITLE
Fix documentation group to use parent_id

### DIFF
--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -24,7 +24,7 @@ resource "gitlab_group" "example" {
 resource "gitlab_project" "example" {
   name         = "example"
   description  = "An example project"
-  namespace_id = "${gitlab_group.example.id}"
+  parent_id = "${gitlab_group.example.id}"
 }
 ```
 


### PR DESCRIPTION
The example incorrectly states the `namespace_id` key.