### PR TITLE
Add jira flags

### DIFF
--- a/gitlab/resource_gitlab_service_jira.go
+++ b/gitlab/resource_gitlab_service_jira.go
@@ -63,6 +63,21 @@ func resourceGitlabServiceJira() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"commit_events": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"merge_requests_events": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"comment_on_event_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -119,7 +134,9 @@ func resourceGitlabServiceJiraRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("active", jiraService.Active)
 	d.Set("push_events", jiraService.PushEvents)
 	d.Set("issues_events", jiraService.IssuesEvents)
+	d.Set("commit_events", jiraService.CommitEvents)
 	d.Set("merge_requests_events", jiraService.MergeRequestsEvents)
+	d.Set("comment_on_event_enabled", jiraService.CommentOnEventEnabled)
 	d.Set("tag_push_events", jiraService.TagPushEvents)
 	d.Set("note_events", jiraService.NoteEvents)
 	d.Set("pipeline_events", jiraService.PipelineEvents)
@@ -152,6 +169,9 @@ func expandJiraOptions(d *schema.ResourceData) (*gitlab.SetJiraServiceOptions, e
 	setJiraServiceOptions.ProjectKey = gitlab.String(d.Get("project_key").(string))
 	setJiraServiceOptions.Username = gitlab.String(d.Get("username").(string))
 	setJiraServiceOptions.Password = gitlab.String(d.Get("password").(string))
+	setJiraServiceOptions.CommitEvents = gitlab.Bool(d.Get("commit_events").(bool))
+	setJiraServiceOptions.MergeRequestsEvents = gitlab.Bool(d.Get("merge_requests_events").(bool))
+	setJiraServiceOptions.CommentOnEventEnabled = gitlab.Bool(d.Get("comment_on_event_enabled").(bool))
 
 	// Set optional properties
 	if val := d.Get("jira_issue_transition_id"); val != nil {

--- a/gitlab/resource_gitlab_service_jira_test.go
+++ b/gitlab/resource_gitlab_service_jira_test.go
@@ -28,6 +28,9 @@ func TestAccGitlabServiceJira_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(jiraResourceName, "url", "https://test.com"),
 					resource.TestCheckResourceAttr(jiraResourceName, "username", "user1"),
 					resource.TestCheckResourceAttr(jiraResourceName, "password", "mypass"),
+					resource.TestCheckResourceAttr(jiraResourceName, "commit_events", "true"),
+					resource.TestCheckResourceAttr(jiraResourceName, "merge_requests_events", "false"),
+					resource.TestCheckResourceAttr(jiraResourceName, "comment_on_event_enabled", "false"),
 				),
 			},
 			// Update the jira service
@@ -39,6 +42,9 @@ func TestAccGitlabServiceJira_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(jiraResourceName, "username", "user2"),
 					resource.TestCheckResourceAttr(jiraResourceName, "password", "mypass_update"),
 					resource.TestCheckResourceAttr(jiraResourceName, "jira_issue_transition_id", "3"),
+					resource.TestCheckResourceAttr(jiraResourceName, "commit_events", "false"),
+					resource.TestCheckResourceAttr(jiraResourceName, "merge_requests_events", "true"),
+					resource.TestCheckResourceAttr(jiraResourceName, "comment_on_event_enabled", "true"),
 				),
 			},
 			// Update the jira service to get back to previous settings
@@ -49,6 +55,9 @@ func TestAccGitlabServiceJira_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(jiraResourceName, "url", "https://test.com"),
 					resource.TestCheckResourceAttr(jiraResourceName, "username", "user1"),
 					resource.TestCheckResourceAttr(jiraResourceName, "password", "mypass"),
+					resource.TestCheckResourceAttr(jiraResourceName, "commit_events", "true"),
+					resource.TestCheckResourceAttr(jiraResourceName, "merge_requests_events", "false"),
+					resource.TestCheckResourceAttr(jiraResourceName, "comment_on_event_enabled", "false"),
 				),
 			},
 		},
@@ -158,6 +167,9 @@ resource "gitlab_service_jira" "jira" {
   url      = "https://test.com"
   username = "user1"
   password = "mypass"
+  commit_events = true
+  merge_requests_events    = false
+  comment_on_event_enabled = false
 }
 `, rInt)
 }
@@ -178,6 +190,9 @@ resource "gitlab_service_jira" "jira" {
   username = "user2"
   password = "mypass_update"
   jira_issue_transition_id = "3"
+  commit_events = false
+  merge_requests_events    = true
+  comment_on_event_enabled = true
 }
 `, rInt)
 }

--- a/website/docs/r/service_jira.html.markdown
+++ b/website/docs/r/service_jira.html.markdown
@@ -43,6 +43,12 @@ The following arguments are supported:
 
 * `jira_issue_transition_id` - (Optional) The ID of a transition that moves issues to a closed state. You can find this number under the JIRA workflow administration (Administration > Issues > Workflows) by selecting View under Operations of the desired workflow of your project. By default, this ID is set to 2.
 
+* `commit_events` - (Optional) Enable notifications for commit events
+
+* `merge_requests_events` - (Optional) Enable notifications for merge request events
+
+* `comment_on_event_enabled` - (Optional) Enable comments inside Jira issues on each GitLab event (commit / merge request)
+
 ## Importing Jira service
 
  You can import a service_jira state using `terraform import <resource> <project_id>`:


### PR DESCRIPTION
Relies on https://github.com/terraform-providers/terraform-provider-gitlab/pull/273 

The jira service has some extra flags that reduce the spamminess of the service. 