### PR TITLE
Implement the `archived` attribute on Project data source and resource 

### DIFF
--- a/gitlab/data_source_gitlab_project.go
+++ b/gitlab/data_source_gitlab_project.go
@@ -87,6 +87,11 @@ func dataSourceGitlabProject() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"archived": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -118,5 +123,6 @@ func dataSourceGitlabProjectRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("http_url_to_repo", found.HTTPURLToRepo)
 	d.Set("web_url", found.WebURL)
 	d.Set("runners_token", found.RunnersToken)
+	d.Set("archived", found.Archived)
 	return nil
 }

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -368,9 +368,13 @@ func resourceGitlabProjectUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	// TODO: handle partial state update
 	if d.HasChange("shared_with_groups") {
-		updateSharedWithGroups(d, meta)
+		err := updateSharedWithGroups(d, meta)
+		// TODO: check if handling partial state update in this simplistic
+		// way is ok when an error in the "shared groups" API calls occurs
+		if err != nil {
+			d.SetPartial("shared_with_groups")
+		}
 	}
 
 	if d.HasChange("archived") {

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -32,6 +32,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 		MergeMethod:                      gitlab.FastForwardMerge,
 		OnlyAllowMergeIfPipelineSucceeds: true,
 		OnlyAllowMergeIfAllDiscussionsAreResolved: true,
+		Archived: false, // needless, but let's make this explicit
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -39,7 +40,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
-			// Step0 Create a project with all the features on
+			// Step0 Create a project with all the features on (note: "archived" is "false")
 			{
 				Config: testAccGitlabProjectConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
@@ -47,7 +48,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 					testAccCheckAggregateGitlabProject(&defaults, &received),
 				),
 			},
-			// Step1 Update the project to turn the features off
+			// Step1 Update the project to turn the features off (note: "archived" is "true")
 			{
 				Config: testAccGitlabProjectUpdateConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
@@ -65,10 +66,11 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						MergeMethod:                      gitlab.FastForwardMerge,
 						OnlyAllowMergeIfPipelineSucceeds: true,
 						OnlyAllowMergeIfAllDiscussionsAreResolved: true,
+						Archived: true,
 					}, &received),
 				),
 			},
-			// Step2 Update the project to turn the features on again
+			// Step2 Update the project to turn the features on again (note: "archived" is "false")
 			{
 				Config: testAccGitlabProjectConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
@@ -411,7 +413,8 @@ resource "gitlab_project" "foo" {
   wiki_enabled = false
   snippets_enabled = false
   container_registry_enabled = false
-  shared_runners_enabled = false
+	shared_runners_enabled = false
+	archived = true
 }
 	`, rInt, rInt)
 }

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -58,3 +58,5 @@ The following attributes are exported:
 * `web_url` - URL that can be used to find the project in a browser.
 
 * `runners_token` - Registration token to use during runner setup.
+
+* `archived` - Whether the project is in read-only mode (archived).

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -71,6 +71,8 @@ The following arguments are supported:
   * `group_access_level` - (Optional) Group's sharing permissions. See [group members permission][group_members_permissions] for more info.
   Valid values are `guest`, `reporter`, `developer`, `master`.
 
+* `archived` - (Optional) Whether the project is in read-only mode (archived). Repositories can be archived/unarchived by toggling this parameter.
+
 ## Attributes Reference
 
 The following additional attributes are exported:

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `shared_with_groups` - (Optional) Enable sharing the project with a list of groups (maps).
   * `group_id` - (Required) Group id of the group you want to share the project with.
-  * `group_access_level` - (Optional) Group's sharing permissions. See [group members permission][group_members_permissions] for more info.
+  * `group_access_level` - (Required) Group's sharing permissions. See [group members permission][group_members_permissions] for more info.
   Valid values are `guest`, `reporter`, `developer`, `master`.
 
 * `archived` - (Optional) Whether the project is in read-only mode (archived). Repositories can be archived/unarchived by toggling this parameter.


### PR DESCRIPTION
Hallo, I'm proposing in this PR a few changes to enable the management of the `archived` attribute on both the `gitlab_project` resource and data source.
In doing so I had to implement partial state update in the project's update method, since the existing project properties update logic and the new archiving/unarchiving operation require different API calls, which may fail independently. 
In the process I also noticed that the existing code to handle the `shared_with_groups` attribute in the `gitlab_project` resource method does not seem to handle errors which are swallowed altogether. Since this attribute, just like the `archived` attribute, requires its own different API call, I expected it to use partial state updates in order to avoid an inconsistent state in case of failure.
I updated the acceptance tests and the documentation for both resource and datasource.
Hope this helps!