### PR TITLE
Fix state not being updated for gitlab_branch_protection

### DIFF
--- a/gitlab/resource_gitlab_branch_protection.go
+++ b/gitlab/resource_gitlab_branch_protection.go
@@ -94,8 +94,8 @@ func resourceGitlabBranchProtectionRead(d *schema.ResourceData, meta interface{}
 
 	d.Set("project", project)
 	d.Set("branch", pb.Name)
-	d.Set("merge_access_level", pb.MergeAccessLevels[0].AccessLevel)
-	d.Set("push_access_level", pb.PushAccessLevels[0].AccessLevel)
+	d.Set("merge_access_level", accessLevel[pb.MergeAccessLevels[0].AccessLevel])
+	d.Set("push_access_level", accessLevel[pb.PushAccessLevels[0].AccessLevel])
 
 	d.SetId(buildTwoPartID(&project, &pb.Name))
 

--- a/gitlab/resource_gitlab_branch_protection_test.go
+++ b/gitlab/resource_gitlab_branch_protection_test.go
@@ -25,6 +25,7 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 				Config: testAccGitlabBranchProtectionConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
@@ -37,6 +38,7 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 				Config: testAccGitlabBranchProtectionUpdateConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:  accessLevel[gitlab.MasterPermissions],
@@ -49,6 +51,7 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 				Config: testAccGitlabBranchProtectionConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
@@ -58,6 +61,23 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckGitlabBranchProtectionPersistsInStateCorrectly(n string, pb *gitlab.ProtectedBranch) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		if rs.Primary.Attributes["merge_access_level"] != accessLevel[pb.MergeAccessLevels[0].AccessLevel] {
+			return fmt.Errorf("merge access level not persisted in state correctly")
+		}
+
+		if rs.Primary.Attributes["push_access_level"] != accessLevel[pb.PushAccessLevels[0].AccessLevel] {
+			return fmt.Errorf("push access level not persisted in state correctly")
+		}
+	}
 }
 
 func testAccCheckGitlabBranchProtectionExists(n string, pb *gitlab.ProtectedBranch) resource.TestCheckFunc {

--- a/gitlab/resource_gitlab_branch_protection_test.go
+++ b/gitlab/resource_gitlab_branch_protection_test.go
@@ -77,6 +77,8 @@ func testAccCheckGitlabBranchProtectionPersistsInStateCorrectly(n string, pb *gi
 		if rs.Primary.Attributes["push_access_level"] != accessLevel[pb.PushAccessLevels[0].AccessLevel] {
 			return fmt.Errorf("push access level not persisted in state correctly")
 		}
+
+		return nil
 	}
 }
 


### PR DESCRIPTION
The merge access level and push access level is not being mapped back to the textual forms in the state currently. This causes drift to not be detected by terrafrom refresh actions.

This fix uses the accessLevel map to translate the response from the API back to the format used by Terraform to store the state.