### PR TITLE
fix: enable environment_scope of project variable loopkup

### DIFF
--- a/gitlab/resource_gitlab_project_variable.go
+++ b/gitlab/resource_gitlab_project_variable.go
@@ -114,7 +114,7 @@ func resourceGitlabProjectVariableRead(d *schema.ResourceData, meta interface{})
 	//For now I'm ignoring environment_scope when reading back data. (this can cause configuration drift so it is bad).
 	//However I'm unable to stop terraform from gratuitously updating this to values that are unacceptable by Gitlab)
 	//I don't have an enterprise license to properly test this either.
-	//d.Set("environment_scope", v.EnvironmentScope)
+	d.Set("environment_scope", v.EnvironmentScope)
 	return nil
 }
 


### PR DESCRIPTION
Disabling `environment_scope` makes `gitlab_project_variable` only useful, if you are not differentiating between environments. Since a lot of use cases have multiple environments though, the current implementation is not very useful.

This PR fixes this known issue, by looking up variables with scope.

#213 