### PR TITLE
Update go-gitlab to v0.28.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/ulikunitz/xz v0.5.6 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
-	github.com/xanzy/go-gitlab v0.22.3
+	github.com/xanzy/go-gitlab v0.28.0
 	github.com/zclconf/go-cty v1.1.1 // indirect
 	go.opencensus.io v0.22.2 // indirect
 	golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/xanzy/go-gitlab v0.22.2 h1:KYPewSm3Tl7WHrVON7BOwX6FZ1gaiFEdpOt0DNIYyS
 github.com/xanzy/go-gitlab v0.22.2/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
 github.com/xanzy/go-gitlab v0.22.3 h1:/rNlZ2hquUWNc6rJdntVM03tEOoTmnZ1lcNyJCl0WlU=
 github.com/xanzy/go-gitlab v0.22.3/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
+github.com/xanzy/go-gitlab v0.28.0 h1:nsyjDVvBrP4KRXEN4b1m1ewiqmTNL4BOWW041nKGV7k=
+github.com/xanzy/go-gitlab v0.28.0/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/vendor/github.com/xanzy/go-gitlab/.travis.yml
+++ b/vendor/github.com/xanzy/go-gitlab/.travis.yml
@@ -1,8 +1,6 @@
 language: go
 
 go:
-  - 1.10.x
-  - 1.11.x
   - 1.12.x
   - 1.13.x
   - master

