### PR TITLE
Add gitlab_group_label resource

### DIFF
--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -54,6 +54,7 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_group":               resourceGitlabGroup(),
 			"gitlab_project":             resourceGitlabProject(),
 			"gitlab_label":               resourceGitlabLabel(),
+			"gitlab_group_label":         resourceGitlabGroupLabel(),
 			"gitlab_pipeline_schedule":   resourceGitlabPipelineSchedule(),
 			"gitlab_pipeline_trigger":    resourceGitlabPipelineTrigger(),
 			"gitlab_project_hook":        resourceGitlabProjectHook(),

--- a/gitlab/resource_gitlab_group_label.go
+++ b/gitlab/resource_gitlab_group_label.go
@@ -1,6 +1,8 @@
 package gitlab
 
 import (
+	"errors"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -81,8 +83,7 @@ func resourceGitlabGroupLabelRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 	if !found {
-		log.Printf("[WARN] removing label %s from state because it no longer exists in gitlab", labelName)
-		d.SetId("")
+		return errors.New(fmt.Sprintf("label %s no longer exists in group %s", labelName, group))
 	}
 
 	return nil

--- a/gitlab/resource_gitlab_group_label.go
+++ b/gitlab/resource_gitlab_group_label.go
@@ -83,7 +83,7 @@ func resourceGitlabGroupLabelRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 	if !found {
-		return errors.New(fmt.Sprintf("label %s no longer exists in group %s", labelName, group))
+		return errors.New(fmt.Sprintf("label %s does not exist or the user does not have permissions to see it", labelName))
 	}
 
 	return nil

--- a/gitlab/resource_gitlab_group_label.go
+++ b/gitlab/resource_gitlab_group_label.go
@@ -1,0 +1,123 @@
+package gitlab
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func resourceGitlabGroupLabel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabGroupLabelCreate,
+		Read:   resourceGitlabGroupLabelRead,
+		Update: resourceGitlabGroupLabelUpdate,
+		Delete: resourceGitlabGroupLabelDelete,
+
+		Schema: map[string]*schema.Schema{
+			"group": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"color": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceGitlabGroupLabelCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	group := d.Get("group").(string)
+	options := &gitlab.CreateGroupLabelOptions{
+		Name:  gitlab.String(d.Get("name").(string)),
+		Color: gitlab.String(d.Get("color").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		options.Description = gitlab.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] create gitlab group label %s", *options.Name)
+
+	label, _, err := client.GroupLabels.CreateGroupLabel(group, options)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(label.Name)
+
+	return resourceGitlabGroupLabelRead(d, meta)
+}
+
+func resourceGitlabGroupLabelRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	group := d.Get("group").(string)
+	labelName := d.Id()
+	log.Printf("[DEBUG] read gitlab group label %s/%s", group, labelName)
+
+	labels, _, err := client.GroupLabels.ListGroupLabels(group, nil)
+	if err != nil {
+		return err
+	}
+	found := false
+	for _, label := range labels {
+		if label.Name == labelName {
+			d.Set("description", label.Description)
+			d.Set("color", label.Color)
+			d.Set("name", label.Name)
+			found = true
+			break
+		}
+	}
+	if !found {
+		log.Printf("[WARN] removing label %s from state because it no longer exists in gitlab", labelName)
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceGitlabGroupLabelUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	group := d.Get("group").(string)
+	options := &gitlab.UpdateGroupLabelOptions{
+		Name:  gitlab.String(d.Get("name").(string)),
+		Color: gitlab.String(d.Get("color").(string)),
+	}
+
+	if d.HasChange("description") {
+		options.Description = gitlab.String(d.Get("description").(string))
+	}
+
+	log.Printf("[DEBUG] update gitlab group label %s", d.Id())
+
+	_, _, err := client.GroupLabels.UpdateGroupLabel(group, options)
+	if err != nil {
+		return err
+	}
+
+	return resourceGitlabGroupLabelRead(d, meta)
+}
+
+func resourceGitlabGroupLabelDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	group := d.Get("group").(string)
+	log.Printf("[DEBUG] Delete gitlab group label %s", d.Id())
+	options := &gitlab.DeleteGroupLabelOptions{
+		Name: gitlab.String(d.Id()),
+	}
+
+	_, err := client.GroupLabels.DeleteGroupLabel(group, options)
+	return err
+}

--- a/gitlab/resource_gitlab_group_label_test.go
+++ b/gitlab/resource_gitlab_group_label_test.go
@@ -1,0 +1,167 @@
+package gitlab
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/xanzy/go-gitlab"
+)
+
+func TestAccGitlabGroupLabel_basic(t *testing.T) {
+	var label gitlab.GroupLabel
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabGroupLabelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabGroupLabelConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabGroupLabelExists("gitlab_group_label.fixme", &label),
+					testAccCheckGitlabGroupLabelAttributes(&label, &testAccGitlabGroupLabelExpectedAttributes{
+						Name:        fmt.Sprintf("FIXME-%d", rInt),
+						Color:       "#ffcc00",
+						Description: "fix this test",
+					}),
+				),
+			},
+			{
+				Config: testAccGitlabGroupLabelUpdateConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabGroupLabelExists("gitlab_group_label.fixme", &label),
+					testAccCheckGitlabGroupLabelAttributes(&label, &testAccGitlabGroupLabelExpectedAttributes{
+						Name:        fmt.Sprintf("FIXME-%d", rInt),
+						Color:       "#ff0000",
+						Description: "red label",
+					}),
+				),
+			},
+			{
+				Config: testAccGitlabGroupLabelConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabGroupLabelExists("gitlab_group_label.fixme", &label),
+					testAccCheckGitlabGroupLabelAttributes(&label, &testAccGitlabGroupLabelExpectedAttributes{
+						Name:        fmt.Sprintf("FIXME-%d", rInt),
+						Color:       "#ffcc00",
+						Description: "fix this test",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGitlabGroupLabelExists(n string, label *gitlab.GroupLabel) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		labelName := rs.Primary.ID
+		groupName := rs.Primary.Attributes["group"]
+		if groupName == "" {
+			return fmt.Errorf("No group ID is set")
+		}
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		labels, _, err := conn.GroupLabels.ListGroupLabels(groupName, nil)
+		if err != nil {
+			return err
+		}
+		for _, gotLabel := range labels {
+			if gotLabel.Name == labelName {
+				*label = *gotLabel
+				return nil
+			}
+		}
+		return fmt.Errorf("Label does not exist")
+	}
+}
+
+type testAccGitlabGroupLabelExpectedAttributes struct {
+	Name        string
+	Color       string
+	Description string
+}
+
+func testAccCheckGitlabGroupLabelAttributes(label *gitlab.GroupLabel, want *testAccGitlabGroupLabelExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if label.Name != want.Name {
+			return fmt.Errorf("got name %q; want %q", label.Name, want.Name)
+		}
+
+		if label.Description != want.Description {
+			return fmt.Errorf("got description %q; want %q", label.Description, want.Description)
+		}
+
+		if label.Color != want.Color {
+			return fmt.Errorf("got color %q; want %q", label.Color, want.Color)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGitlabGroupLabelDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_group" {
+			continue
+		}
+
+		group, resp, err := conn.Groups.GetGroup(rs.Primary.ID)
+		if err == nil {
+			if group != nil && fmt.Sprintf("%d", group.ID) == rs.Primary.ID {
+				return fmt.Errorf("Group still exists")
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccGitlabGroupLabelConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_group" "foo" {
+  name             = "foo-%d"
+  path             = "foo-%d"
+  description      = "Terraform acceptance tests"
+  visibility_level = "public"
+}
+
+resource "gitlab_group_label" "fixme" {
+  group       = "${gitlab_group.foo.id}"
+  name        = "FIXME-%d"
+  color       = "#ffcc00"
+  description = "fix this test"
+}
+	`, rInt, rInt, rInt)
+}
+
+func testAccGitlabGroupLabelUpdateConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_group" "foo" {
+  name             = "foo-%d"
+  path             = "foo-%d"
+  description      = "Terraform acceptance tests"
+  visibility_level = "public"
+}
+
+resource "gitlab_group_label" "fixme" {
+  group       = "${gitlab_group.foo.id}"
+  name        = "FIXME-%d"
+  color       = "#ff0000"
+  description = "red label"
+}
+	`, rInt, rInt, rInt)
+}

--- a/website/docs/r/group_label.html.markdown
+++ b/website/docs/r/group_label.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "gitlab"
+page_title: "GitLab: gitlab_group_label"
+sidebar_current: "docs-gitlab-resource-group-label"
+description: |-
+  Creates and manages labels for GitLab groups
+---
+
+# gitlab\_group\_label
+
+This resource allows you to create and manage labels for your GitLab groups.
+For further information on labels, consult the [gitlab
+documentation](https://docs.gitlab.com/ee/user/group/labels.htm).
+
+
+## Example Usage
+
+```hcl
+resource "gitlab_group_label" "fixme" {
+  group       = "example"
+  name        = "fixme"
+  description = "issue with failing tests"
+  color       = "#ffcc00"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `group` - (Required) The name or id of the group to add the label to.
+
+* `name` - (Required) The name of the label.
+
+* `color` - (Required) The color of the label given in 6-digit hex notation with leading '#' sign (e.g. #FFAABB) or one of the [CSS color names](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Color_keywords).
+
+* `description` - (Optional) The description of the label.
+
+## Attributes Reference
+
+The resource exports the following attributes:
+
+* `id` - The unique id assigned to the label by the GitLab server (the name of the label).

--- a/website/gitlab.erb
+++ b/website/gitlab.erb
@@ -49,6 +49,9 @@
           <li<%= sidebar_current("docs-gitlab-resource-label") %>>
             <a href="/docs/providers/gitlab/r/label.html">gitlab_label</a>
           </li>
+          <li<%= sidebar_current("docs-gitlab-resource-group-label") %>>
+            <a href="/docs/providers/gitlab/r/group_label.html">gitlab_group_label</a>
+          </li>
           <li<%= sidebar_current("docs-gitlab-resource-pipeline-schedule") %>>
           <a href="/docs/providers/gitlab/r/pipeline_schedule.html">gitlab_pipeline_schedule</a>
           </li>


### PR DESCRIPTION
This MR adds a new resource `gitlab_group_label` to manage group labels.