### PR TITLE
docs(gitlab_project_membership): fix documentation

### DIFF
--- a/website/docs/r/project_membership.html.markdown
+++ b/website/docs/r/project_membership.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 ## Import
 
-GitLab group membership can be imported using an id made up of `groupid:username`, e.g.
+GitLab group membership can be imported using an id made up of `groupid:user_id`, e.g.
 
 ```
 $ terraform import gitlab_project_membership.test 12345:1337


### PR DESCRIPTION
fix documentation for gitlab_project_membership import, it's "groupid:user_id" use for import note username