### PR TITLE
Fix for acceptance tests: lock Gitlab to v12.6.4

### DIFF
--- a/scripts/start-gitlab.sh
+++ b/scripts/start-gitlab.sh
@@ -4,7 +4,7 @@ echo "Starting gitlab container..."
 if [[ -n $GITLAB_LICENSE_FILE ]]
 then
     extra="-v $PWD/license:/license -e GITLAB_LICENSE_FILE=/license/$GITLAB_LICENSE_FILE"
-    img=gitlab/gitlab-ee:12.6.4-ce.0
+    img=gitlab/gitlab-ee:12.6.4-ee.0
     if [[ ! -f license/$GITLAB_LICENSE_FILE ]]
     then
         echo No license

--- a/scripts/start-gitlab.sh
+++ b/scripts/start-gitlab.sh
@@ -4,14 +4,14 @@ echo "Starting gitlab container..."
 if [[ -n $GITLAB_LICENSE_FILE ]]
 then
     extra="-v $PWD/license:/license -e GITLAB_LICENSE_FILE=/license/$GITLAB_LICENSE_FILE"
-    img=gitlab/gitlab-ee
+    img=gitlab/gitlab-ee:12.6.4-ce.0
     if [[ ! -f license/$GITLAB_LICENSE_FILE ]]
     then
         echo No license
         exit 1
     fi
 else
-    img=gitlab/gitlab-ce
+    img=gitlab/gitlab-ce:12.6.4-ce.0
 fi
 docker run -d --rm --name gitlab \
   -e GITLAB_ROOT_PASSWORD=adminadmin \


### PR DESCRIPTION
After #247 I did some more exploratory testing with various Gitlab CE versions. My test setup is now based on a Vagrant setup I found [here](https://gist.github.com/cjtallman/b526d8c7d8b910ba4fd41eb51cd5405b).

Here is a timeline of the [Gitlab releases](https://about.gitlab.com/releases/categories/releases/), interleaved with the commits and Travis results of my previous PR:

09/01 - 12.6.3
13/01 - 12.6.4   

First commit on 15/01 - Travis build OK

22/01 - 12.7.0
24/01 - 12.7.2
30/01 - 12.7.4 + 12.6.6
31/01 - 12.7.5

Second commit on 31/01 - Rebased & Travis fails

13/02 - 12.7.6 + 12.6.7

So I started running the acceptance tests against different versions with these results:

12.6.4 = PASS
12.6.7 = FAIL
12.7.0 = FAIL

2nd round:
12.6.4 = PASS
12.6.6 = PASS

I'm locking the Gitlab version now to 12.6.4 as I have twice a success which makes it deterministic.

Probably there is a regression somewhere in Gitlab which makes the test results for the provider fail. While it can be fixed upstream, this provider has stable tests now.
