### PR TITLE
Avoid switching the default branch to null if omitted

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -39,6 +39,19 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 	"default_branch": {
 		Type:     schema.TypeString,
 		Optional: true,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			// If the old default branch is empty, it means that the project does not
+			// have a default branch. This can only happen if the project does not have
+			// branches, i.e. it is an empty project. In that case it is useless to
+			// try setting a specific default branch (because no branch exists).
+			// This code will defer the setting of a default branch to a time when the
+			// project is no longer empty.
+			if old == "" {
+				return true
+			}
+
+			return old == new
+		},
 	},
 	"issues_enabled": {
 		Type:     schema.TypeBool,


### PR DESCRIPTION
If a gitlab_project resource does not include the default_branch attribute, terraform would set the default branch to null.
The scenario is as follows

1. create a terraform file defining a gitlab_project without the default_branch attribute
2. execute terraform apply to create the project in GitLab
3. push code to the new project, thus creating the master branch. This would make the master branch the defualt branch.
4. run again terraform apply. Terraform would reset the default branch, setting it to null.

Setting the default branch equal to master in the terraform file, would make the first terraform apply fail. This is because terraform would attempt to set the defult branch to master, but this branch does not exist yet.