### PR TITLE
Make read callbacks graceful for project_share_group, branch_protection and label resources

### DIFF
--- a/gitlab/resource_gitlab_branch_protection.go
+++ b/gitlab/resource_gitlab_branch_protection.go
@@ -89,7 +89,9 @@ func resourceGitlabBranchProtectionRead(d *schema.ResourceData, meta interface{}
 
 	pb, _, err := client.ProtectedBranches.GetProtectedBranch(project, branch)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab branch protection for project %s, branch %s: %s", project, branch, err)
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("project", project)

--- a/gitlab/resource_gitlab_label.go
+++ b/gitlab/resource_gitlab_label.go
@@ -70,7 +70,9 @@ func resourceGitlabLabelRead(d *schema.ResourceData, meta interface{}) error {
 
 	labels, _, err := client.Labels.ListLabels(project, nil)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab label %s/%s: %s", project, labelName, err)
+		d.SetId("")
+		return nil
 	}
 	found := false
 	for _, label := range labels {

--- a/gitlab/resource_gitlab_project_share_group.go
+++ b/gitlab/resource_gitlab_project_share_group.go
@@ -76,7 +76,9 @@ func resourceGitlabProjectShareGroupRead(d *schema.ResourceData, meta interface{
 
 	projectInformation, _, err := client.Projects.GetProject(projectId, nil)
 	if err != nil {
-		return err
+		log.Printf("[DEBUG] failed to read gitlab project %s: %s", id, err)
+		d.SetId("")
+		return nil
 	}
 
 	for _, v := range projectInformation.SharedWithGroups {


### PR DESCRIPTION
More details in #222 