### PR TITLE
Do not enforce the default_branch in an empty repository

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -39,6 +39,19 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 	"default_branch": {
 		Type:     schema.TypeString,
 		Optional: true,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			// If the old default branch is empty, it means that the project does not
+			// have a default branch. This can only happen if the project does not have
+			// branches, i.e. it is an empty project. In that case it is useless to
+			// try setting a specific default branch (because no branch exists).
+			// This code will defer the setting of a default branch to a time when the
+			// project is no longer empty.
+			if old == "" {
+				return true
+			}
+
+			return old == new
+		},
 	},
 	"issues_enabled": {
 		Type:     schema.TypeBool,


### PR DESCRIPTION
Currently, when defining a repository resource, the provider attempts to set a default branch even if the repository is empty (no branch).

Consider the following scenario:
1. Define a gitlab repository resource and set the default_branch attribute to "master"
2. Run terraform apply; terraform creates the repository, but gitlab sets the default branch to null, because the repository is empty (no branch has been created yet)
3. run again terraform apply; the terraform provider refreshes the project state and discovers that the default branch is set to null, while the resource description requires master. It tries to update the repository, setting the default branch; but the master branch does not exist, thus the operation fails.

With the changes in this pull request, the provider discards any difference to the default_branch attribute until the attribute value is null on Gitlab.In fact a null value simply means that there is no branch in the Gitlab repository; as soon as the first branch gets created, Gitlab automatically sets the default branch to this initial branch. My understanding is that from that time on, while it will be possible to change the default branch, it will not be possible to change it back to a null value.

I also updated the unit tests to check that: setting default_branch = "master"
1. does not generate any failure during the updates
2. behaves as expected after creating the master branch (i.e. the first branch) in the repository.