### PR TITLE
Add import_url attribute to project resource to allow importing repository from URL.

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -76,6 +76,10 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 		ValidateFunc: validation.StringInSlice([]string{"private", "internal", "public"}, true),
 		Default:      "private",
 	},
+	"import_url": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
 	"merge_method": {
 		Type:         schema.TypeString,
 		Optional:     true,
@@ -214,6 +218,10 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("tags"); ok {
 		options.TagList = stringSetToStringSlice(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("import_url"); ok {
+		options.ImportURL = gitlab.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] create gitlab project %q", *options.Name)


### PR DESCRIPTION
This resolves issue #42 .

Although I succesfully tested it with a locally running gitlab instance, unfortunately for now acceptance tests for import_url attribute are missing. From my understanding the requirements for such tests to fit the other tests approach are:
1. Before creating actual test gitlab project, create dummy gitlab project, which can be imported in the actual test.
2. Run actual test.
3. Check if import succeeded.
4. Remove dummy gitlab project.

Apart from that an already existing git repo url could be used for the test e.g. this repo itself. Although still a check would be needed to see if import was successful. 

What do you guys suggest?