### PR TITLE
Make read callbacks graceful

### DIFF
--- a/gitlab/resource_gitlab_branch_protection.go
+++ b/gitlab/resource_gitlab_branch_protection.go
@@ -89,7 +89,9 @@ func resourceGitlabBranchProtectionRead(d *schema.ResourceData, meta interface{}
 
 	pb, _, err := client.ProtectedBranches.GetProtectedBranch(project, branch)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab branch protection for project %s, branch %s: %s", project, branch, err)
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("project", project)

--- a/gitlab/resource_gitlab_deploy_key.go
+++ b/gitlab/resource_gitlab_deploy_key.go
@@ -80,7 +80,9 @@ func resourceGitlabDeployKeyRead(d *schema.ResourceData, meta interface{}) error
 
 	deployKey, _, err := client.DeployKeys.GetDeployKey(project, deployKeyID)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab deploy key %s/%d: %s", project, deployKeyID, err)
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("title", deployKey.Title)

--- a/gitlab/resource_gitlab_deploy_key_enable.go
+++ b/gitlab/resource_gitlab_deploy_key_enable.go
@@ -77,7 +77,9 @@ func resourceGitlabDeployKeyEnableRead(d *schema.ResourceData, meta interface{})
 
 	deployKey, _, err := client.DeployKeys.GetDeployKey(project, deployKeyID)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab deploy key %s/%d: %s", project, deployKeyID, err)
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("title", deployKey.Title)

--- a/gitlab/resource_gitlab_group.go
+++ b/gitlab/resource_gitlab_group.go
@@ -114,7 +114,9 @@ func resourceGitlabGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	group, _, err := client.Groups.GetGroup(d.Id())
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab group %s: %s", d.Id(), err)
+		d.SetId("")
+		return nil
 	}
 
 	d.SetId(fmt.Sprintf("%d", group.ID))

--- a/gitlab/resource_gitlab_group_label.go
+++ b/gitlab/resource_gitlab_group_label.go
@@ -70,7 +70,9 @@ func resourceGitlabGroupLabelRead(d *schema.ResourceData, meta interface{}) erro
 
 	labels, _, err := client.GroupLabels.ListGroupLabels(group, nil)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab group label %s/%s: %s", group, labelName, err)
+		d.SetId("")
+		return nil
 	}
 	found := false
 	for _, label := range labels {

--- a/gitlab/resource_gitlab_group_membership.go
+++ b/gitlab/resource_gitlab_group_membership.go
@@ -84,7 +84,9 @@ func resourceGitlabGroupMembershipRead(d *schema.ResourceData, meta interface{})
 
 	groupMember, _, err := client.GroupMembers.GetGroupMember(groupId, userId)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab group groupMember %s: %s", id, err)
+		d.SetId("")
+		return nil
 	}
 
 	resourceGitlabGroupMembershipSetToState(d, groupMember, &groupId)

--- a/gitlab/resource_gitlab_group_variable.go
+++ b/gitlab/resource_gitlab_group_variable.go
@@ -88,7 +88,9 @@ func resourceGitlabGroupVariableRead(d *schema.ResourceData, meta interface{}) e
 
 	v, _, err := client.GroupVariables.GetVariable(group, key)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab group variable %s/%s: %s", group, key, err)
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("key", v.Key)

--- a/gitlab/resource_gitlab_label.go
+++ b/gitlab/resource_gitlab_label.go
@@ -70,7 +70,9 @@ func resourceGitlabLabelRead(d *schema.ResourceData, meta interface{}) error {
 
 	labels, _, err := client.Labels.ListLabels(project, nil)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab label %s/%s: %s", project, labelName, err)
+		d.SetId("")
+		return nil
 	}
 	found := false
 	for _, label := range labels {

--- a/gitlab/resource_gitlab_pipeline_schedule.go
+++ b/gitlab/resource_gitlab_pipeline_schedule.go
@@ -1,7 +1,6 @@
 package gitlab
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -85,7 +84,9 @@ func resourceGitlabPipelineScheduleRead(d *schema.ResourceData, meta interface{}
 
 	pipelineSchedules, _, err := client.PipelineSchedules.ListPipelineSchedules(project, nil)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab PipelineSchedule %s/%d: %s", project, pipelineScheduleID, err)
+		d.SetId("")
+		return nil
 	}
 	found := false
 	for _, pipelineSchedule := range pipelineSchedules {
@@ -100,7 +101,9 @@ func resourceGitlabPipelineScheduleRead(d *schema.ResourceData, meta interface{}
 		}
 	}
 	if !found {
-		return errors.New(fmt.Sprintf("PipelineSchedule %d no longer exists in gitlab", pipelineScheduleID))
+		log.Printf("[DEBUG] PipelineSchedule %d no longer exists in gitlab", pipelineScheduleID)
+		d.SetId("")
+		return nil
 	}
 
 	return nil

--- a/gitlab/resource_gitlab_pipeline_schedule_variable.go
+++ b/gitlab/resource_gitlab_pipeline_schedule_variable.go
@@ -73,7 +73,9 @@ func resourceGitlabPipelineScheduleVariableRead(d *schema.ResourceData, meta int
 
 	pipelineSchedule, _, err := client.PipelineSchedules.GetPipelineSchedule(project, scheduleID)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] read gitlab PipelineSchedule %s/%d: %s", project, scheduleID, err)
+		d.SetId("")
+		return nil
 	}
 
 	found := false

