### PR TITLE
Add initialize_with_readme to project

### DIFF
--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -73,6 +73,8 @@ The following arguments are supported:
 
 * `archived` - (Optional) Whether the project is in read-only mode (archived). Repositories can be archived/unarchived by toggling this parameter.
 
+* `initialize_with_readme` - (Optional) Create master branch with first commit containing a README.md file.
+
 ## Attributes Reference
 
 The following additional attributes are exported:


### PR DESCRIPTION
Resolves #177 - add `initialize_with_readme` attribute to project resource.
Not sure if we need additional acceptance tests here.