--- a/vendor/github.com/xanzy/go-gitlab/LICENSE
+++ b/vendor/github.com/xanzy/go-gitlab/LICENSE
@@ -1,4 +1,4 @@
-Apache License
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
@@ -178,7 +178,7 @@ Apache License
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -199,4 +199,3 @@ Apache License
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/vendor/github.com/xanzy/go-gitlab/commits.go
+++ b/vendor/github.com/xanzy/go-gitlab/commits.go
@@ -70,12 +70,13 @@ func (c Commit) String() string {
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#list-repository-commits
 type ListCommitsOptions struct {
 	ListOptions
-	RefName   *string    `url:"ref_name,omitempty" json:"ref_name,omitempty"`
-	Since     *time.Time `url:"since,omitempty" json:"since,omitempty"`
-	Until     *time.Time `url:"until,omitempty" json:"until,omitempty"`
-	Path      *string    `url:"path,omitempty" json:"path,omitempty"`
-	All       *bool      `url:"all,omitempty" json:"all,omitempty"`
-	WithStats *bool      `url:"with_stats,omitempty" json:"with_stats,omitempty"`
+	RefName     *string    `url:"ref_name,omitempty" json:"ref_name,omitempty"`
+	Since       *time.Time `url:"since,omitempty" json:"since,omitempty"`
+	Until       *time.Time `url:"until,omitempty" json:"until,omitempty"`
+	Path        *string    `url:"path,omitempty" json:"path,omitempty"`
+	All         *bool      `url:"all,omitempty" json:"all,omitempty"`
+	WithStats   *bool      `url:"with_stats,omitempty" json:"with_stats,omitempty"`
+	FirstParent *bool      `url:"first_parent,omitempty" json:"first_parent,omitempty"`
 }
 
 // ListCommits gets a list of repository commits in a project.

--- a/vendor/github.com/xanzy/go-gitlab/deployments.go
+++ b/vendor/github.com/xanzy/go-gitlab/deployments.go
@@ -118,3 +118,71 @@ func (s *DeploymentsService) GetProjectDeployment(pid interface{}, deployment in
 
 	return d, resp, err
 }
+
+// CreateProjectDeploymentOptions represents the available
+// CreateProjectDeployment() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/deployments.html#create-a-deployment
+type CreateProjectDeploymentOptions struct {
+	Environment *string                `url:"environment,omitempty" json:"environment,omitempty"`
+	Ref         *string                `url:"ref,omitempty" json:"ref,omitempty"`
+	SHA         *string                `url:"sha,omitempty" json:"sha,omitempty"`
+	Tag         *bool                  `url:"tag,omitempty" json:"tag,omitempty"`
+	Status      *DeploymentStatusValue `url:"status,omitempty" json:"status,omitempty"`
+}
+
+// CreateProjectDeployment creates a project deployment.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/deployments.html#create-a-deployment
+func (s *DeploymentsService) CreateProjectDeployment(pid interface{}, opt *CreateProjectDeploymentOptions, options ...OptionFunc) (*Deployment, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/deployments", pathEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	d := new(Deployment)
+	resp, err := s.client.Do(req, &d)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return d, resp, err
+}
+
+// UpdateProjectDeploymentOptions represents the available
+// UpdateProjectDeployment() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/deployments.html#updating-a-deployment
+type UpdateProjectDeploymentOptions struct {
+	Status *DeploymentStatusValue `url:"status,omitempty" json:"status,omitempty"`
+}
+
+// UpdateProjectDeployment updates a project deployment.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/deployments.html#updating-a-deployment
+func (s *DeploymentsService) UpdateProjectDeployment(pid interface{}, deployment int, opt *UpdateProjectDeploymentOptions, options ...OptionFunc) (*Deployment, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/deployments/%d", pathEscape(project), deployment)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	d := new(Deployment)
+	resp, err := s.client.Do(req, &d)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return d, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/event_parsing.go
+++ b/vendor/github.com/xanzy/go-gitlab/event_parsing.go
@@ -11,15 +11,18 @@ type EventType string
 
 // List of available event types.
 const (
-	EventTypeBuild        EventType = "Build Hook"
-	EventTypeIssue        EventType = "Issue Hook"
-	EventTypeJob          EventType = "Job Hook"
-	EventTypeMergeRequest EventType = "Merge Request Hook"
-	EventTypeNote         EventType = "Note Hook"
-	EventTypePipeline     EventType = "Pipeline Hook"
-	EventTypePush         EventType = "Push Hook"
-	EventTypeTagPush      EventType = "Tag Push Hook"
-	EventTypeWikiPage     EventType = "Wiki Page Hook"
+	EventTypeBuild         EventType = "Build Hook"
+	EventTypeIssue         EventType = "Issue Hook"
+	EventConfidentialIssue EventType = "Confidential Issue Hook"
+	EventTypeJob           EventType = "Job Hook"
+	EventTypeMergeRequest  EventType = "Merge Request Hook"
+	EventTypeNote          EventType = "Note Hook"
+	EventConfidentialNote  EventType = "Confidential Note Hook"
+	EventTypePipeline      EventType = "Pipeline Hook"
+	EventTypePush          EventType = "Push Hook"
+	EventTypeSystemHook    EventType = "System Hook"
+	EventTypeTagPush       EventType = "Tag Push Hook"
+	EventTypeWikiPage      EventType = "Wiki Page Hook"
 )
 
 const (
@@ -38,6 +41,119 @@ type noteEvent struct {
 
 const eventTypeHeader = "X-Gitlab-Event"
 
+// HookEventType returns the event type for the given request.
+func HookEventType(r *http.Request) EventType {
+	return EventType(r.Header.Get(eventTypeHeader))
+}
+
+// ParseHook tries to parse both web- and system hooks.
+//
+// Example usage:
+//
+// func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+//     payload, err := ioutil.ReadAll(r.Body)
+//     if err != nil { ... }
+//     event, err := gitlab.ParseHook(gitlab.HookEventType(r), payload)
+//     if err != nil { ... }
+//     switch event := event.(type) {
+//     case *gitlab.PushEvent:
+//         processPushEvent(event)
+//     case *gitlab.MergeEvent:
+//         processMergeEvent(event)
+//     ...
+//     }
+// }
+//
+func ParseHook(eventType EventType, payload []byte) (event interface{}, err error) {
+	switch eventType {
+	case EventTypeSystemHook:
+		return ParseSystemhook(payload)
+	default:
+		return ParseWebhook(eventType, payload)
+	}
+}
+
+// ParseSystemhook parses the event payload. For recognized event types, a
+// value of the corresponding struct type will be returned. An error will be
+// returned for unrecognized event types.
+//
+// Example usage:
+//
+// func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+//     payload, err := ioutil.ReadAll(r.Body)
+//     if err != nil { ... }
+//     event, err := gitlab.ParseSystemhook(payload)
+//     if err != nil { ... }
+//     switch event := event.(type) {
+//     case *gitlab.PushSystemEvent:
+//         processPushSystemEvent(event)
+//     case *gitlab.MergeSystemEvent:
+//         processMergeSystemEvent(event)
+//     ...
+//     }
+// }
+//
+func ParseSystemhook(payload []byte) (event interface{}, err error) {
+	e := &systemHookEvent{}
+	err = json.Unmarshal(payload, e)
+	if err != nil {
+		return nil, err
+	}
+
+	switch e.EventName {
+	case "push":
+		event = &PushSystemEvent{}
+	case "tag_push":
+		event = &TagPushSystemEvent{}
+	case "repository_update":
+		event = &RepositoryUpdateSystemEvent{}
+	case
+		"project_create",
+		"project_update",
+		"project_destroy",
+		"project_transfer",
+		"project_rename":
+		event = &ProjectSystemEvent{}
+	case
+		"group_create",
+		"group_destroy",
+		"group_rename":
+		event = &GroupSystemEvent{}
+	case
+		"key_create",
+		"key_destroy":
+		event = &KeySystemEvent{}
+	case
+		"user_create",
+		"user_destroy",
+		"user_rename":
+		event = &UserSystemEvent{}
+	case
+		"user_add_to_group",
+		"user_remove_from_group",
+		"user_update_for_group":
+		event = &UserGroupSystemEvent{}
+	case
+		"user_add_to_team",
+		"user_remove_from_team",
+		"user_update_for_team":
+		event = &UserTeamSystemEvent{}
+	default:
+		switch e.ObjectKind {
+		case "merge_request":
+			event = &MergeEvent{}
+		default:
+			return nil, fmt.Errorf("unexpected system hook type %s", e.EventName)
+		}
+	}
+
+	if err := json.Unmarshal(payload, event); err != nil {
+		return nil, err
+	}
+
+	return event, nil
+}
+
 // WebhookEventType returns the event type for the given request.
 func WebhookEventType(r *http.Request) EventType {
 	return EventType(r.Header.Get(eventTypeHeader))
@@ -52,7 +168,7 @@ func WebhookEventType(r *http.Request) EventType {
 // func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 //     payload, err := ioutil.ReadAll(r.Body)
 //     if err != nil { ... }
-//     event, err := gitlab.ParseWebhook(gitlab.WebhookEventType(r), payload)
+//     event, err := gitlab.ParseWebhook(gitlab.HookEventType(r), payload)
 //     if err != nil { ... }
 //     switch event := event.(type) {
 //     case *gitlab.PushEvent:
@@ -67,7 +183,7 @@ func ParseWebhook(eventType EventType, payload []byte) (event interface{}, err e
 	switch eventType {
 	case EventTypeBuild:
 		event = &BuildEvent{}
-	case EventTypeIssue:
+	case EventTypeIssue, EventConfidentialIssue:
 		event = &IssueEvent{}
 	case EventTypeJob:
 		event = &JobEvent{}
@@ -81,7 +197,7 @@ func ParseWebhook(eventType EventType, payload []byte) (event interface{}, err e
 		event = &TagEvent{}
 	case EventTypeWikiPage:
 		event = &WikiPageEvent{}
-	case EventTypeNote:
+	case EventTypeNote, EventConfidentialNote:
 		note := &noteEvent{}
 		err := json.Unmarshal(payload, note)
 		if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/event_systemhook_types.go
+++ b/vendor/github.com/xanzy/go-gitlab/event_systemhook_types.go
@@ -1,0 +1,133 @@
+package gitlab
+
+// systemHookEvent is used to pre-process events to determine the
+// system hook event type.
+type systemHookEvent struct {
+	BaseSystemEvent
+	ObjectKind string `json:"object_kind"`
+}
+
+// BaseSystemEvent contains system hook's common properties.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+type BaseSystemEvent struct {
+	EventName string `json:"event_name"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// ProjectSystemEvent represents a project system event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+type ProjectSystemEvent struct {
+	BaseSystemEvent
+	Name                 string `json:"name"`
+	Path                 string `json:"path"`
+	PathWithNamespace    string `json:"path_with_namespace"`
+	ProjectID            int    `json:"project_id"`
+	OwnerName            string `json:"owner_name"`
+	OwnerEmail           string `json:"owner_email"`
+	ProjectVisibility    string `json:"project_visibility"`
+	OldPathWithNamespace string `json:"old_path_with_namespace,omitempty"`
+}
+
+// GroupSystemEvent represents a group system event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+type GroupSystemEvent struct {
+	BaseSystemEvent
+	Name                 string `json:"name"`
+	Path                 string `json:"path"`
+	PathWithNamespace    string `json:"full_path"`
+	GroupID              int    `json:"group_id"`
+	OwnerName            string `json:"owner_name"`
+	OwnerEmail           string `json:"owner_email"`
+	ProjectVisibility    string `json:"project_visibility"`
+	OldPath              string `json:"old_path,omitempty"`
+	OldPathWithNamespace string `json:"old_full_path,omitempty"`
+}
+
+// KeySystemEvent represents a key system event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+type KeySystemEvent struct {
+	BaseSystemEvent
+	ID       int    `json:"id"`
+	Username string `json:"username"`
+	Key      string `json:"key"`
+}
+
+// UserSystemEvent represents a user system event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+type UserSystemEvent struct {
+	BaseSystemEvent
+	ID          int    `json:"user_id"`
+	Name        string `json:"name"`
+	Username    string `json:"username"`
+	OldUsername string `json:"old_username,omitempty"`
+	Email       string `json:"email"`
+}
+
+// UserGroupSystemEvent represents a user group system event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+type UserGroupSystemEvent struct {
+	BaseSystemEvent
+	ID          int    `json:"user_id"`
+	Name        string `json:"user_name"`
+	Username    string `json:"user_username"`
+	Email       string `json:"user_email"`
+	GroupID     int    `json:"group_id"`
+	GroupName   string `json:"group_name"`
+	GroupPath   string `json:"group_path"`
+	GroupAccess string `json:"group_access"`
+}
+
+// UserTeamSystemEvent represents a user team system event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+type UserTeamSystemEvent struct {
+	BaseSystemEvent
+	ID                       int    `json:"user_id"`
+	Name                     string `json:"user_name"`
+	Username                 string `json:"user_username"`
+	Email                    string `json:"user_email"`
+	ProjectID                int    `json:"project_id"`
+	ProjectName              string `json:"project_name"`
+	ProjectPath              string `json:"project_path"`
+	ProjectPathWithNamespace string `json:"project_path_with_namespace"`
+	ProjectVisibility        string `json:"project_visibility"`
+	AccessLevel              string `json:"access_level"`
+}
+
+// PushSystemEvent represents a push system event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+type PushSystemEvent struct {
+	BaseSystemEvent
+}
+
+// TagPushSystemEvent represents a tag push system event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+type TagPushSystemEvent struct {
+	BaseSystemEvent
+}
+
+// RepositoryUpdateSystemEvent represents a repository updated system event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+type RepositoryUpdateSystemEvent struct {
+	BaseSystemEvent
+}

--- a/vendor/github.com/xanzy/go-gitlab/event_webhook_types.go
+++ b/vendor/github.com/xanzy/go-gitlab/event_webhook_types.go
@@ -336,6 +336,7 @@ type MergeCommentEvent struct {
 		SourceProjectID           int          `json:"source_project_id"`
 		AuthorID                  int          `json:"author_id"`
 		AssigneeID                int          `json:"assignee_id"`
+		AssigneeIDs               []int        `json:"assignee_ids"`
 		Title                     string       `json:"title"`
 		CreatedAt                 string       `json:"created_at"`
 		UpdatedAt                 string       `json:"updated_at"`

--- a/vendor/github.com/xanzy/go-gitlab/gitlab.go
+++ b/vendor/github.com/xanzy/go-gitlab/gitlab.go
@@ -83,12 +83,25 @@ type BuildStateValue string
 // These constants represent all valid build states.
 const (
 	Pending  BuildStateValue = "pending"
+	Created  BuildStateValue = "created"
 	Running  BuildStateValue = "running"
 	Success  BuildStateValue = "success"
 	Failed   BuildStateValue = "failed"
 	Canceled BuildStateValue = "canceled"
 	Skipped  BuildStateValue = "skipped"
 	Manual   BuildStateValue = "manual"
+)
+
+// DeploymentStatusValue represents a Gitlab deployment status.
+type DeploymentStatusValue string
+
+// These constants represent all valid deployment statuses.
+const (
+	DeploymentStatusCreated  DeploymentStatusValue = "created"
+	DeploymentStatusRunning  DeploymentStatusValue = "running"
+	DeploymentStatusSuccess  DeploymentStatusValue = "success"
+	DeploymentStatusFailed   DeploymentStatusValue = "failed"
+	DeploymentStatusCanceled DeploymentStatusValue = "canceled"
 )
 
 // ISOTime represents an ISO 8601 formatted date
@@ -213,6 +226,33 @@ const (
 	PrivateVisibility  VisibilityValue = "private"
 	InternalVisibility VisibilityValue = "internal"
 	PublicVisibility   VisibilityValue = "public"
+)
+
+// ProjectCreationLevelValue represents a project creation level within GitLab.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/
+type ProjectCreationLevelValue string
+
+// List of available project creation levels.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/
+const (
+	NoOneProjectCreation      ProjectCreationLevelValue = "noone"
+	MaintainerProjectCreation ProjectCreationLevelValue = "maintainer"
+	DeveloperProjectCreation  ProjectCreationLevelValue = "developer"
+)
+
+// SubGroupCreationLevelValue represents a sub group creation level within GitLab.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/
+type SubGroupCreationLevelValue string
+
+// List of available sub group creation levels.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/
+const (
+	OwnerSubGroupCreationLevelValue      SubGroupCreationLevelValue = "owner"
+	MaintainerSubGroupCreationLevelValue SubGroupCreationLevelValue = "maintainer"
 )
 
 // VariableTypeValue represents a variable type within GitLab.
@@ -901,6 +941,14 @@ func BuildState(v BuildStateValue) *BuildStateValue {
 	return p
 }
 
+// DeploymentStatus is a helper routine that allocates a new
+// DeploymentStatusValue to store v and returns a pointer to it.
+func DeploymentStatus(v DeploymentStatusValue) *DeploymentStatusValue {
+	p := new(DeploymentStatusValue)
+	*p = v
+	return p
+}
+
 // NotificationLevel is a helper routine that allocates a new NotificationLevelValue
 // to store v and returns a pointer to it.
 func NotificationLevel(v NotificationLevelValue) *NotificationLevelValue {
@@ -921,6 +969,22 @@ func VariableType(v VariableTypeValue) *VariableTypeValue {
 // to store v and returns a pointer to it.
 func Visibility(v VisibilityValue) *VisibilityValue {
 	p := new(VisibilityValue)
+	*p = v
+	return p
+}
+
+// ProjectCreationLevel is a helper routine that allocates a new ProjectCreationLevelValue
+// to store v and returns a pointer to it.
+func ProjectCreationLevel(v ProjectCreationLevelValue) *ProjectCreationLevelValue {
+	p := new(ProjectCreationLevelValue)
+	*p = v
+	return p
+}
+
+// SubGroupCreationLevel is a helper routine that allocates a new SubGroupCreationLevelValue
+// to store v and returns a pointer to it.
+func SubGroupCreationLevel(v SubGroupCreationLevelValue) *SubGroupCreationLevelValue {
+	p := new(SubGroupCreationLevelValue)
 	*p = v
 	return p
 }

--- a/vendor/github.com/xanzy/go-gitlab/group_boards.go
+++ b/vendor/github.com/xanzy/go-gitlab/group_boards.go
@@ -77,6 +77,40 @@ func (s *GroupIssueBoardsService) ListGroupIssueBoards(gid interface{}, opt *Lis
 	return gs, resp, err
 }
 
+// CreateGroupIssueBoardOptions represents the available
+// CreateGroupIssueBoard() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_boards.html#create-a-group-issue-board-premium
+type CreateGroupIssueBoardOptions struct {
+	Name *string `url:"name" json:"name"`
+}
+
+// CreateGroupIssueBoard creates a new issue board.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_boards.html#create-a-group-issue-board-premium
+func (s *GroupIssueBoardsService) CreateGroupIssueBoard(gid interface{}, opt *CreateGroupIssueBoardOptions, options ...OptionFunc) (*GroupIssueBoard, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/boards", pathEscape(group))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gib := new(GroupIssueBoard)
+	resp, err := s.client.Do(req, gib)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gib, resp, err
+}
+
 // GetGroupIssueBoard gets a single issue board of a group.
 //
 // GitLab API docs:
@@ -100,6 +134,62 @@ func (s *GroupIssueBoardsService) GetGroupIssueBoard(gid interface{}, board int,
 	}
 
 	return gib, resp, err
+}
+
+// UpdateGroupIssueBoardOptions represents a group issue board.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_boards.html#update-a-group-issue-board-premium
+type UpdateGroupIssueBoardOptions struct {
+	Name        *string `url:"name,omitempty" json:"name,omitempty"`
+	AssigneeID  *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	MilestoneID *int    `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
+	Labels      *Labels `url:"labels,omitempty" json:"labels,omitempty"`
+	Weight      *int    `url:"weight,omitempty" json:"weight,omitempty"`
+}
+
+// UpdateIssueBoard updates a single issue board of a group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_boards.html#update-a-group-issue-board-premium
+func (s *GroupIssueBoardsService) UpdateIssueBoard(gid interface{}, board int, opt *UpdateGroupIssueBoardOptions, options ...OptionFunc) (*GroupIssueBoard, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/boards/%d", pathEscape(group), board)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gib := new(GroupIssueBoard)
+	resp, err := s.client.Do(req, gib)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gib, resp, err
+}
+
+// DeleteIssueBoard delete a single issue board of a group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_boards.html#delete-a-group-issue-board-premium
+func (s *GroupIssueBoardsService) DeleteIssueBoard(gid interface{}, board int, options ...OptionFunc) (*Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/boards/%d", pathEscape(group), board)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }
 
 // ListGroupIssueBoardListsOptions represents the available

--- a/vendor/github.com/xanzy/go-gitlab/group_hooks.go
+++ b/vendor/github.com/xanzy/go-gitlab/group_hooks.go
@@ -1,0 +1,65 @@
+//
+// Copyright 2020, Eric Stevens
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"time"
+)
+
+// GroupHook represents a GitLab group hook.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#list-group-hooks
+type GroupHook struct {
+	ID                       int        `json:"id"`
+	URL                      string     `json:"url"`
+	GroupID                  int        `json:"group_id"`
+	PushEvents               bool       `json:"push_events"`
+	IssuesEvents             bool       `json:"issues_events"`
+	ConfidentialIssuesEvents bool       `json:"confidential_issues_events"`
+	MergeRequestsEvents      bool       `json:"merge_requests_events"`
+	TagPushEvents            bool       `json:"tag_push_events"`
+	NoteEvents               bool       `json:"note_events"`
+	JobEvents                bool       `json:"job_events"`
+	PipelineEvents           bool       `json:"pipeline_events"`
+	WikiPageEvents           bool       `json:"wiki_page_events"`
+	EnableSslVerification    bool       `json:"enable_ssl_verification"`
+	CreatedAt                *time.Time `json:"created_at"`
+}
+
+// ListGroupHooks gets a list of group hooks.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#list-group-hooks
+func (s *GroupsService) ListGroupHooks(gid interface{}) ([]*GroupHook, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/hooks", pathEscape(group))
+
+	req, err := s.client.NewRequest("GET", u, nil, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var gh []*GroupHook
+	resp, err := s.client.Do(req, &gh)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gh, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/group_members.go
+++ b/vendor/github.com/xanzy/go-gitlab/group_members.go
@@ -28,18 +28,30 @@ type GroupMembersService struct {
 	client *Client
 }
 
+// GroupMemberSAMLIdentity represents the SAML Identity link for the group member.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
+// Gitlab MR for API change: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/20357
+// Gitlab MR for API Doc change: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/25652
+type GroupMemberSAMLIdentity struct {
+	ExternUID      string `json:"extern_uid"`
+	Provider       string `json:"provider"`
+	SAMLProviderID int    `json:"saml_provider_id"`
+}
+
 // GroupMember represents a GitLab group member.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/members.html
 type GroupMember struct {
-	ID          int              `json:"id"`
-	Username    string           `json:"username"`
-	Name        string           `json:"name"`
-	State       string           `json:"state"`
-	AvatarURL   string           `json:"avatar_url"`
-	WebURL      string           `json:"web_url"`
-	ExpiresAt   *ISOTime         `json:"expires_at"`
-	AccessLevel AccessLevelValue `json:"access_level"`
+	ID                int                      `json:"id"`
+	Username          string                   `json:"username"`
+	Name              string                   `json:"name"`
+	State             string                   `json:"state"`
+	AvatarURL         string                   `json:"avatar_url"`
+	WebURL            string                   `json:"web_url"`
+	ExpiresAt         *ISOTime                 `json:"expires_at"`
+	AccessLevel       AccessLevelValue         `json:"access_level"`
+	GroupSAMLIdentity *GroupMemberSAMLIdentity `json:"group_saml_identity"`
 }
 
 // ListGroupMembersOptions represents the available ListGroupMembers() and

--- a/vendor/github.com/xanzy/go-gitlab/group_variables.go
+++ b/vendor/github.com/xanzy/go-gitlab/group_variables.go
@@ -39,6 +39,7 @@ type GroupVariable struct {
 	Value        string            `json:"value"`
 	VariableType VariableTypeValue `json:"variable_type"`
 	Protected    bool              `json:"protected"`
+	Masked       bool              `json:"masked"`
 }
 
 func (v GroupVariable) String() string {
@@ -112,6 +113,7 @@ type CreateGroupVariableOptions struct {
 	Value        *string            `url:"value,omitempty" json:"value,omitempty"`
 	VariableType *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 	Protected    *bool              `url:"protected,omitempty" json:"protected,omitempty"`
+	Masked       *bool              `url:"masked,omitempty" json:"masked,omitempty"`
 }
 
 // CreateVariable creates a new group variable.
@@ -148,6 +150,7 @@ type UpdateGroupVariableOptions struct {
 	Value        *string            `url:"value,omitempty" json:"value,omitempty"`
 	VariableType *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 	Protected    *bool              `url:"protected,omitempty" json:"protected,omitempty"`
+	Masked       *bool              `url:"masked,omitempty" json:"masked,omitempty"`
 }
 
 // UpdateVariable updates the position of an existing

--- a/vendor/github.com/xanzy/go-gitlab/groups.go
+++ b/vendor/github.com/xanzy/go-gitlab/groups.go
@@ -32,34 +32,36 @@ type GroupsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html
 type Group struct {
-	ID                             int                `json:"id"`
-	Name                           string             `json:"name"`
-	Path                           string             `json:"path"`
-	Description                    string             `json:"description"`
-	Visibility                     *VisibilityValue   `json:"visibility"`
-	LFSEnabled                     bool               `json:"lfs_enabled"`
-	AvatarURL                      string             `json:"avatar_url"`
-	WebURL                         string             `json:"web_url"`
-	RequestAccessEnabled           bool               `json:"request_access_enabled"`
-	FullName                       string             `json:"full_name"`
-	FullPath                       string             `json:"full_path"`
-	ParentID                       int                `json:"parent_id"`
-	Projects                       []*Project         `json:"projects"`
-	Statistics                     *StorageStatistics `json:"statistics"`
-	CustomAttributes               []*CustomAttribute `json:"custom_attributes"`
-	ShareWithGroupLock             bool               `json:"share_with_group_lock"`
-	RequireTwoFactorAuth           bool               `json:"require_two_factor_authentication"`
-	TwoFactorGracePeriod           int                `json:"two_factor_grace_period"`
-	ProjectCreationLevel           string             `json:"project_creation_level"`
-	AutoDevopsEnabled              bool               `json:"auto_devops_enabled"`
-	SubGroupCreationLevel          string             `json:"subgroup_creation_level"`
-	EmailsDisabled                 bool               `json:"emails_disabled"`
-	RunnersToken                   string             `json:"runners_token"`
-	SharedProjects                 []*Project         `json:"shared_projects"`
-	LDAPCN                         string             `json:"ldap_cn"`
-	LDAPAccess                     bool               `json:"ldap_access"`
-	SharedRunnersMinutesLimit      int                `json:"shared_runners_minutes_limit"`
-	ExtraSharedRunnersMinutesLimit int                `json:"extra_shared_runners_minutes_limit"`
+	ID                             int                        `json:"id"`
+	Name                           string                     `json:"name"`
+	Path                           string                     `json:"path"`
+	Description                    string                     `json:"description"`
+	MembershipLock                 bool                       `json:"membership_lock"`
+	Visibility                     VisibilityValue            `json:"visibility"`
+	LFSEnabled                     bool                       `json:"lfs_enabled"`
+	AvatarURL                      string                     `json:"avatar_url"`
+	WebURL                         string                     `json:"web_url"`
+	RequestAccessEnabled           bool                       `json:"request_access_enabled"`
+	FullName                       string                     `json:"full_name"`
+	FullPath                       string                     `json:"full_path"`
+	ParentID                       int                        `json:"parent_id"`
+	Projects                       []*Project                 `json:"projects"`
+	Statistics                     *StorageStatistics         `json:"statistics"`
+	CustomAttributes               []*CustomAttribute         `json:"custom_attributes"`
+	ShareWithGroupLock             bool                       `json:"share_with_group_lock"`
+	RequireTwoFactorAuth           bool                       `json:"require_two_factor_authentication"`
+	TwoFactorGracePeriod           int                        `json:"two_factor_grace_period"`
+	ProjectCreationLevel           ProjectCreationLevelValue  `json:"project_creation_level"`
+	AutoDevopsEnabled              bool                       `json:"auto_devops_enabled"`
+	SubGroupCreationLevel          SubGroupCreationLevelValue `json:"subgroup_creation_level"`
+	EmailsDisabled                 bool                       `json:"emails_disabled"`
+	MentionsDisabled               bool                       `json:"mentions_disabled"`
+	RunnersToken                   string                     `json:"runners_token"`
+	SharedProjects                 []*Project                 `json:"shared_projects"`
+	LDAPCN                         string                     `json:"ldap_cn"`
+	LDAPAccess                     AccessLevelValue           `json:"ldap_access"`
+	SharedRunnersMinutesLimit      int                        `json:"shared_runners_minutes_limit"`
+	ExtraSharedRunnersMinutesLimit int                        `json:"extra_shared_runners_minutes_limit"`
 }
 
 // ListGroupsOptions represents the available ListGroups() options.
@@ -125,13 +127,24 @@ func (s *GroupsService) GetGroup(gid interface{}, options ...OptionFunc) (*Group
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#new-group
 type CreateGroupOptions struct {
-	Name                 *string          `url:"name,omitempty" json:"name,omitempty"`
-	Path                 *string          `url:"path,omitempty" json:"path,omitempty"`
-	Description          *string          `url:"description,omitempty" json:"description,omitempty"`
-	Visibility           *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
-	LFSEnabled           *bool            `url:"lfs_enabled,omitempty" json:"lfs_enabled,omitempty"`
-	RequestAccessEnabled *bool            `url:"request_access_enabled,omitempty" json:"request_access_enabled,omitempty"`
-	ParentID             *int             `url:"parent_id,omitempty" json:"parent_id,omitempty"`
+	Name                           *string                     `url:"name,omitempty" json:"name,omitempty"`
+	Path                           *string                     `url:"path,omitempty" json:"path,omitempty"`
+	Description                    *string                     `url:"description,omitempty" json:"description,omitempty"`
+	MembershipLock                 *bool                       `url:"membership_lock,omitempty" json:"membership_lock,omitempty"`
+	Visibility                     *VisibilityValue            `url:"visibility,omitempty" json:"visibility,omitempty"`
+	ShareWithGroupLock             *bool                       `url:"share_with_group_lock,omitempty" json:"share_with_group_lock,omitempty"`
+	RequireTwoFactorAuth           *bool                       `url:"require_two_factor_authentication,omitempty" json:"require_two_factor_authentication,omitempty"`
+	TwoFactorGracePeriod           *int                        `url:"two_factor_grace_period,omitempty" json:"two_factor_grace_period,omitempty"`
+	ProjectCreationLevel           *ProjectCreationLevelValue  `url:"project_creation_level,omitempty" json:"project_creation_level,omitempty"`
+	AutoDevopsEnabled              *bool                       `url:"auto_devops_enabled,omitempty" json:"auto_devops_enabled,omitempty"`
+	SubGroupCreationLevel          *SubGroupCreationLevelValue `url:"subgroup_creation_level,omitempty" json:"subgroup_creation_level,omitempty"`
+	EmailsDisabled                 *bool                       `url:"emails_disabled,omitempty" json:"emails_disabled,omitempty"`
+	MentionsDisabled               *bool                       `url:"mentions_disabled,omitempty" json:"mentions_disabled,omitempty"`
+	LFSEnabled                     *bool                       `url:"lfs_enabled,omitempty" json:"lfs_enabled,omitempty"`
+	RequestAccessEnabled           *bool                       `url:"request_access_enabled,omitempty" json:"request_access_enabled,omitempty"`
+	ParentID                       *int                        `url:"parent_id,omitempty" json:"parent_id,omitempty"`
+	SharedRunnersMinutesLimit      *int                        `url:"shared_runners_minutes_limit,omitempty" json:"shared_runners_minutes_limit,omitempty"`
+	ExtraSharedRunnersMinutesLimit *int                        `url:"extra_shared_runners_minutes_limit,omitempty" json:"extra_shared_runners_minutes_limit,omitempty"`
 }
 
 // CreateGroup creates a new project group. Available only for users who can

--- a/vendor/github.com/xanzy/go-gitlab/issues.go
+++ b/vendor/github.com/xanzy/go-gitlab/issues.go
@@ -19,6 +19,7 @@ package gitlab
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -91,6 +92,10 @@ type Issue struct {
 	Links             *IssueLinks      `json:"_links"`
 	IssueLinkID       int              `json:"issue_link_id"`
 	MergeRequestCount int              `json:"merge_requests_count"`
+	TaskCompletionStatus struct {
+		Count          int `json:"count"`
+		CompletedCount int `json:"completed_count"`
+	} `json:"task_completion_status"`
 }
 
 func (i Issue) String() string {
@@ -103,6 +108,12 @@ type Labels []string
 // MarshalJSON implements the json.Marshaler interface.
 func (l *Labels) MarshalJSON() ([]byte, error) {
 	return json.Marshal(strings.Join(*l, ","))
+}
+
+// EncodeValues implements the query.EncodeValues interface
+func (l *Labels) EncodeValues(key string, v *url.Values) error {
+	v.Set(key, strings.Join(*l, ","))
+	return nil
 }
 
 // ListIssuesOptions represents the available ListIssues() options.

--- a/vendor/github.com/xanzy/go-gitlab/merge_request_approvals.go
+++ b/vendor/github.com/xanzy/go-gitlab/merge_request_approvals.go
@@ -74,6 +74,17 @@ type MergeRequestApprovalRule struct {
 	Users                []*BasicUser         `json:"users"`
 	Groups               []*Group             `json:"groups"`
 	ContainsHiddenGroups bool                 `json:"contains_hidden_groups"`
+	ApprovedBy           []*BasicUser         `json:"approved_by"`
+	Approved             bool                 `json:"approved"`
+}
+
+// MergeRequestApprovalState represents a GitLab merge request approval state.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-the-approval-state-of-merge-requests
+type MergeRequestApprovalState struct {
+	ApprovalRulesOverwritten bool                        `json:"approval_rules_overwritten"`
+	Rules                    []*MergeRequestApprovalRule `json:"rules"`
 }
 
 // String is a stringify for MergeRequestApprovalRule
@@ -149,6 +160,31 @@ func (s *MergeRequestApprovalsService) UnapproveMergeRequest(pid interface{}, mr
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-approval-configuration
 type ChangeMergeRequestApprovalConfigurationOptions struct {
 	ApprovalsRequired *int `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
+}
+
+// GetConfiguration shows information about single merge request approvals
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-configuration-1
+func (s *MergeRequestApprovalsService) GetConfiguration(pid interface{}, mr int, options ...OptionFunc) (*MergeRequestApprovals, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/approvals", pathEscape(project), mr)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(MergeRequestApprovals)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
 }
 
 // ChangeApprovalConfiguration updates the approval configuration of a merge request.
@@ -234,6 +270,31 @@ func (s *MergeRequestApprovalsService) GetApprovalRules(pid interface{}, mergeRe
 	}
 
 	return par, resp, err
+}
+
+// GetApprovalState requests information about a merge request’s approval state
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-the-approval-state-of-merge-requests
+func (s *MergeRequestApprovalsService) GetApprovalState(pid interface{}, mergeRequest int, options ...OptionFunc) (*MergeRequestApprovalState, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/approval_state", pathEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var pas *MergeRequestApprovalState
+	resp, err := s.client.Do(req, &pas)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pas, resp, err
 }
 
 // CreateMergeRequestApprovalRuleOptions represents the available CreateApprovalRule()

--- a/vendor/github.com/xanzy/go-gitlab/merge_requests.go
+++ b/vendor/github.com/xanzy/go-gitlab/merge_requests.go
@@ -64,6 +64,7 @@ type MergeRequest struct {
 	Subscribed                bool         `json:"subscribed"`
 	SHA                       string       `json:"sha"`
 	MergeCommitSHA            string       `json:"merge_commit_sha"`
+	SquashCommitSHA           string       `json:"squash_commit_sha"`
 	UserNotesCount            int          `json:"user_notes_count"`
 	ChangesCount              string       `json:"changes_count"`
 	ShouldRemoveSourceBranch  bool         `json:"should_remove_source_branch"`
@@ -97,6 +98,7 @@ type MergeRequest struct {
 		Count          int `json:"count"`
 		CompletedCount int `json:"completed_count"`
 	} `json:"task_completion_status"`
+	HasConflicts bool `json:"has_conflicts"`
 }
 
 func (m MergeRequest) String() string {

--- a/vendor/github.com/xanzy/go-gitlab/pages_domains.go
+++ b/vendor/github.com/xanzy/go-gitlab/pages_domains.go
@@ -18,6 +18,7 @@ type PagesDomainsService struct {
 // GitLab API docs: https://docs.gitlab.com/ce/api/pages_domains.html
 type PagesDomain struct {
 	Domain           string     `json:"domain"`
+	AutoSslEnabled   bool       `json:"auto_ssl_enabled"`
 	URL              string     `json:"url"`
 	ProjectID        int        `json:"project_id"`
 	Verified         bool       `json:"verified"`
@@ -107,11 +108,12 @@ func (s *PagesDomainsService) GetPagesDomain(pid interface{}, domain string, opt
 // CreatePagesDomainOptions represents the available CreatePagesDomain() options.
 //
 // GitLab API docs:
-// // https://docs.gitlab.com/ce/api/pages_domains.html#create-new-pages-domain
+// https://docs.gitlab.com/ce/api/pages_domains.html#create-new-pages-domain
 type CreatePagesDomainOptions struct {
-	Domain      *string `url:"domain,omitempty" json:"domain,omitempty"`
-	Certificate *string `url:"certifiate,omitempty" json:"certifiate,omitempty"`
-	Key         *string `url:"key,omitempty" json:"key,omitempty"`
+	Domain         *string `url:"domain,omitempty" json:"domain,omitempty"`
+	AutoSslEnabled *bool   `url:"auto_ssl_enabled,omitempty" json:"auto_ssl_enabled,omitempty"`
+	Certificate    *string `url:"certifiate,omitempty" json:"certifiate,omitempty"`
+	Key            *string `url:"key,omitempty" json:"key,omitempty"`
 }
 
 // CreatePagesDomain creates a new project pages domain.
@@ -144,8 +146,9 @@ func (s *PagesDomainsService) CreatePagesDomain(pid interface{}, opt *CreatePage
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/pages_domains.html#update-pages-domain
 type UpdatePagesDomainOptions struct {
-	Cerificate *string `url:"certifiate" json:"certifiate"`
-	Key        *string `url:"key" json:"key"`
+	AutoSslEnabled *bool   `url:"auto_ssl_enabled,omitempty" json:"auto_ssl_enabled,omitempty"`
+	Certificate    *string `url:"certifiate,omitempty" json:"certifiate,omitempty"`
+	Key            *string `url:"key,omitempty" json:"key,omitempty"`
 }
 
 // UpdatePagesDomain updates an existing project pages domain.

--- a/vendor/github.com/xanzy/go-gitlab/pipelines.go
+++ b/vendor/github.com/xanzy/go-gitlab/pipelines.go
@@ -101,15 +101,17 @@ func (p PipelineInfo) String() string {
 // GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#list-project-pipelines
 type ListProjectPipelinesOptions struct {
 	ListOptions
-	Scope      *string          `url:"scope,omitempty" json:"scope,omitempty"`
-	Status     *BuildStateValue `url:"status,omitempty" json:"status,omitempty"`
-	Ref        *string          `url:"ref,omitempty" json:"ref,omitempty"`
-	SHA        *string          `url:"sha,omitempty" json:"sha,omitempty"`
-	YamlErrors *bool            `url:"yaml_errors,omitempty" json:"yaml_errors,omitempty"`
-	Name       *string          `url:"name,omitempty" json:"name,omitempty"`
-	Username   *string          `url:"username,omitempty" json:"username,omitempty"`
-	OrderBy    *string          `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort       *string          `url:"sort,omitempty" json:"sort,omitempty"`
+	Scope         *string          `url:"scope,omitempty" json:"scope,omitempty"`
+	Status        *BuildStateValue `url:"status,omitempty" json:"status,omitempty"`
+	Ref           *string          `url:"ref,omitempty" json:"ref,omitempty"`
+	SHA           *string          `url:"sha,omitempty" json:"sha,omitempty"`
+	YamlErrors    *bool            `url:"yaml_errors,omitempty" json:"yaml_errors,omitempty"`
+	Name          *string          `url:"name,omitempty" json:"name,omitempty"`
+	Username      *string          `url:"username,omitempty" json:"username,omitempty"`
+	UpdatedAfter  *time.Time       `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore *time.Time       `url:"update_before,omitempty" json:"updated_before,omitempty"`
+	OrderBy       *string          `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort          *string          `url:"sort,omitempty" json:"sort,omitempty"`
 }
 
 // ListProjectPipelines gets a list of project piplines.

--- a/vendor/github.com/xanzy/go-gitlab/projects.go
+++ b/vendor/github.com/xanzy/go-gitlab/projects.go
@@ -797,6 +797,8 @@ type ProjectMember struct {
 	CreatedAt   *time.Time       `json:"created_at"`
 	ExpiresAt   *ISOTime         `json:"expires_at"`
 	AccessLevel AccessLevelValue `json:"access_level"`
+	WebURL      string           `json:"web_url"`
+	AvatarURL   string           `json:"avatar_url"`
 }
 
 // ProjectHook represents a project hook.
@@ -806,6 +808,7 @@ type ProjectMember struct {
 type ProjectHook struct {
 	ID                       int        `json:"id"`
 	URL                      string     `json:"url"`
+	ConfidentialNoteEvents   bool       `json:"confidential_note_events"`
 	ProjectID                int        `json:"project_id"`
 	PushEvents               bool       `json:"push_events"`
 	IssuesEvents             bool       `json:"issues_events"`
@@ -881,6 +884,7 @@ func (s *ProjectsService) GetProjectHook(pid interface{}, hook int, options ...O
 // https://docs.gitlab.com/ce/api/projects.html#add-project-hook
 type AddProjectHookOptions struct {
 	URL                      *string `url:"url,omitempty" json:"url,omitempty"`
+	ConfidentialNoteEvents   *bool   `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
 	PushEvents               *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
 	IssuesEvents             *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
 	ConfidentialIssuesEvents *bool   `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
@@ -925,6 +929,7 @@ func (s *ProjectsService) AddProjectHook(pid interface{}, opt *AddProjectHookOpt
 // https://docs.gitlab.com/ce/api/projects.html#edit-project-hook
 type EditProjectHookOptions struct {
 	URL                      *string `url:"url,omitempty" json:"url,omitempty"`
+	ConfidentialNoteEvents   *bool   `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
 	PushEvents               *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
 	IssuesEvents             *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
 	ConfidentialIssuesEvents *bool   `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`

--- a/vendor/github.com/xanzy/go-gitlab/runners.go
+++ b/vendor/github.com/xanzy/go-gitlab/runners.go
@@ -70,7 +70,7 @@ type RunnerDetails struct {
 	Revision       string   `json:"revision"`
 	TagList        []string `json:"tag_list"`
 	Version        string   `json:"version"`
-	Locked         bool `json:"locked"`
+	Locked         bool     `json:"locked"`
 	AccessLevel    string   `json:"access_level"`
 	MaximumTimeout int      `json:"maximum_timeout"`
 	Groups         []struct {

--- a/vendor/github.com/xanzy/go-gitlab/services.go
+++ b/vendor/github.com/xanzy/go-gitlab/services.go
@@ -52,26 +52,71 @@ type Service struct {
 	WikiPageEvents           bool       `json:"wiki_page_events"`
 }
 
-// SetGitLabCIServiceOptions represents the available SetGitLabCIService()
+// DroneCIService represents Drone CI service settings.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#drone-ci
+type DroneCIService struct {
+	Service
+	Properties *DroneCIServiceProperties `json:"properties"`
+}
+
+// DroneCIServiceProperties represents Drone CI specific properties.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#drone-ci
+type DroneCIServiceProperties struct {
+	Token                 string `json:"token"`
+	DroneURL              string `json:"drone_url"`
+	EnableSSLVerification bool   `json:"enable_ssl_verification"`
+}
+
+// GetDroneCIService gets Drone CI service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#get-drone-ci-service-settings
+func (s *ServicesService) GetDroneCIService(pid interface{}, options ...OptionFunc) (*DroneCIService, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/drone-ci", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	svc := new(DroneCIService)
+	resp, err := s.client.Do(req, svc)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return svc, resp, err
+}
+
+// SetDroneCIServiceOptions represents the available SetDroneCIService()
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-gitlab-ci-service
-type SetGitLabCIServiceOptions struct {
-	Token      *string `url:"token,omitempty" json:"token,omitempty"`
-	ProjectURL *string `url:"project_url,omitempty" json:"project_url,omitempty"`
+// https://docs.gitlab.com/ce/api/services.html#createedit-drone-ci-service
+type SetDroneCIServiceOptions struct {
+	Token                 *string `url:"token" json:"token" `
+	DroneURL              *string `url:"drone_url" json:"drone_url"`
+	EnableSSLVerification *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
 }
 
-// SetGitLabCIService sets GitLab CI service for a project.
+// SetDroneCIService sets Drone CI service for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-gitlab-ci-service
-func (s *ServicesService) SetGitLabCIService(pid interface{}, opt *SetGitLabCIServiceOptions, options ...OptionFunc) (*Response, error) {
+// https://docs.gitlab.com/ce/api/services.html#createedit-drone-ci-service
+func (s *ServicesService) SetDroneCIService(pid interface{}, opt *SetDroneCIServiceOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/gitlab-ci", pathEscape(project))
+	u := fmt.Sprintf("projects/%s/services/drone-ci", pathEscape(project))
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -81,16 +126,105 @@ func (s *ServicesService) SetGitLabCIService(pid interface{}, opt *SetGitLabCISe
 	return s.client.Do(req, nil)
 }
 
-// DeleteGitLabCIService deletes GitLab CI service settings for a project.
+// DeleteDroneCIService deletes Drone CI service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-gitlab-ci-service
-func (s *ServicesService) DeleteGitLabCIService(pid interface{}, options ...OptionFunc) (*Response, error) {
+// https://docs.gitlab.com/ce/api/services.html#delete-drone-ci-service
+func (s *ServicesService) DeleteDroneCIService(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/gitlab-ci", pathEscape(project))
+	u := fmt.Sprintf("projects/%s/services/drone-ci", pathEscape(project))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// ExternalWikiService represents External Wiki service settings.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#external-wiki
+type ExternalWikiService struct {
+	Service
+	Properties *ExternalWikiServiceProperties `json:"properties"`
+}
+
+// ExternalWikiServiceProperties represents External Wiki specific properties.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#external-wiki
+type ExternalWikiServiceProperties struct {
+	ExternalWikiURL string `json:"external_wiki_url"`
+}
+
+// GetExternalWikiService gets External Wiki service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#get-external-wiki-service-settings
+func (s *ServicesService) GetExternalWikiService(pid interface{}, options ...OptionFunc) (*ExternalWikiService, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/external-wiki", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	svc := new(ExternalWikiService)
+	resp, err := s.client.Do(req, svc)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return svc, resp, err
+}
+
+// SetExternalWikiServiceOptions represents the available SetExternalWikiService()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#createedit-external-wiki-service
+type SetExternalWikiServiceOptions struct {
+	ExternalWikiURL *string `url:"external_wiki_url,omitempty" json:"external_wiki_url,omitempty"`
+}
+
+// SetExternalWikiService sets External Wiki service for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#createedit-external-wiki-service
+func (s *ServicesService) SetExternalWikiService(pid interface{}, opt *SetExternalWikiServiceOptions, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/external-wiki", pathEscape(project))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// DeleteExternalWikiService deletes External Wiki service for project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#delete-external-wiki-service
+func (s *ServicesService) DeleteExternalWikiService(pid interface{}, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/external-wiki", pathEscape(project))
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -192,6 +326,54 @@ func (s *ServicesService) DeleteGithubService(pid interface{}, options ...Option
 	return s.client.Do(req, nil)
 }
 
+// SetGitLabCIServiceOptions represents the available SetGitLabCIService()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#edit-gitlab-ci-service
+type SetGitLabCIServiceOptions struct {
+	Token      *string `url:"token,omitempty" json:"token,omitempty"`
+	ProjectURL *string `url:"project_url,omitempty" json:"project_url,omitempty"`
+}
+
+// SetGitLabCIService sets GitLab CI service for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#edit-gitlab-ci-service
+func (s *ServicesService) SetGitLabCIService(pid interface{}, opt *SetGitLabCIServiceOptions, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/gitlab-ci", pathEscape(project))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// DeleteGitLabCIService deletes GitLab CI service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#delete-gitlab-ci-service
+func (s *ServicesService) DeleteGitLabCIService(pid interface{}, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/gitlab-ci", pathEscape(project))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // SetHipChatServiceOptions represents the available SetHipChatService()
 // options.
 //
@@ -240,42 +422,42 @@ func (s *ServicesService) DeleteHipChatService(pid interface{}, options ...Optio
 	return s.client.Do(req, nil)
 }
 
-// DroneCIService represents Drone CI service settings.
+// JenkinsCIService represents Jenkins CI service settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#drone-ci
-type DroneCIService struct {
+// https://docs.gitlab.com/ee/api/services.html#jenkins-ci
+type JenkinsCIService struct {
 	Service
-	Properties *DroneCIServiceProperties `json:"properties"`
+	Properties *JenkinsCIServiceProperties `json:"properties"`
 }
 
-// DroneCIServiceProperties represents Drone CI specific properties.
+// JenkinsCIServiceProperties represents Jenkins CI specific properties.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#drone-ci
-type DroneCIServiceProperties struct {
-	Token                 string `json:"token"`
-	DroneURL              string `json:"drone_url"`
-	EnableSSLVerification bool   `json:"enable_ssl_verification"`
+// https://docs.gitlab.com/ee/api/services.html#jenkins-ci
+type JenkinsCIServiceProperties struct {
+	URL         string `json:"jenkins_url,omitempty"`
+	ProjectName string `json:"project_name,omitempty"`
+	Username    string `json:"username,omitempty"`
 }
 
-// GetDroneCIService gets Drone CI service settings for a project.
+// GetJenkinsCIService gets Jenkins CI service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-drone-ci-service-settings
-func (s *ServicesService) GetDroneCIService(pid interface{}, options ...OptionFunc) (*DroneCIService, *Response, error) {
+// https://docs.gitlab.com/ee/api/services.html#get-jenkins-ci-service-settings
+func (s *ServicesService) GetJenkinsCIService(pid interface{}, options ...OptionFunc) (*JenkinsCIService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/drone-ci", pathEscape(project))
+	u := fmt.Sprintf("projects/%s/services/jenkins", pathEscape(project))
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	svc := new(DroneCIService)
+	svc := new(JenkinsCIService)
 	resp, err := s.client.Do(req, svc)
 	if err != nil {
 		return nil, resp, err
@@ -284,27 +466,28 @@ func (s *ServicesService) GetDroneCIService(pid interface{}, options ...OptionFu
 	return svc, resp, err
 }
 
-// SetDroneCIServiceOptions represents the available SetDroneCIService()
+// SetJenkinsCIServiceOptions represents the available SetJenkinsCIService()
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-drone-ci-service
-type SetDroneCIServiceOptions struct {
-	Token                 *string `url:"token" json:"token" `
-	DroneURL              *string `url:"drone_url" json:"drone_url"`
-	EnableSSLVerification *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
+// https://docs.gitlab.com/ee/api/services.html#jenkins-ci
+type SetJenkinsCIServiceOptions struct {
+	URL         *string `url:"jenkins_url,omitempty" json:"jenkins_url,omitempty"`
+	ProjectName *string `url:"project_name,omitempty" json:"project_name,omitempty"`
+	Username    *string `url:"username,omitempty" json:"username,omitempty"`
+	Password    *string `url:"password,omitempty" json:"password,omitempty"`
 }
 
-// SetDroneCIService sets Drone CI service for a project.
+// SetJenkinsCIService sets Jenkins service for a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-drone-ci-service
-func (s *ServicesService) SetDroneCIService(pid interface{}, opt *SetDroneCIServiceOptions, options ...OptionFunc) (*Response, error) {
+// https://docs.gitlab.com/ee/api/services.html#create-edit-jenkins-ci-service
+func (s *ServicesService) SetJenkinsCIService(pid interface{}, opt *SetJenkinsCIServiceOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/drone-ci", pathEscape(project))
+	u := fmt.Sprintf("projects/%s/services/jenkins", pathEscape(project))
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -314,16 +497,335 @@ func (s *ServicesService) SetDroneCIService(pid interface{}, opt *SetDroneCIServ
 	return s.client.Do(req, nil)
 }
 
-// DeleteDroneCIService deletes Drone CI service settings for a project.
+// DeleteJenkinsCIService deletes Jenkins CI service for project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-drone-ci-service
-func (s *ServicesService) DeleteDroneCIService(pid interface{}, options ...OptionFunc) (*Response, error) {
+// https://docs.gitlab.com/ce/api/services.html#delete-jira-service
+func (s *ServicesService) DeleteJenkinsCIService(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/drone-ci", pathEscape(project))
+	u := fmt.Sprintf("projects/%s/services/jenkins", pathEscape(project))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// JiraService represents Jira service settings.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#jira
+type JiraService struct {
+	Service
+	Properties *JiraServiceProperties `json:"properties"`
+}
+
+// JiraServiceProperties represents Jira specific properties.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#jira
+type JiraServiceProperties struct {
+	URL                   string `json:"url,omitempty"`
+	APIURL                string `json:"api_url,omitempty"`
+	ProjectKey            string `json:"project_key,omitempty" `
+	Username              string `json:"username,omitempty" `
+	Password              string `json:"password,omitempty" `
+	JiraIssueTransitionID string `json:"jira_issue_transition_id,omitempty"`
+	CommitEvents          bool   `json:"commit_events,omitempty" `
+	MergeRequestsEvents   bool   `json:"merge_requests_events,omitempty" `
+	CommentOnEventEnabled bool   `json:"comment_on_event_enabled,omitempty" `
+}
+
+// UnmarshalJSON decodes the Jira Service Properties.
+//
+// This allows support of JiraIssueTransitionID for both type string (>11.9) and float64 (<11.9)
+func (p *JiraServiceProperties) UnmarshalJSON(b []byte) error {
+	type Alias JiraServiceProperties
+	raw := struct {
+		*Alias
+		JiraIssueTransitionID interface{} `json:"jira_issue_transition_id"`
+	}{
+		Alias: (*Alias)(p),
+	}
+
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+
+	switch id := raw.JiraIssueTransitionID.(type) {
+	case nil:
+		// No action needed.
+	case string:
+		p.JiraIssueTransitionID = id
+	case float64:
+		p.JiraIssueTransitionID = strconv.Itoa(int(id))
+	default:
+		return fmt.Errorf("failed to unmarshal JiraTransitionID of type: %T", id)
+	}
+
+	return nil
+}
+
+// GetJiraService gets Jira service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#get-jira-service-settings
+func (s *ServicesService) GetJiraService(pid interface{}, options ...OptionFunc) (*JiraService, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/jira", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	svc := new(JiraService)
+	resp, err := s.client.Do(req, svc)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return svc, resp, err
+}
+
+// SetJiraServiceOptions represents the available SetJiraService()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#edit-jira-service
+type SetJiraServiceOptions struct {
+	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
+	APIURL                *string `url:"api_url,omitempty" json:"api_url,omitempty"`
+	ProjectKey            *string `url:"project_key,omitempty" json:"project_key,omitempty" `
+	Username              *string `url:"username,omitempty" json:"username,omitempty" `
+	Password              *string `url:"password,omitempty" json:"password,omitempty" `
+	JiraIssueTransitionID *string `url:"jira_issue_transition_id,omitempty" json:"jira_issue_transition_id,omitempty"`
+	CommitEvents          *bool   `url:"commit_events,omitempty" json:"commit_events,omitempty"`
+	MergeRequestsEvents   *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
+	CommentOnEventEnabled *bool   `url:"comment_on_event_enabled,omitempty" json:"comment_on_event_enabled,omitempty"`
+}
+
+// SetJiraService sets Jira service for a project
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#edit-jira-service
+func (s *ServicesService) SetJiraService(pid interface{}, opt *SetJiraServiceOptions, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/jira", pathEscape(project))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// DeleteJiraService deletes Jira service for project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#delete-jira-service
+func (s *ServicesService) DeleteJiraService(pid interface{}, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/jira", pathEscape(project))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// MicrosoftTeamsService represents Microsoft Teams service settings.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#microsoft-teams
+type MicrosoftTeamsService struct {
+	Service
+	Properties *MicrosoftTeamsServiceProperties `json:"properties"`
+}
+
+// MicrosoftTeamsServiceProperties represents Microsoft Teams specific properties.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#microsoft-teams
+type MicrosoftTeamsServiceProperties struct {
+	WebHook string `json:"webhook"`
+}
+
+// GetMicrosoftTeamsService gets MicrosoftTeams service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#get-microsoft-teams-service-settings
+func (s *ServicesService) GetMicrosoftTeamsService(pid interface{}, options ...OptionFunc) (*MicrosoftTeamsService, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/microsoft-teams", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	svc := new(MicrosoftTeamsService)
+	resp, err := s.client.Do(req, svc)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return svc, resp, err
+}
+
+// SetMicrosoftTeamsServiceOptions represents the available SetMicrosoftTeamsService()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#create-edit-microsoft-teams-service
+type SetMicrosoftTeamsServiceOptions struct {
+	WebHook *string `url:"webhook,omitempty" json:"webhook,omitempty"`
+}
+
+// SetMicrosoftTeamsService sets Microsoft Teams service for a project
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#create-edit-microsoft-teams-service
+func (s *ServicesService) SetMicrosoftTeamsService(pid interface{}, opt *SetMicrosoftTeamsServiceOptions, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/microsoft-teams", pathEscape(project))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// DeleteMicrosoftTeamsService deletes Microsoft Teams service for project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#delete-microsoft-teams-service
+func (s *ServicesService) DeleteMicrosoftTeamsService(pid interface{}, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/microsoft-teams", pathEscape(project))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// PipelinesEmailService represents Pipelines Email service settings.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/services.html#pipeline-emails
+type PipelinesEmailService struct {
+	Service
+	Properties *PipelinesEmailProperties `json:"properties"`
+}
+
+// PipelinesEmailProperties represents PipelinesEmail specific properties.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/services.html#pipeline-emails
+type PipelinesEmailProperties struct {
+	Recipients                string    `json:"recipients,omitempty"`
+	NotifyOnlyBrokenPipelines BoolValue `json:"notify_only_broken_pipelines,omitempty"`
+	NotifyOnlyDefaultBranch   BoolValue `json:"notify_only_default_branch,omitempty"`
+}
+
+// GetPipelinesEmailService gets Pipelines Email service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/services.html#get-pipeline-emails-service-settings
+func (s *ServicesService) GetPipelinesEmailService(pid interface{}, options ...OptionFunc) (*PipelinesEmailService, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/pipelines-email", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	svc := new(PipelinesEmailService)
+	resp, err := s.client.Do(req, svc)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return svc, resp, err
+}
+
+// SetPipelinesEmailServiceOptions represents the available SetPipelinesEmailService()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/services.html#pipeline-emails
+type SetPipelinesEmailServiceOptions struct {
+	Recipients                *string `url:"recipients,omitempty" json:"recipients,omitempty"`
+	NotifyOnlyBrokenPipelines *bool   `url:"notify_only_broken_pipelines,omitempty" json:"notify_only_broken_pipelines,omitempty"`
+	NotifyOnlyDefaultBranch   *bool   `url:"notify_only_default_branch,omitempty" json:"notify_only_default_branch,omitempty"`
+	AddPusher                 *bool   `url:"add_pusher,omitempty" json:"add_pusher,omitempty"`
+	BranchesToBeNotified      *string `url:"branches_to_be_notified,omitempty" json:"branches_to_be_notified,omitempty"`
+	PipelineEvents            *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
+}
+
+// SetPipelinesEmailService sets Pipelines Email service for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/services.html#pipeline-emails
+func (s *ServicesService) SetPipelinesEmailService(pid interface{}, opt *SetPipelinesEmailServiceOptions, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/pipelines-email", pathEscape(project))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// DeletePipelinesEmailService deletes Pipelines Email service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/services.html#delete-pipeline-emails-service
+func (s *ServicesService) DeletePipelinesEmailService(pid interface{}, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/pipelines-email", pathEscape(project))
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -465,75 +967,42 @@ func (s *ServicesService) DeleteSlackService(pid interface{}, options ...OptionF
 	return s.client.Do(req, nil)
 }
 
-// JiraService represents Jira service settings.
+// CustomIssueTrackerService represents Custom Issue Tracker service settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#jira
-type JiraService struct {
+// https://docs.gitlab.com/ce/api/services.html#custom-issue-tracker
+type CustomIssueTrackerService struct {
 	Service
-	Properties *JiraServiceProperties `json:"properties"`
+	Properties *CustomIssueTrackerServiceProperties `json:"properties"`
 }
 
-// JiraServiceProperties represents Jira specific properties.
+// CustomIssueTrackerServiceProperties represents Custom Issue Tracker specific properties.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#jira
-type JiraServiceProperties struct {
-	URL                   string `json:"url,omitempty"`
-	APIURL                string `json:"api_url,omitempty"`
-	ProjectKey            string `json:"project_key,omitempty" `
-	Username              string `json:"username,omitempty" `
-	Password              string `json:"password,omitempty" `
-	JiraIssueTransitionID string `json:"jira_issue_transition_id,omitempty"`
+// https://docs.gitlab.com/ce/api/services.html#custom-issue-tracker
+type CustomIssueTrackerServiceProperties struct {
+	ProjectURL  string `json:"project_url,omitempty"`
+	IssuesURL   string `json:"issues_url,omitempty"`
+	NewIssueURL string `json:"new_issue_url,omitempty"`
 }
 
-// UnmarshalJSON decodes the Jira Service Properties.
-//
-// This allows support of JiraIssueTransitionID for both type string (>11.9) and float64 (<11.9)
-func (p *JiraServiceProperties) UnmarshalJSON(b []byte) error {
-	type Alias JiraServiceProperties
-	raw := struct {
-		*Alias
-		JiraIssueTransitionID interface{} `json:"jira_issue_transition_id"`
-	}{
-		Alias: (*Alias)(p),
-	}
-
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-
-	switch id := raw.JiraIssueTransitionID.(type) {
-	case nil:
-		// No action needed.
-	case string:
-		p.JiraIssueTransitionID = id
-	case float64:
-		p.JiraIssueTransitionID = strconv.Itoa(int(id))
-	default:
-		return fmt.Errorf("failed to unmarshal JiraTransitionID of type: %T", id)
-	}
-
-	return nil
-}
-
-// GetJiraService gets Jira service settings for a project.
+// GetCustomIssueTrackerService gets Custom Issue Tracker service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-jira-service-settings
-func (s *ServicesService) GetJiraService(pid interface{}, options ...OptionFunc) (*JiraService, *Response, error) {
+// https://docs.gitlab.com/ce/api/services.html#get-custom-issue-tracker-service-settings
+func (s *ServicesService) GetCustomIssueTrackerService(pid interface{}, options ...OptionFunc) (*CustomIssueTrackerService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/jira", pathEscape(project))
+	u := fmt.Sprintf("projects/%s/services/custom-issue-tracker", pathEscape(project))
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	svc := new(JiraService)
+	svc := new(CustomIssueTrackerService)
 	resp, err := s.client.Do(req, svc)
 	if err != nil {
 		return nil, resp, err
@@ -542,30 +1011,30 @@ func (s *ServicesService) GetJiraService(pid interface{}, options ...OptionFunc)
 	return svc, resp, err
 }
 
-// SetJiraServiceOptions represents the available SetJiraService()
+// SetCustomIssueTrackerServiceOptions represents the available SetCustomIssueTrackerService()
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-jira-service
-type SetJiraServiceOptions struct {
-	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
-	APIURL                *string `url:"api_url,omitempty" json:"api_url,omitempty"`
-	ProjectKey            *string `url:"project_key,omitempty" json:"project_key,omitempty" `
-	Username              *string `url:"username,omitempty" json:"username,omitempty" `
-	Password              *string `url:"password,omitempty" json:"password,omitempty" `
-	JiraIssueTransitionID *string `url:"jira_issue_transition_id,omitempty" json:"jira_issue_transition_id,omitempty"`
+// https://docs.gitlab.com/ce/api/services.html#createedit-custom-issue-tracker-service
+type SetCustomIssueTrackerServiceOptions struct {
+	NewIssueURL *string `url:"new_issue_url,omitempty" json:"new_issue_url,omitempty"`
+	IssuesURL   *string `url:"issues_url,omitempty" json:"issues_url,omitempty"`
+	ProjectURL  *string `url:"project_url,omitempty" json:"project_url,omitempty"`
+	Description *string `url:"description,omitempty" json:"description,omitempty"`
+	Title       *string `url:"title,omitempty" json:"title,omitempty"`
+	PushEvents  *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
 }
 
-// SetJiraService sets Jira service for a project
+// SetCustomIssueTrackerService sets Custom Issue Tracker service for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-jira-service
-func (s *ServicesService) SetJiraService(pid interface{}, opt *SetJiraServiceOptions, options ...OptionFunc) (*Response, error) {
+// https://docs.gitlab.com/ce/api/services.html#createedit-custom-issue-tracker-service
+func (s *ServicesService) SetCustomIssueTrackerService(pid interface{}, opt *SetCustomIssueTrackerServiceOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/jira", pathEscape(project))
+	u := fmt.Sprintf("projects/%s/services/custom-issue-tracker", pathEscape(project))
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -575,287 +1044,16 @@ func (s *ServicesService) SetJiraService(pid interface{}, opt *SetJiraServiceOpt
 	return s.client.Do(req, nil)
 }
 
-// DeleteJiraService deletes Jira service for project.
+// DeleteCustomIssueTrackerService deletes Custom Issue Tracker service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-jira-service
-func (s *ServicesService) DeleteJiraService(pid interface{}, options ...OptionFunc) (*Response, error) {
+// https://docs.gitlab.com/ce/api/services.html#delete-custom-issue-tracker-service
+func (s *ServicesService) DeleteCustomIssueTrackerService(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/jira", pathEscape(project))
-
-	req, err := s.client.NewRequest("DELETE", u, nil, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(req, nil)
-}
-
-// JenkinsCIService represents Jenkins CI service settings.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/services.html#jenkins-ci
-type JenkinsCIService struct {
-	Service
-	Properties *JenkinsCIServiceProperties `json:"properties"`
-}
-
-// JenkinsCIServiceProperties represents Jenkins CI specific properties.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/services.html#jenkins-ci
-type JenkinsCIServiceProperties struct {
-	URL         string `json:"jenkins_url,omitempty"`
-	ProjectName string `json:"project_name,omitempty"`
-	Username    string `json:"username,omitempty"`
-}
-
-// GetJenkinsCIService gets Jenkins CI service settings for a project.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/services.html#get-jenkins-ci-service-settings
-func (s *ServicesService) GetJenkinsCIService(pid interface{}, options ...OptionFunc) (*JenkinsCIService, *Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("projects/%s/services/jenkins", pathEscape(project))
-
-	req, err := s.client.NewRequest("GET", u, nil, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	svc := new(JenkinsCIService)
-	resp, err := s.client.Do(req, svc)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return svc, resp, err
-}
-
-// SetJenkinsCIServiceOptions represents the available SetJenkinsCIService()
-// options.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/services.html#jenkins-ci
-type SetJenkinsCIServiceOptions struct {
-	URL         *string `url:"jenkins_url,omitempty" json:"jenkins_url,omitempty"`
-	ProjectName *string `url:"project_name,omitempty" json:"project_name,omitempty"`
-	Username    *string `url:"username,omitempty" json:"username,omitempty"`
-	Password    *string `url:"password,omitempty" json:"password,omitempty"`
-}
-
-// SetJenkinsCIService sets Jenkins service for a project
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/services.html#create-edit-jenkins-ci-service
-func (s *ServicesService) SetJenkinsCIService(pid interface{}, opt *SetJenkinsCIServiceOptions, options ...OptionFunc) (*Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("projects/%s/services/jenkins", pathEscape(project))
-
-	req, err := s.client.NewRequest("PUT", u, opt, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(req, nil)
-}
-
-// DeleteJenkinsCIService deletes Jenkins CI service for project.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-jira-service
-func (s *ServicesService) DeleteJenkinsCIService(pid interface{}, options ...OptionFunc) (*Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("projects/%s/services/jenkins", pathEscape(project))
-
-	req, err := s.client.NewRequest("DELETE", u, nil, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(req, nil)
-}
-
-// MicrosoftTeamsService represents Microsoft Teams service settings.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#microsoft-teams
-type MicrosoftTeamsService struct {
-	Service
-	Properties *MicrosoftTeamsServiceProperties `json:"properties"`
-}
-
-// MicrosoftTeamsServiceProperties represents Microsoft Teams specific properties.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#microsoft-teams
-type MicrosoftTeamsServiceProperties struct {
-	WebHook string `json:"webhook"`
-}
-
-// GetMicrosoftTeamsService gets MicrosoftTeams service settings for a project.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-microsoft-teams-service-settings
-func (s *ServicesService) GetMicrosoftTeamsService(pid interface{}, options ...OptionFunc) (*MicrosoftTeamsService, *Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("projects/%s/services/microsoft-teams", pathEscape(project))
-
-	req, err := s.client.NewRequest("GET", u, nil, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	svc := new(MicrosoftTeamsService)
-	resp, err := s.client.Do(req, svc)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return svc, resp, err
-}
-
-// SetMicrosoftTeamsServiceOptions represents the available SetMicrosoftTeamsService()
-// options.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#create-edit-microsoft-teams-service
-type SetMicrosoftTeamsServiceOptions struct {
-	WebHook *string `url:"webhook,omitempty" json:"webhook,omitempty"`
-}
-
-// SetMicrosoftTeamsService sets Microsoft Teams service for a project
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#create-edit-microsoft-teams-service
-func (s *ServicesService) SetMicrosoftTeamsService(pid interface{}, opt *SetMicrosoftTeamsServiceOptions, options ...OptionFunc) (*Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("projects/%s/services/microsoft-teams", pathEscape(project))
-
-	req, err := s.client.NewRequest("PUT", u, opt, options)
-	if err != nil {
-		return nil, err
-	}
-	return s.client.Do(req, nil)
-}
-
-// DeleteMicrosoftTeamsService deletes Microsoft Teams service for project.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-microsoft-teams-service
-func (s *ServicesService) DeleteMicrosoftTeamsService(pid interface{}, options ...OptionFunc) (*Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("projects/%s/services/microsoft-teams", pathEscape(project))
-
-	req, err := s.client.NewRequest("DELETE", u, nil, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(req, nil)
-}
-
-// ExternalWikiService represents External Wiki service settings.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#external-wiki
-type ExternalWikiService struct {
-	Service
-	Properties *ExternalWikiServiceProperties `json:"properties"`
-}
-
-// ExternalWikiServiceProperties represents External Wiki specific properties.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#external-wiki
-type ExternalWikiServiceProperties struct {
-	ExternalWikiURL string `json:"external_wiki_url"`
-}
-
-// GetExternalWikiService gets External Wiki service settings for a project.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-external-wiki-service-settings
-func (s *ServicesService) GetExternalWikiService(pid interface{}, options ...OptionFunc) (*ExternalWikiService, *Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("projects/%s/services/external-wiki", pathEscape(project))
-
-	req, err := s.client.NewRequest("GET", u, nil, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	svc := new(ExternalWikiService)
-	resp, err := s.client.Do(req, svc)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return svc, resp, err
-}
-
-// SetExternalWikiServiceOptions represents the available SetExternalWikiService()
-// options.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-external-wiki-service
-type SetExternalWikiServiceOptions struct {
-	ExternalWikiURL *string `url:"external_wiki_url,omitempty" json:"external_wiki_url,omitempty"`
-}
-
-// SetExternalWikiService sets External Wiki service for a project.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-external-wiki-service
-func (s *ServicesService) SetExternalWikiService(pid interface{}, opt *SetExternalWikiServiceOptions, options ...OptionFunc) (*Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("projects/%s/services/external-wiki", pathEscape(project))
-
-	req, err := s.client.NewRequest("PUT", u, opt, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(req, nil)
-}
-
-// DeleteExternalWikiService deletes External Wiki service for project.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-external-wiki-service
-func (s *ServicesService) DeleteExternalWikiService(pid interface{}, options ...OptionFunc) (*Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("projects/%s/services/external-wiki", pathEscape(project))
+	u := fmt.Sprintf("projects/%s/services/custom-issue-tracker", pathEscape(project))
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/settings.go
+++ b/vendor/github.com/xanzy/go-gitlab/settings.go
@@ -55,11 +55,11 @@ type Settings struct {
 	ContainerRegistryTokenExpireDelay         int               `json:"container_registry_token_expire_delay"`
 	DefaultArtifactsExpireIn                  string            `json:"default_artifacts_expire_in"`
 	DefaultBranchProtection                   int               `json:"default_branch_protection"`
-	DefaultGroupVisibility                    *VisibilityValue  `json:"default_group_visibility"`
+	DefaultGroupVisibility                    VisibilityValue   `json:"default_group_visibility"`
 	DefaultProjectCreation                    int               `json:"default_project_creation"`
 	DefaultProjectsLimit                      int               `json:"default_projects_limit"`
-	DefaultProjectVisibility                  *VisibilityValue  `json:"default_project_visibility"`
-	DefaultSnippetVisibility                  *VisibilityValue  `json:"default_snippet_visibility"`
+	DefaultProjectVisibility                  VisibilityValue   `json:"default_project_visibility"`
+	DefaultSnippetVisibility                  VisibilityValue   `json:"default_snippet_visibility"`
 	DiffMaxPatchBytes                         int               `json:"diff_max_patch_bytes"`
 	DisabledOauthSignInSources                []string          `json:"disabled_oauth_sign_in_sources"`
 	DNSRebindingProtectionEnabled             bool              `json:"dns_rebinding_protection_enabled"`

--- a/vendor/github.com/xanzy/go-gitlab/users.go
+++ b/vendor/github.com/xanzy/go-gitlab/users.go
@@ -157,26 +157,27 @@ func (s *UsersService) GetUser(user int, options ...OptionFunc) (*User, *Respons
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-creation
 type CreateUserOptions struct {
-	Email            *string `url:"email,omitempty" json:"email,omitempty"`
-	Password         *string `url:"password,omitempty" json:"password,omitempty"`
-	ResetPassword    *bool   `url:"reset_password,omitempty" json:"reset_password,omitempty"`
-	Username         *string `url:"username,omitempty" json:"username,omitempty"`
-	Name             *string `url:"name,omitempty" json:"name,omitempty"`
-	Skype            *string `url:"skype,omitempty" json:"skype,omitempty"`
-	Linkedin         *string `url:"linkedin,omitempty" json:"linkedin,omitempty"`
-	Twitter          *string `url:"twitter,omitempty" json:"twitter,omitempty"`
-	WebsiteURL       *string `url:"website_url,omitempty" json:"website_url,omitempty"`
-	Organization     *string `url:"organization,omitempty" json:"organization,omitempty"`
-	ProjectsLimit    *int    `url:"projects_limit,omitempty" json:"projects_limit,omitempty"`
-	ExternUID        *string `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
-	Provider         *string `url:"provider,omitempty" json:"provider,omitempty"`
-	Bio              *string `url:"bio,omitempty" json:"bio,omitempty"`
-	Location         *string `url:"location,omitempty" json:"location,omitempty"`
-	Admin            *bool   `url:"admin,omitempty" json:"admin,omitempty"`
-	CanCreateGroup   *bool   `url:"can_create_group,omitempty" json:"can_create_group,omitempty"`
-	SkipConfirmation *bool   `url:"skip_confirmation,omitempty" json:"skip_confirmation,omitempty"`
-	External         *bool   `url:"external,omitempty" json:"external,omitempty"`
-	PrivateProfile   *bool   `url:"private_profile,omitempty" json:"private_profile,omitempty"`
+	Email               *string `url:"email,omitempty" json:"email,omitempty"`
+	Password            *string `url:"password,omitempty" json:"password,omitempty"`
+	ResetPassword       *bool   `url:"reset_password,omitempty" json:"reset_password,omitempty"`
+	ForceRandomPassword *bool   `url:"force_random_password,omitempty" json:"force_random_password,omitempty"`
+	Username            *string `url:"username,omitempty" json:"username,omitempty"`
+	Name                *string `url:"name,omitempty" json:"name,omitempty"`
+	Skype               *string `url:"skype,omitempty" json:"skype,omitempty"`
+	Linkedin            *string `url:"linkedin,omitempty" json:"linkedin,omitempty"`
+	Twitter             *string `url:"twitter,omitempty" json:"twitter,omitempty"`
+	WebsiteURL          *string `url:"website_url,omitempty" json:"website_url,omitempty"`
+	Organization        *string `url:"organization,omitempty" json:"organization,omitempty"`
+	ProjectsLimit       *int    `url:"projects_limit,omitempty" json:"projects_limit,omitempty"`
+	ExternUID           *string `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
+	Provider            *string `url:"provider,omitempty" json:"provider,omitempty"`
+	Bio                 *string `url:"bio,omitempty" json:"bio,omitempty"`
+	Location            *string `url:"location,omitempty" json:"location,omitempty"`
+	Admin               *bool   `url:"admin,omitempty" json:"admin,omitempty"`
+	CanCreateGroup      *bool   `url:"can_create_group,omitempty" json:"can_create_group,omitempty"`
+	SkipConfirmation    *bool   `url:"skip_confirmation,omitempty" json:"skip_confirmation,omitempty"`
+	External            *bool   `url:"external,omitempty" json:"external,omitempty"`
+	PrivateProfile      *bool   `url:"private_profile,omitempty" json:"private_profile,omitempty"`
 }
 
 // CreateUser creates a new user. Note only administrators can create new users.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -231,7 +231,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.4+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/xanzy/go-gitlab v0.22.3
+# github.com/xanzy/go-gitlab v0.28.0
 github.com/xanzy/go-gitlab
 # github.com/zclconf/go-cty v1.1.1
 github.com/zclconf/go-cty/cty


### PR DESCRIPTION
Updates go-gitlab to v0.28.0

This update has some jira integration changes that i will create a followup PR on that will reduce spamming. Right now jira integration by default creates a jira comment for every commit back to the jira issue.