### PR TITLE
Add resource for looking up a list of projects

### DIFF
--- a/gitlab/data_source_gitlab_group_projects.go
+++ b/gitlab/data_source_gitlab_group_projects.go
@@ -54,7 +54,7 @@ func dataSourceGitlabGroupProjects() *schema.Resource {
 func dataSourceGitlabGroupProjectsRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
-	log.Printf("[INFO] Reading Gitlab projects")
+	log.Printf("[DEBUG] Reading Gitlab projects in group")
 
 	listGroupProjectsOptions, id, err := expandGitlabGroupProjectsOptions(d)
 	if err != nil {

--- a/gitlab/data_source_gitlab_group_projects.go
+++ b/gitlab/data_source_gitlab_group_projects.go
@@ -1,0 +1,124 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/xanzy/go-gitlab"
+)
+
+func dataSourceGitlabGroupProjects() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGitlabGroupProjectsRead,
+
+		Schema: map[string]*schema.Schema{
+			"order_by": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "id",
+				ValidateFunc: validation.StringInSlice([]string{"id", "name",
+					"username", "created_at", "updated_at"}, true),
+			},
+			"search": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"group_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"projects": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGitlabGroupProjectsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	log.Printf("[INFO] Reading Gitlab projects")
+
+	listGroupProjectsOptions, id, err := expandGitlabGroupProjectsOptions(d)
+	if err != nil {
+		return err
+	}
+
+	groupId, _ := d.GetOk("group_id")
+
+	projectList := []*gitlab.Project{}
+	for {
+		projects, response, err := client.Groups.ListGroupProjects(groupId, listGroupProjectsOptions, nil)
+		projectList = append(projectList, projects...)
+
+		if err != nil {
+			return err
+		}
+		listGroupProjectsOptions.ListOptions.Page++
+
+		log.Printf("[INFO] Currentpage: %d, Total: %d", response.CurrentPage, response.TotalPages)
+		if response.CurrentPage == response.TotalPages {
+			break
+		}
+	}
+
+	d.SetId(fmt.Sprintf("%d", id))
+	d.Set("projects", flattenGroupProjects(projectList))
+	return nil
+}
+
+func flattenGroupProjects(projects []*gitlab.Project) []interface{} {
+	projectsList := []interface{}{}
+
+	for _, project := range projects {
+		values := map[string]interface{}{
+			"id":   project.ID,
+			"name": project.Name,
+		}
+
+		projectsList = append(projectsList, values)
+	}
+
+	return projectsList
+}
+
+func expandGitlabGroupProjectsOptions(d *schema.ResourceData) (*gitlab.ListGroupProjectsOptions, int, error) {
+	listGroupProjectsOptions := &gitlab.ListGroupProjectsOptions{}
+	var optionsHash strings.Builder
+
+	if data, ok := d.GetOk("order_by"); ok {
+		orderBy := data.(string)
+		listGroupProjectsOptions.OrderBy = &orderBy
+		optionsHash.WriteString(orderBy)
+	}
+
+	if data, ok := d.GetOk("search"); ok {
+		search := data.(string)
+		listGroupProjectsOptions.Search = &search
+		optionsHash.WriteString(search)
+	}
+
+	listGroupProjectsOptions.ListOptions.PerPage = 100
+	listGroupProjectsOptions.ListOptions.Page = 1
+
+	id := schema.HashString(optionsHash.String())
+
+	return listGroupProjectsOptions, id, nil
+}

