### PR TITLE
Tag protection generates the wrong URL

### DIFF
--- a/gitlab/resource_gitlab_tag_protection.go
+++ b/gitlab/resource_gitlab_tag_protection.go
@@ -2,7 +2,6 @@ package gitlab
 
 import (
 	"log"
-	"net/url"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -55,7 +54,7 @@ func resourceGitlabTagProtectionCreate(d *schema.ResourceData, meta interface{})
 	tp, _, err := client.ProtectedTags.ProtectRepositoryTags(project, options)
 	if err != nil {
 		// Remove existing tag protection
-		_, err = client.ProtectedTags.UnprotectRepositoryTags(project, url.PathEscape(*tag))
+		_, err = client.ProtectedTags.UnprotectRepositoryTags(project, *tag)
 		if err != nil {
 			return err
 		}
@@ -80,7 +79,7 @@ func resourceGitlabTagProtectionRead(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] read gitlab tag protection for project %s, tag %s", project, tag)
 
-	pt, _, err := client.ProtectedTags.GetProtectedTag(project, url.PathEscape(tag))
+	pt, _, err := client.ProtectedTags.GetProtectedTag(project, tag)
 	if err != nil {
 		return err
 	}
@@ -101,7 +100,7 @@ func resourceGitlabTagProtectionDelete(d *schema.ResourceData, meta interface{})
 
 	log.Printf("[DEBUG] Delete gitlab protected tag %s for project %s", tag, project)
 
-	_, err := client.ProtectedTags.UnprotectRepositoryTags(project, url.PathEscape(tag))
+	_, err := client.ProtectedTags.UnprotectRepositoryTags(project, tag)
 	return err
 }
 


### PR DESCRIPTION
When protecting a tag containing a wildcard (like v*), the terraform plugin generates an invalid URL and thus fails to protect it.

For example, the Terraform log contains:
2019/06/24 12:28:39 [DEBUG] read gitlab tag protection for project 38, tag v*
2019/06/24 12:28:39 [DEBUG] GitLab API Request Details:
---[ REQUEST ]---------------------------------------
GET /api/v4/projects/38/protected_tags/v%252A HTTP/1.1
Host: 10.164.61.17
User-Agent: go-gitlab
Accept: application/json
Private-Token: nyPXE9zGT9aisyXvpWyG
Accept-Encoding: gzip

This is the REST call that checks if a protected tag has been correctly created, after the creation occurred. The URL is completely broken (it includes a double URL encoding). The GitLab server answers with a 404 return code.

Branches work correctly:
2019/06/24 12:28:39 [DEBUG] read gitlab branch protection for project 38, branch release-*
2019/06/24 12:28:39 [DEBUG] GitLab API Request Details:
---[ REQUEST ]---------------------------------------
GET /api/v4/projects/38/protected_branches/release-* HTTP/1.1
Host: 10.164.61.17
User-Agent: go-gitlab
Accept: application/json
Private-Token: nyPXE9zGT9aisyXvpWyG
Accept-Encoding: gzip

So I aligned the code for protecting tags to the used code for protecting branches, thus removing the URL encoding. I think this issue is now visible because of changes in pull request #130 that made the code fail when the server returns 404.