--- a/gitlab/resource_gitlab_pipeline_trigger.go
+++ b/gitlab/resource_gitlab_pipeline_trigger.go
@@ -65,7 +65,9 @@ func resourceGitlabPipelineTriggerRead(d *schema.ResourceData, meta interface{})
 
 	pipelineTrigger, _, err := client.PipelineTriggers.GetPipelineTrigger(project, pipelineTriggerID)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab PipelineTrigger %s/%d: %s", project, pipelineTriggerID, err)
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("description", pipelineTrigger.Description)

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -327,7 +327,9 @@ func resourceGitlabProjectRead(d *schema.ResourceData, meta interface{}) error {
 
 	project, _, err := client.Projects.GetProject(d.Id(), nil)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab project %s: %s", d.Id(), err)
+		d.SetId("")
+		return nil
 	}
 
 	resourceGitlabProjectSetToState(d, project)

--- a/gitlab/resource_gitlab_project_cluster.go
+++ b/gitlab/resource_gitlab_project_cluster.go
@@ -157,7 +157,9 @@ func resourceGitlabProjectClusterRead(d *schema.ResourceData, meta interface{}) 
 
 	cluster, _, err := client.ProjectCluster.GetCluster(project, clusterId)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab project cluster %q/%d: %s", project, clusterId, err)
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("project", project)

--- a/gitlab/resource_gitlab_project_hook.go
+++ b/gitlab/resource_gitlab_project_hook.go
@@ -122,7 +122,9 @@ func resourceGitlabProjectHookRead(d *schema.ResourceData, meta interface{}) err
 
 	hook, _, err := client.Projects.GetProjectHook(project, hookId)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] read gitlab project hook %s/%d: %s", project, hookId, err)
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("url", hook.URL)

--- a/gitlab/resource_gitlab_project_membership.go
+++ b/gitlab/resource_gitlab_project_membership.go
@@ -79,7 +79,9 @@ func resourceGitlabProjectMembershipRead(d *schema.ResourceData, meta interface{
 
 	projectMember, _, err := client.ProjectMembers.GetProjectMember(projectId, userId)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab project projectMember %s: %s", id, err)
+		d.SetId("")
+		return nil
 	}
 
 	resourceGitlabProjectMembershipSetToState(d, projectMember, &projectId)

--- a/gitlab/resource_gitlab_project_push_rules.go
+++ b/gitlab/resource_gitlab_project_push_rules.go
@@ -110,7 +110,9 @@ func resourceGitlabProjectPushRulesRead(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] read gitlab project %s", project)
 	pushRules, _, err := client.Projects.GetProjectPushRules(project)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab project %s: %s", project, err)
+		d.SetId("")
+		return nil
 	}
 	d.Set("commit_message_regex", pushRules.CommitMessageRegex)
 	d.Set("branch_name_regex", pushRules.BranchNameRegex)

--- a/gitlab/resource_gitlab_project_share_group.go
+++ b/gitlab/resource_gitlab_project_share_group.go
@@ -76,7 +76,9 @@ func resourceGitlabProjectShareGroupRead(d *schema.ResourceData, meta interface{
 
 	projectInformation, _, err := client.Projects.GetProject(projectId, nil)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] read gitlab project projectMember %s: %s", id, err)
+		d.SetId("")
+		return nil
 	}
 
 	for _, v := range projectInformation.SharedWithGroups {

--- a/gitlab/resource_gitlab_project_variable.go
+++ b/gitlab/resource_gitlab_project_variable.go
@@ -102,7 +102,9 @@ func resourceGitlabProjectVariableRead(d *schema.ResourceData, meta interface{})
 
 	v, _, err := client.ProjectVariables.GetVariable(project, key)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab project variable %s/%s: %s", project, key, err)
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("key", v.Key)

--- a/gitlab/resource_gitlab_service_jira.go
+++ b/gitlab/resource_gitlab_service_jira.go
@@ -97,7 +97,9 @@ func resourceGitlabServiceJiraRead(d *schema.ResourceData, meta interface{}) err
 
 	jiraService, _, err := client.Services.GetJiraService(project)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] Read Gitlab Jira service %s: %s", d.Id(), err)
+		d.SetId("")
+		return nil
 	}
 
 	if v := jiraService.Properties.URL; v != "" {

--- a/gitlab/resource_gitlab_service_slack.go
+++ b/gitlab/resource_gitlab_service_slack.go
@@ -209,7 +209,9 @@ func resourceGitlabServiceSlackRead(d *schema.ResourceData, meta interface{}) er
 
 	service, _, err := client.Services.GetSlackService(project)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab slack service for project %s: %s", project, err)
+		d.SetId("")
+		return nil
 	}
 
 	resourceGitlabServiceSlackSetToState(d, service)

--- a/gitlab/resource_gitlab_tag_protection.go
+++ b/gitlab/resource_gitlab_tag_protection.go
@@ -81,7 +81,9 @@ func resourceGitlabTagProtectionRead(d *schema.ResourceData, meta interface{}) e
 
 	pt, _, err := client.ProtectedTags.GetProtectedTag(project, tag)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab tag protection for project %s, tag %s: %s", project, tag, err)
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("project", project)

--- a/gitlab/resource_gitlab_user.go
+++ b/gitlab/resource_gitlab_user.go
@@ -110,7 +110,9 @@ func resourceGitlabUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	user, _, err := client.Users.GetUser(id)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab user %s: %s", d.Id(), err)
+		d.SetId("")
+		return nil
 	}
 
 	resourceGitlabUserSetToState(d, user)


### PR DESCRIPTION
Every time resource got changed manually, provider fails and the only fix is to remove failing resource from the state. If resource doesn't exist in gitlab, terraform should be informed and state cleaned, instead of failing with error.
Inspired by #209