### PR TITLE
Force recreate gitlab_group when not found on read

### DIFF
--- a/gitlab/resource_gitlab_group_test.go
+++ b/gitlab/resource_gitlab_group_test.go
@@ -156,6 +156,36 @@ func TestAccGitlabGroup_nested(t *testing.T) {
 	})
 }
 
+func TestAccGitlabGroup_disappears(t *testing.T) {
+	var group gitlab.Group
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabGroupConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabGroupExists("gitlab_group.foo", &group),
+					testAccCheckGitlabGroupDisappears(&group),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckGitlabGroupDisappears(group *gitlab.Group) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		_, err := conn.Groups.DeleteGroup(group.ID)
+		return err
+	}
+}
+
 func testAccCheckGitlabGroupExists(n string, group *gitlab.Group) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]


### PR DESCRIPTION
when a group was manually deleted, the read operation was throwing
an unrecoverable 404 error:

```
GET https://gitlab.com/api/v4/projects/16151185: 404 {message: 404 Project Not Found}
```

We should clear this from the state so that we can force recreation
of the group

```
▶ acctests gitlab TestAccGitlabGroup_
=== RUN   TestAccGitlabGroup_basic
--- PASS: TestAccGitlabGroup_basic (29.33s)
=== RUN   TestAccGitlabGroup_import
--- PASS: TestAccGitlabGroup_import (12.77s)
=== RUN   TestAccGitlabGroup_nested
--- PASS: TestAccGitlabGroup_nested (54.77s)
=== RUN   TestAccGitlabGroup_disappears
--- PASS: TestAccGitlabGroup_disappears (4.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-gitlab/gitlab	101.835s
```