--- a/gitlab/data_source_gitlab_group_projects_test.go
+++ b/gitlab/data_source_gitlab_group_projects_test.go
@@ -1,0 +1,51 @@
+package gitlab
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataGitlabGroupProjects_basic(t *testing.T) {
+	projectname := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataGitlabGroupProjectsConfig(projectname),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.gitlab_group_projects.foo", "projects.0.name", projectname),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataGitlabGroupProjectsConfig(projectname string) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "test"{
+	name = "%s"
+	path = "%s"
+	description = "Terraform acceptance tests"
+	visibility_level = "public"
+	namespace_id = "${gitlab_group.foo.id}"
+}
+
+resource "gitlab_group" "foo" {
+	name = "test-%s"
+	path = "test-%s"
+
+	visibility_level = "public"
+}
+
+
+data "gitlab_group_projects" "foo" {
+	search = "${gitlab_project.test.name}"
+	group_id = "${gitlab_group.foo.id}"
+}
+	`, projectname, projectname, projectname, projectname)
+}

--- a/gitlab/data_source_gitlab_projects.go
+++ b/gitlab/data_source_gitlab_projects.go
@@ -50,7 +50,7 @@ func dataSourceGitlabProjects() *schema.Resource {
 func dataSourceGitlabProjectsRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
-	log.Printf("[INFO] Reading Gitlab projects")
+	log.Printf("[DEBUG] Reading Gitlab projects")
 
 	listProjectsOptions, id, err := expandGitlabProjectsOptions(d)
 	if err != nil {

--- a/gitlab/data_source_gitlab_projects.go
+++ b/gitlab/data_source_gitlab_projects.go
@@ -1,0 +1,119 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/xanzy/go-gitlab"
+)
+
+func dataSourceGitlabProjects() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGitlabProjectsRead,
+
+		Schema: map[string]*schema.Schema{
+			"order_by": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "id",
+				ValidateFunc: validation.StringInSlice([]string{"id", "name",
+					"username", "created_at", "updated_at"}, true),
+			},
+			"search": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"projects": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGitlabProjectsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	log.Printf("[INFO] Reading Gitlab projects")
+
+	listProjectsOptions, id, err := expandGitlabProjectsOptions(d)
+	if err != nil {
+		return err
+	}
+
+	projectList := []*gitlab.Project{}
+
+	for {
+		projects, response, err := client.Projects.ListProjects(listProjectsOptions, nil)
+		projectList = append(projectList, projects...)
+
+		if err != nil {
+			return err
+		}
+		listProjectsOptions.ListOptions.Page++
+
+		log.Printf("[INFO] Currentpage: %d, Total: %d", response.CurrentPage, response.TotalPages)
+		if response.CurrentPage == response.TotalPages {
+			break
+		}
+	}
+
+	d.SetId(fmt.Sprintf("%d", id))
+	d.Set("projects", flattenProjects(projectList))
+	return nil
+}
+
+func flattenProjects(projects []*gitlab.Project) []interface{} {
+	projectsList := []interface{}{}
+
+	for _, project := range projects {
+		values := map[string]interface{}{
+			"id":   project.ID,
+			"name": project.Name,
+		}
+
+		projectsList = append(projectsList, values)
+	}
+
+	return projectsList
+}
+
+func expandGitlabProjectsOptions(d *schema.ResourceData) (*gitlab.ListProjectsOptions, int, error) {
+	listProjectsOptions := &gitlab.ListProjectsOptions{}
+	var optionsHash strings.Builder
+
+	if data, ok := d.GetOk("order_by"); ok {
+		orderBy := data.(string)
+		listProjectsOptions.OrderBy = &orderBy
+		optionsHash.WriteString(orderBy)
+	}
+
+	if data, ok := d.GetOk("search"); ok {
+		search := data.(string)
+		listProjectsOptions.Search = &search
+		optionsHash.WriteString(search)
+	}
+
+	listProjectsOptions.ListOptions.PerPage = 100
+	listProjectsOptions.ListOptions.Page = 1
+
+	id := schema.HashString(optionsHash.String())
+
+	return listProjectsOptions, id, nil
+}

--- a/gitlab/data_source_gitlab_projects_test.go
+++ b/gitlab/data_source_gitlab_projects_test.go
@@ -1,0 +1,41 @@
+package gitlab
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataGitlabProjects_basic(t *testing.T) {
+	projectname := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataGitlabProjectsConfig(projectname),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.gitlab_projects.foo", "projects.0.name", projectname),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataGitlabProjectsConfig(projectname string) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "test"{
+	name = "%s"
+	path = "%s"
+	description = "Terraform acceptance tests"
+	visibility_level = "public"
+}
+
+data "gitlab_projects" "foo" {
+	search = "${gitlab_project.test.name}"
+}
+	`, projectname, projectname)
+}

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -42,10 +42,12 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"gitlab_group":   dataSourceGitlabGroup(),
-			"gitlab_project": dataSourceGitlabProject(),
-			"gitlab_user":    dataSourceGitlabUser(),
-			"gitlab_users":   dataSourceGitlabUsers(),
+			"gitlab_group":          dataSourceGitlabGroup(),
+			"gitlab_project":        dataSourceGitlabProject(),
+			"gitlab_projects":       dataSourceGitlabProjects(),
+			"gitlab_group_projects": dataSourceGitlabGroupProjects(),
+			"gitlab_user":           dataSourceGitlabUser(),
+			"gitlab_users":          dataSourceGitlabUsers(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/group_projects.html.markdown
+++ b/website/docs/d/group_projects.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "gitlab"
+page_title: "GitLab: gitlab_group_projects"
+sidebar_current: "docs-gitlab-data-source-group_projects"
+description: |-
+  View information about all projects inside a group
+---
+
+# gitlab\_group\_projects
+
+Provides a list of projects in a specific group
+
+## Example Usage
+
+```hcl
+data "gitlab_group_projects" "example" {
+    group_id = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `group_id` - (Required) The id of the group you want to view the projects for
+
+* `order_by` - (Optional) Return projects ordered by id, name, path, created_at, updated_at, or last_activity_at fields. Default is created_at.
+
+* `search` - (Optional) Return list of projects matching the search criteria
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `projects` - A list containing the projects matching the supplied arguments
+
+Projects have the following fields:
+
+* `id` - The ID of the project
+
+* `name` - The name of the project

--- a/website/docs/d/projects.html.markdown
+++ b/website/docs/d/projects.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "gitlab"
+page_title: "GitLab: gitlab_projects"
+sidebar_current: "docs-gitlab-data-source-projects"
+description: |-
+  View information about multiple projects
+---
+
+# gitlab\_projects
+
+Provides details about a specific project in the gitlab provider. The results include the name of the project, path, description, default branch, etc.
+
+## Example Usage
+
+```hcl
+data "gitlab_projects" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `order_by` - (Optional) Return projects ordered by id, name, path, created_at, updated_at, or last_activity_at fields. Default is created_at.
+
+* `search` - (Optional) Return list of projects matching the search criteria
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `projects` - A list containing the projects matching the supplied arguments
+
+Projects have the following fields:
+
+* `id` - The ID of the project
+
+* `name` - The name of the project

--- a/website/gitlab.erb
+++ b/website/gitlab.erb
@@ -16,8 +16,14 @@
                 <li<%= sidebar_current("docs-gitlab-data-source-group") %>>
                     <a href="/docs/providers/gitlab/d/group.html">gitlab_group</a>
                 </li>
+                <li<%= sidebar_current("docs-gitlab-data-source-group_projects") %>>
+                    <a href="/docs/providers/gitlab/d/group_projects.html">gitlab_group_projects</a>
+                </li>
                 <li<%= sidebar_current("docs-gitlab-data-source-project") %>>
                     <a href="/docs/providers/gitlab/d/project.html">gitlab_project</a>
+                </li>
+                <li<%= sidebar_current("docs-gitlab-data-source-projects") %>>
+                    <a href="/docs/providers/gitlab/d/projects.html">gitlab_projects</a>
                 </li>
                 <li<%= sidebar_current("docks-gitlab-data-source-user") %>>
                     <a href="/docs/providers/gitlab/d/user.html">gitlab_user</a>


### PR DESCRIPTION
This MR adds two resources:
* gitlab_projects - used to return a list of projects that match specified parameters
* gitlab_group_projects - used to return a list of projects that are in a certain group

This allows you to specify branch protection rules for an entire gitlab group without referencing the individual projects. 