### PR TITLE
Changing notify_only_default_branch for branches_to_be_notified on slack

### DIFF
--- a/gitlab/resource_gitlab_service_slack.go
+++ b/gitlab/resource_gitlab_service_slack.go
@@ -37,7 +37,13 @@ func resourceGitlabServiceSlack() *schema.Resource {
 				Computed: true,
 			},
 			"notify_only_default_branch": {
-				Type:     schema.TypeBool,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "use 'branches_to_be_notified' argument instead",
+			},
+			"branches_to_be_notified": {
+				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
@@ -140,6 +146,7 @@ func resourceGitlabServiceSlackSetToState(d *schema.ResourceData, service *gitla
 	d.Set("username", service.Properties.Username)
 	d.Set("notify_only_broken_pipelines", service.Properties.NotifyOnlyBrokenPipelines.UnmarshalJSON)
 	d.Set("notify_only_default_branch", service.Properties.NotifyOnlyDefaultBranch.UnmarshalJSON)
+	d.Set("branches_to_be_notified", service.Properties.BranchesToBeNotified)
 	d.Set("push_events", service.PushEvents)
 	d.Set("push_channel", service.Properties.PushChannel)
 	d.Set("issues_events", service.IssuesEvents)
@@ -175,6 +182,7 @@ func resourceGitlabServiceSlackCreate(d *schema.ResourceData, meta interface{}) 
 	opts.Username = gitlab.String(d.Get("username").(string))
 	opts.NotifyOnlyBrokenPipelines = gitlab.Bool(d.Get("notify_only_broken_pipelines").(bool))
 	opts.NotifyOnlyDefaultBranch = gitlab.Bool(d.Get("notify_only_default_branch").(bool))
+	opts.BranchesToBeNotified = gitlab.String(d.Get("branches_to_be_notified").(string))
 	opts.PushEvents = gitlab.Bool(d.Get("push_events").(bool))
 	opts.PushChannel = gitlab.String(d.Get("push_channel").(string))
 	opts.IssuesEvents = gitlab.Bool(d.Get("issues_events").(bool))

--- a/gitlab/resource_gitlab_service_slack_test.go
+++ b/gitlab/resource_gitlab_service_slack_test.go
@@ -213,6 +213,7 @@ resource "gitlab_service_slack" "slack" {
   wiki_page_channel            = "test"
   notify_only_broken_pipelines = true
   notify_only_default_branch   = true
+  branches_to_be_notified      = "all"
 }
 `, rInt)
 }
@@ -251,6 +252,7 @@ resource "gitlab_service_slack" "slack" {
   wiki_page_channel            = "test wiki_page_channel"
   notify_only_broken_pipelines = false
   notify_only_default_branch   = false
+  branches_to_be_notified      = "all"
 }
 `, rInt)
 }

--- a/website/docs/r/service_slack.html.markdown
+++ b/website/docs/r/service_slack.html.markdown
@@ -40,7 +40,9 @@ The following arguments are supported:
 
 * `notify_only_broken_pipelines` - (Optional) Send notifications for broken pipelines.
 
-* `notify_only_default_branch` - (Optional) Send notifications only for the default branch.
+* `notify_only_default_branch` - (Optional) DEPRECATED: This parameter has been replaced with `branches_to_be_notified`.
+
+* `branches_to_be_notified` - (Optional) Branches to send notifications for. Valid options are "all", "default", "protected", and "default_and_protected".
 
 * `push_events` - (Optional) Enable notifications for push events.
 


### PR DESCRIPTION
Currently, `notify_only_default_branches` is deprecated. `branches_to_be_notified` is the replacement. Everything is documented [here](https://docs.gitlab.com/ee/api/services.html#slack-notifications)

This PR deletes the first and creates the second.