### PR TITLE
Update Jira service: don't delete service from state on 404 errors

### DIFF
--- a/gitlab/resource_gitlab_service_jira.go
+++ b/gitlab/resource_gitlab_service_jira.go
@@ -95,13 +95,8 @@ func resourceGitlabServiceJiraRead(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[DEBUG] Read Gitlab Jira service %s", d.Id())
 
-	jiraService, response, err := client.Services.GetJiraService(project)
+	jiraService, _, err := client.Services.GetJiraService(project)
 	if err != nil {
-		if response.StatusCode == 404 {
-			log.Printf("[WARN] removing Jira service from state because it no longer exists in Gitlab")
-			d.SetId("")
-			return nil
-		}
 		return err
 	}
 


### PR DESCRIPTION
Hi,

This is a quick fix for #101 as requested by @roidelapluie that avoid deleting service from state on 404 errors since Gitlab makes no difference between 403 & 404 for security reasons.

Thanks,