### PR TITLE
datasource: gitlab_projects

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,6 +13,12 @@ test: fmtcheck
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
+testacc-prepareenv:
+	MAKE_TARGET=testacc GITLAB_TOKEN=ACCTEST LC_ALL=en_US sh -c "'$(CURDIR)/scripts/start-gitlab.sh'"
+
+testacc-cleanenv:
+	docker stop gitlab
+
 testacc: fmtcheck
 	TF_ACC=1 go test -v $(TEST) $(TESTARGS) -timeout 40m
 

--- a/gitlab/data_source_gitlab_projects.go
+++ b/gitlab/data_source_gitlab_projects.go
@@ -1,0 +1,852 @@
+package gitlab
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/mitchellh/hashstructure"
+	"github.com/xanzy/go-gitlab"
+	"log"
+)
+
+// Schemas
+
+// WARN: go-gitlab may not be up-to-date with Gitlab exposed options
+// https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects
+// https://docs.gitlab.com/ee/api/projects.html#list-all-projects
+
+// Helper functions
+func flattenProjectPermissions(permissions *gitlab.Permissions) []map[string]interface{} {
+	m := make(map[string]interface{}, 2)
+	if permissions != nil {
+		if permissions.ProjectAccess != nil {
+			m["project_access"] = map[string]int{
+				"access_level":       int(permissions.ProjectAccess.AccessLevel),
+				"notification_level": int(permissions.ProjectAccess.NotificationLevel),
+			}
+		}
+		if permissions.GroupAccess != nil {
+			m["group_access"] = map[string]int{
+				"access_level":       int(permissions.GroupAccess.AccessLevel),
+				"notification_level": int(permissions.GroupAccess.NotificationLevel),
+			}
+		}
+	}
+	return []map[string]interface{}{m}
+}
+
+func flattenProjectNamespace(namespace *gitlab.ProjectNamespace) (values []map[string]interface{}) {
+	if namespace != nil {
+		values = []map[string]interface{}{
+			{
+				"id":        namespace.ID,
+				"name":      namespace.Name,
+				"path":      namespace.Path,
+				"kind":      namespace.Kind,
+				"full_path": namespace.FullPath,
+			},
+		}
+	}
+	return values
+}
+
+func flattenProjectLinks(links *gitlab.Links) (values map[string]string) {
+	if links != nil {
+		values = map[string]string{
+			"self":           links.Self,
+			"issues":         links.Issues,
+			"merge_requests": links.MergeRequests,
+			"repo_branches":  links.RepoBranches,
+			"labels":         links.Labels,
+			"events":         links.Events,
+			"members":        links.Members,
+		}
+	}
+	return values
+}
+
+func flattenForkedFromProject(forked *gitlab.ForkParent) (values []map[string]interface{}) {
+	if forked != nil {
+		values = []map[string]interface{}{
+			{
+				"http_url_to_repo":    forked.HTTPURLToRepo,
+				"id":                  forked.ID,
+				"name":                forked.Name,
+				"name_with_namespace": forked.NameWithNamespace,
+				"path":                forked.Path,
+				"path_with_namespace": forked.PathWithNamespace,
+				"web_url":             forked.WebURL,
+			},
+		}
+	}
+	return values
+}
+
+func flattenGitlabBasicUser(user *gitlab.User) (values []map[string]interface{}) {
+	if user != nil {
+		values = []map[string]interface{}{
+			{
+				"id":          user.ID,
+				"username":    user.Username,
+				"name":        user.Name,
+				"state":       user.State,
+				"avatar_url":  user.AvatarURL,
+				"website_url": user.WebsiteURL,
+			},
+		}
+	}
+	return values
+}
+
+func flattenProjects(projects []*gitlab.Project) (values []map[string]interface{}) {
+	if projects != nil {
+		for _, project := range projects {
+			v := map[string]interface{}{
+				"id":                                    project.ID,
+				"description":                           project.Description,
+				"default_branch":                        project.DefaultBranch,
+				"public":                                project.Public,
+				"visibility":                            string(project.Visibility),
+				"ssh_url_to_repo":                       project.SSHURLToRepo,
+				"http_url_to_repo":                      project.HTTPURLToRepo,
+				"web_url":                               project.WebURL,
+				"readme_url":                            project.ReadmeURL,
+				"tag_list":                              project.TagList,
+				"owner":                                 flattenGitlabBasicUser(project.Owner),
+				"name":                                  project.Name,
+				"name_with_namespace":                   project.NameWithNamespace,
+				"path":                                  project.Path,
+				"path_with_namespace":                   project.PathWithNamespace,
+				"issues_enabled":                        project.IssuesEnabled,
+				"open_issues_count":                     project.OpenIssuesCount,
+				"merge_requests_enabled":                project.MergeRequestsEnabled,
+				"approvals_before_merge":                project.ApprovalsBeforeMerge,
+				"jobs_enabled":                          project.JobsEnabled,
+				"wiki_enabled":                          project.WikiEnabled,
+				"snippets_enabled":                      project.SnippetsEnabled,
+				"resolve_outdated_diff_discussions":     project.ResolveOutdatedDiffDiscussions,
+				"container_registry_enabled":            project.ContainerRegistryEnabled,
+				"created_at":                            project.CreatedAt.String(),
+				"last_activity_at":                      project.LastActivityAt.String(),
+				"creator_id":                            project.CreatorID,
+				"namespace":                             flattenProjectNamespace(project.Namespace),
+				"import_status":                         project.ImportStatus,
+				"import_error":                          project.ImportError,
+				"permissions":                           flattenProjectPermissions(project.Permissions),
+				"archived":                              project.Archived,
+				"avatar_url":                            project.AvatarURL,
+				"shared_runners_enabled":                project.SharedRunnersEnabled,
+				"forks_count":                           project.ForksCount,
+				"star_count":                            project.StarCount,
+				"runners_token":                         project.RunnersToken,
+				"public_builds":                         project.PublicBuilds,
+				"only_allow_merge_if_pipeline_succeeds": project.OnlyAllowMergeIfPipelineSucceeds,
+				"only_allow_merge_if_all_discussions_are_resolved": project.OnlyAllowMergeIfAllDiscussionsAreResolved,
+				"lfs_enabled":                         project.LFSEnabled,
+				"request_access_enabled":              project.RequestAccessEnabled,
+				"merge_method":                        project.MergeMethod,
+				"forked_from_project":                 flattenForkedFromProject(project.ForkedFromProject),
+				"mirror":                              project.Mirror,
+				"mirror_user_id":                      project.MirrorUserID,
+				"mirror_trigger_builds":               project.MirrorTriggerBuilds,
+				"only_mirror_protected_branches":      project.OnlyMirrorProtectedBranches,
+				"mirror_overwrites_diverged_branches": project.MirrorOverwritesDivergedBranches,
+				"shared_with_groups":                  flattenSharedWithGroupsOptions(project),
+				"statistics":                          project.Statistics,
+				"_links":                              flattenProjectLinks(project.Links),
+				"ci_config_path":                      project.CIConfigPath,
+				"custom_attributes":                   project.CustomAttributes,
+			}
+			values = append(values, v)
+		}
+	}
+	return values
+}
+
+func dataSourceGitlabProjects() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGitlabProjectsRead,
+
+		Schema: map[string]*schema.Schema{
+			"max_queryable_pages": {
+				Type:        schema.TypeInt,
+				Description: "Prevents overloading your Gitlab instance in case of a misconfiguration.",
+				Optional:    true,
+				Default:     10,
+			},
+			"group_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+			"page": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+			},
+			"per_page": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      20,
+				ValidateFunc: validation.IntAtMost(100),
+			},
+			"archived": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"order_by": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"id",
+					"name",
+					"username",
+					"created_at",
+					"updated_at"}, true),
+			},
+			"sort": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"desc", "asc"}, true),
+			},
+			"search": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"simple": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"owned": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"starred": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"visibility": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"public",
+					"private",
+					"internal"}, true),
+			},
+			"with_issues_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"with_merge_requests_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"with_custom_attributes": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"membership": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"min_access_level": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ValidateFunc: validation.IntInSlice([]int{
+					int(gitlab.GuestPermissions),
+					int(gitlab.DeveloperPermissions),
+					int(gitlab.MaintainerPermissions),
+					int(gitlab.MasterPermissions),
+				}),
+				ConflictsWith: []string{
+					"group_id",
+				},
+			},
+			"with_programming_language": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ConflictsWith: []string{
+					"group_id",
+				},
+			},
+			"statistics": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ConflictsWith: []string{
+					"group_id",
+				},
+			},
+			"with_shared": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ConflictsWith: []string{
+					"statistics",
+					"with_programming_language",
+					"min_access_level",
+				},
+			},
+			"include_subgroups": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ConflictsWith: []string{
+					"statistics",
+					"with_programming_language",
+					"min_access_level",
+				},
+			},
+			"projects": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"default_branch": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"visibility": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ssh_url_to_repo": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"http_url_to_repo": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"web_url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"readme_url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tag_list": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"owner": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"username": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"state": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"avatar_url": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"website_url": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name_with_namespace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"path_with_namespace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"issues_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"open_issues_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"merge_requests_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"approvals_before_merge": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"jobs_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"wiki_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"snippets_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"resolve_outdated_diff_discussions": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"container_registry_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"last_activity_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creator_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"namespace": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"path": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"full_path": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"import_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"import_error": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"permissions": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"project_access": {
+										Type:     schema.TypeMap,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeInt,
+										},
+									},
+									"group_access": {
+										Type:     schema.TypeMap,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeInt,
+										},
+									},
+								},
+							},
+						},
+						"archived": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"avatar_url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"shared_runners_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"forks_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"star_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"runners_token": {
+							Type:      schema.TypeString,
+							Computed:  true,
+							Sensitive: true,
+						},
+						"public_builds": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"only_allow_merge_if_pipeline_succeeds": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"only_allow_merge_if_all_discussions_are_resolved": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"lfs_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"request_access_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"merge_method": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"forked_from_project": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"http_url_to_repo": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"id": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name_with_namespace": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"path": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"path_with_namespace": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"web_url": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"mirror": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"mirror_user_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"mirror_trigger_builds": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"only_mirror_protected_branches": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"mirror_overwrites_diverged_branches": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"shared_with_groups": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"group_id": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"group_access_level": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"group_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"statistics": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeInt,
+							},
+						},
+						"_links": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"ci_config_path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"custom_attributes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeMap,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// CRUD methods
+
+func dataSourceGitlabProjectsRead(d *schema.ResourceData, meta interface{}) (err error) {
+	client := meta.(*gitlab.Client)
+	var projectList []*gitlab.Project
+
+	// Permanent parameters
+
+	page := d.Get("page").(int)
+	perPage := d.Get("per_page").(int)
+	maxQueryablePages := d.Get("max_queryable_pages").(int)
+
+	// Conditional parameters
+	// Only way I found to conditionally pass a search parameter to the List(Group/Project)Options
+	// Json marshalling a complete List(Group/Project)Options JSON object had conversion issues with booleans
+	var archivedPtr *bool
+	var includeSubGroupsPtr *bool
+	var membershipPtr *bool
+	var minAccessLevelPtr *gitlab.AccessLevelValue
+	var orderByPtr *string
+	var ownedPtr *bool
+	var searchPtr *string
+	var simplePtr *bool
+	var sortPtr *string
+	var starredPtr *bool
+	var statisticsPtr *bool
+	var visibilityPtr *gitlab.VisibilityValue
+	var withCustomAttributesPtr *bool
+	var withIssuesEnabledPtr *bool
+	var withMergeRequestsEnabledPtr *bool
+	var withProgrammingLanguagePtr *string
+	var withSharedPtr *bool
+
+	if data, ok := d.GetOk("archived"); ok {
+		d := data.(bool)
+		archivedPtr = &d
+	}
+	if data, ok := d.GetOk("include_subgroups"); ok {
+		d := data.(bool)
+		includeSubGroupsPtr = &d
+	}
+	if data, ok := d.GetOk("membership"); ok {
+		d := data.(bool)
+		membershipPtr = &d
+	}
+	if data, ok := d.GetOk("min_access_level"); ok {
+		minAccessLevelPtr = gitlab.AccessLevel(gitlab.AccessLevelValue(data.(int)))
+	}
+	if data, ok := d.GetOk("order_by"); ok {
+		d := data.(string)
+		orderByPtr = &d
+	}
+	if data, ok := d.GetOk("owned"); ok {
+		d := data.(bool)
+		ownedPtr = &d
+	}
+	if data, ok := d.GetOk("search"); ok {
+		d := data.(string)
+		searchPtr = &d
+	}
+	if data, ok := d.GetOk("simple"); ok {
+		d := data.(bool)
+		simplePtr = &d
+	}
+	if data, ok := d.GetOk("sort"); ok {
+		d := data.(string)
+		sortPtr = &d
+	}
+	if data, ok := d.GetOk("starred"); ok {
+		d := data.(bool)
+		starredPtr = &d
+	}
+	if data, ok := d.GetOk("statistics"); ok {
+		d := data.(bool)
+		statisticsPtr = &d
+	}
+	if data, ok := d.GetOk("visibility"); ok {
+		visibilityPtr = gitlab.Visibility(gitlab.VisibilityValue(data.(string)))
+	}
+	if data, ok := d.GetOk("with_custom_attributes"); ok {
+		d := data.(bool)
+		withCustomAttributesPtr = &d
+	}
+	if data, ok := d.GetOk("with_issues_enabled"); ok {
+		d := data.(bool)
+		withIssuesEnabledPtr = &d
+	}
+	if data, ok := d.GetOk("with_merge_requests_enabled"); ok {
+		d := data.(bool)
+		withMergeRequestsEnabledPtr = &d
+	}
+	if data, ok := d.GetOk("with_programming_language"); ok {
+		d := data.(string)
+		withProgrammingLanguagePtr = &d
+	}
+	if data, ok := d.GetOk("with_shared"); ok {
+		d := data.(bool)
+		withSharedPtr = &d
+	}
+
+	log.Printf("[DEBUG] Reading Gitlab projects")
+
+	switch groupId, ok := d.GetOk("group_id"); ok {
+	// GroupProject case
+	case true:
+		opts := &gitlab.ListGroupProjectsOptions{
+			ListOptions: gitlab.ListOptions{
+				Page:    page,
+				PerPage: perPage,
+			},
+			Archived:                 archivedPtr,
+			Visibility:               visibilityPtr,
+			OrderBy:                  orderByPtr,
+			Sort:                     sortPtr,
+			Search:                   searchPtr,
+			Simple:                   simplePtr,
+			Owned:                    ownedPtr,
+			Starred:                  starredPtr,
+			WithIssuesEnabled:        withIssuesEnabledPtr,
+			WithMergeRequestsEnabled: withMergeRequestsEnabledPtr,
+			WithShared:               withSharedPtr,
+			IncludeSubgroups:         includeSubGroupsPtr,
+			WithCustomAttributes:     withCustomAttributesPtr,
+		}
+
+		for {
+			projects, response, err := client.Groups.ListGroupProjects(groupId.(int), opts, nil)
+			if err != nil {
+				return err
+			}
+			projectList = append(projectList, projects...)
+			opts.ListOptions.Page++
+
+			log.Printf("[INFO] Currentpage: %d, Total: %d", response.CurrentPage, response.TotalPages)
+			if response.CurrentPage == response.TotalPages || response.CurrentPage > maxQueryablePages {
+				break
+			}
+		}
+		h, err := hashstructure.Hash(*opts, nil)
+		if err != nil {
+			return err
+		}
+		d.SetId(fmt.Sprintf("%d-%d", groupId.(int), h))
+		if err := d.Set("projects", flattenProjects(projectList)); err != nil {
+			return err
+		}
+
+	// Project case
+	default:
+		opts := &gitlab.ListProjectsOptions{
+			ListOptions: gitlab.ListOptions{
+				Page:    page,
+				PerPage: perPage,
+			},
+			Archived:                 archivedPtr,
+			OrderBy:                  orderByPtr,
+			Sort:                     sortPtr,
+			Search:                   searchPtr,
+			Simple:                   simplePtr,
+			Owned:                    ownedPtr,
+			Membership:               membershipPtr,
+			Starred:                  starredPtr,
+			Statistics:               statisticsPtr,
+			Visibility:               visibilityPtr,
+			WithIssuesEnabled:        withIssuesEnabledPtr,
+			WithMergeRequestsEnabled: withMergeRequestsEnabledPtr,
+			MinAccessLevel:           minAccessLevelPtr,
+			WithCustomAttributes:     withCustomAttributesPtr,
+			WithProgrammingLanguage:  withProgrammingLanguagePtr,
+		}
+
+		for {
+			projects, response, err := client.Projects.ListProjects(opts, nil)
+			if err != nil {
+				return err
+			}
+			projectList = append(projectList, projects...)
+			opts.ListOptions.Page++
+
+			log.Printf("[INFO] Currentpage: %d, Total: %d", response.CurrentPage, response.TotalPages)
+			if response.CurrentPage == response.TotalPages || response.CurrentPage > maxQueryablePages {
+				break
+			}
+		}
+		h, err := hashstructure.Hash(*opts, nil)
+		if err != nil {
+			return err
+		}
+		d.SetId(fmt.Sprintf("%d", h))
+		if err := d.Set("projects", flattenProjects(projectList)); err != nil {
+			return err
+		}
+	}
+	return err
+}

--- a/gitlab/data_source_gitlab_projects_test.go
+++ b/gitlab/data_source_gitlab_projects_test.go
@@ -1,0 +1,226 @@
+package gitlab
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataGitlabProjectsSearch(t *testing.T) {
+	projectName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataGitlabProjectsConfigGetProjectSearch(projectName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDataSourceGitlabProjects(
+						"gitlab_project.search",
+						"data.gitlab_projects.search",
+					),
+					resource.TestCheckResourceAttr(
+						"data.gitlab_projects.search",
+						"projects.0.owner.0.id",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						"data.gitlab_projects.search",
+						"projects.0.permissions.0.project_access.access_level",
+						"40",
+					),
+					resource.TestCheckNoResourceAttr(
+						"data.gitlab_projects.search",
+						"projects.0.permissions.0.project_access.group_level",
+					),
+					resource.TestCheckResourceAttr(
+						"data.gitlab_projects.search",
+						"projects.0.namespace.0.kind",
+						"user",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataGitlabProjectsGroups(t *testing.T) {
+	projectName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	groupName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	parentGroupName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	subGroupName1 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	subGroupName2 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	subGroupProjectName1 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	subGroupProjectName2 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataGitlabProjectsConfigGetGroupProjectsByGroupId(groupName, projectName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDataSourceGitlabProjects(
+						"gitlab_project.testProject",
+						"data.gitlab_projects.group",
+					),
+					resource.TestCheckResourceAttr(
+						"data.gitlab_projects.group",
+						"projects.0.namespace.0.kind",
+						"group",
+					),
+				),
+			},
+			{
+				Config: testAccDataGitlabProjectsConfigGetNestedProjectsByParentGroupId(parentGroupName, subGroupName1, subGroupName2, subGroupProjectName1, subGroupProjectName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceGitlabProjects(
+						"gitlab_project.testProject1",
+						"data.gitlab_projects.subGroups",
+					),
+					testAccDataSourceGitlabProjects(
+						"gitlab_project.testProject2",
+						"data.gitlab_projects.subGroups",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGitlabProjects(src string, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		project := s.RootModule().Resources[src]
+		projectResource := project.Primary.Attributes
+
+		search := s.RootModule().Resources[n]
+		searchResource := search.Primary.Attributes
+
+		if searchResource["id"] == "" {
+			return fmt.Errorf("expected to get a project ID from Gitlab")
+		}
+		if searchResource["projects.#"] == "0" {
+			return fmt.Errorf("expected to find at least one matching project from the datasource")
+		}
+
+		projectsNumber, err := strconv.Atoi(searchResource["projects.#"])
+		if err != nil {
+			return fmt.Errorf("the datasource returned no 'projects' attribute, got: %s", searchResource)
+		}
+
+		testAttributes := []string{
+			"id",
+			"name",
+			"path",
+		}
+
+		for i := 0; i < projectsNumber; i++ {
+			for j, attribute := range testAttributes {
+				if searchResource[fmt.Sprintf("projects.%d.%s", i, attribute)] != projectResource[attribute] {
+					break
+				}
+				if j == len(testAttributes)-1 {
+					// Found an exact match
+					return nil
+				}
+			}
+		}
+
+		var errorMessageExpected strings.Builder
+		for _, attr := range testAttributes {
+			errorMessageExpected.WriteString(fmt.Sprintf("%s=%v, ", attr, projectResource[fmt.Sprintf("%s", attr)]))
+		}
+
+		var errorMessageGot strings.Builder
+		for i := 0; i < projectsNumber; i++ {
+			errorMessageGot.WriteString(fmt.Sprintf("project_%d: ", i))
+			for _, attr := range testAttributes {
+				errorMessageGot.WriteString(fmt.Sprintf("%s_%d=%v, ", attr, i, searchResource[fmt.Sprintf("projects.%d.%s", i, attr)]))
+			}
+			errorMessageGot.WriteString("\n")
+		}
+
+		return fmt.Errorf("datasource did not return any match.\nExpected: %s\nGot:\n  %s", errorMessageExpected.String(), errorMessageGot.String())
+	}
+}
+
+func testAccDataGitlabProjectsConfigGetProjectSearch(projectName string) string {
+	return fmt.Sprintf(`
+
+resource "gitlab_project" "search" {
+  name = "%s"
+  path = "%s"
+}
+
+data "gitlab_projects" "search" {
+  search = gitlab_project.search.name
+}
+	`, projectName, projectName)
+}
+
+func testAccDataGitlabProjectsConfigGetGroupProjectsByGroupId(groupName string, projectName string) string {
+	return fmt.Sprintf(`
+resource "gitlab_group" "testGroup" {
+  name = "%s"
+  path = "%s"
+  description = "Terraform acceptance tests"
+}
+
+resource "gitlab_project" "testProject"{
+  name = "%s"
+  namespace_id = gitlab_group.testGroup.id
+}
+
+data "gitlab_projects" "group" {
+  group_id = gitlab_project.testProject.namespace_id
+}
+	`, groupName, groupName, projectName)
+}
+
+func testAccDataGitlabProjectsConfigGetNestedProjectsByParentGroupId(parentGroupName string, subGroupName1 string, subGroupName2 string, projectName1 string, projectName2 string) string {
+	return fmt.Sprintf(`
+resource "gitlab_group" "testGroup" {
+  name = "%s"
+  path = "%s"
+}
+
+resource "gitlab_group" "testSubGroup1" {
+  name = "%s"
+  path = "%s"
+  parent_id = gitlab_group.testGroup.id
+}
+
+resource "gitlab_group" "testSubGroup2" {
+  name = "%s"
+  path = "%s"
+  parent_id = gitlab_group.testGroup.id
+}
+
+resource "gitlab_project" "testProject1"{
+  name = "%s"
+  namespace_id = gitlab_group.testSubGroup1.id
+  description = gitlab_group.testGroup.id
+}
+
+resource "gitlab_project" "testProject2"{
+  name = "%s"
+  namespace_id = gitlab_group.testSubGroup2.id
+  // This is all just to avoid using explicit depends_on on the datasource
+  // since it seems to break the acceptance tests
+  description = gitlab_project.testProject1.description
+}
+
+data "gitlab_projects" "subGroups" {
+  // This is to ensure the projects have been created before running the datasource
+  group_id = gitlab_project.testProject2.description
+  include_subgroups = true
+}
+	`, parentGroupName, parentGroupName, subGroupName1, subGroupName1, subGroupName2, subGroupName2, projectName1, projectName2)
+}

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -54,10 +54,11 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"gitlab_group":   dataSourceGitlabGroup(),
-			"gitlab_project": dataSourceGitlabProject(),
-			"gitlab_user":    dataSourceGitlabUser(),
-			"gitlab_users":   dataSourceGitlabUsers(),
+			"gitlab_group":    dataSourceGitlabGroup(),
+			"gitlab_project":  dataSourceGitlabProject(),
+			"gitlab_projects": dataSourceGitlabProjects(),
+			"gitlab_user":     dataSourceGitlabUser(),
+			"gitlab_users":    dataSourceGitlabUsers(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.8.0
 	github.com/hashicorp/terraform-svchost v0.0.0-20191119180714-d2e4933b9136 // indirect
 	github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d // indirect
+	github.com/mitchellh/hashstructure v1.0.0
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
+github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/vendor/github.com/mitchellh/hashstructure/LICENSE
+++ b/vendor/github.com/mitchellh/hashstructure/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/hashstructure/README.md
+++ b/vendor/github.com/mitchellh/hashstructure/README.md
@@ -1,0 +1,65 @@
+# hashstructure [![GoDoc](https://godoc.org/github.com/mitchellh/hashstructure?status.svg)](https://godoc.org/github.com/mitchellh/hashstructure)
+
+hashstructure is a Go library for creating a unique hash value
+for arbitrary values in Go.
+
+This can be used to key values in a hash (for use in a map, set, etc.)
+that are complex. The most common use case is comparing two values without
+sending data across the network, caching values locally (de-dup), and so on.
+
+## Features
+
+  * Hash any arbitrary Go value, including complex types.
+
+  * Tag a struct field to ignore it and not affect the hash value.
+
+  * Tag a slice type struct field to treat it as a set where ordering
+    doesn't affect the hash code but the field itself is still taken into
+    account to create the hash value.
+
+  * Optionally specify a custom hash function to optimize for speed, collision
+    avoidance for your data set, etc.
+  
+  * Optionally hash the output of `.String()` on structs that implement fmt.Stringer,
+    allowing effective hashing of time.Time
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/hashstructure
+```
+
+## Usage & Example
+
+For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/hashstructure).
+
+A quick code example is shown below:
+
+```go
+type ComplexStruct struct {
+    Name     string
+    Age      uint
+    Metadata map[string]interface{}
+}
+
+v := ComplexStruct{
+    Name: "mitchellh",
+    Age:  64,
+    Metadata: map[string]interface{}{
+        "car":      true,
+        "location": "California",
+        "siblings": []string{"Bob", "John"},
+    },
+}
+
+hash, err := hashstructure.Hash(v, nil)
+if err != nil {
+    panic(err)
+}
+
+fmt.Printf("%d", hash)
+// Output:
+// 2307517237273902113
+```

--- a/vendor/github.com/mitchellh/hashstructure/go.mod
+++ b/vendor/github.com/mitchellh/hashstructure/go.mod
@@ -1,0 +1,1 @@
+module github.com/mitchellh/hashstructure

--- a/vendor/github.com/mitchellh/hashstructure/hashstructure.go
+++ b/vendor/github.com/mitchellh/hashstructure/hashstructure.go
@@ -1,0 +1,358 @@
+package hashstructure
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"reflect"
+)
+
+// ErrNotStringer is returned when there's an error with hash:"string"
+type ErrNotStringer struct {
+	Field string
+}
+
+// Error implements error for ErrNotStringer
+func (ens *ErrNotStringer) Error() string {
+	return fmt.Sprintf("hashstructure: %s has hash:\"string\" set, but does not implement fmt.Stringer", ens.Field)
+}
+
+// HashOptions are options that are available for hashing.
+type HashOptions struct {
+	// Hasher is the hash function to use. If this isn't set, it will
+	// default to FNV.
+	Hasher hash.Hash64
+
+	// TagName is the struct tag to look at when hashing the structure.
+	// By default this is "hash".
+	TagName string
+
+	// ZeroNil is flag determining if nil pointer should be treated equal
+	// to a zero value of pointed type. By default this is false.
+	ZeroNil bool
+}
+
+// Hash returns the hash value of an arbitrary value.
+//
+// If opts is nil, then default options will be used. See HashOptions
+// for the default values. The same *HashOptions value cannot be used
+// concurrently. None of the values within a *HashOptions struct are
+// safe to read/write while hashing is being done.
+//
+// Notes on the value:
+//
+//   * Unexported fields on structs are ignored and do not affect the
+//     hash value.
+//
+//   * Adding an exported field to a struct with the zero value will change
+//     the hash value.
+//
+// For structs, the hashing can be controlled using tags. For example:
+//
+//    struct {
+//        Name string
+//        UUID string `hash:"ignore"`
+//    }
+//
+// The available tag values are:
+//
+//   * "ignore" or "-" - The field will be ignored and not affect the hash code.
+//
+//   * "set" - The field will be treated as a set, where ordering doesn't
+//             affect the hash code. This only works for slices.
+//
+//   * "string" - The field will be hashed as a string, only works when the
+//                field implements fmt.Stringer
+//
+func Hash(v interface{}, opts *HashOptions) (uint64, error) {
+	// Create default options
+	if opts == nil {
+		opts = &HashOptions{}
+	}
+	if opts.Hasher == nil {
+		opts.Hasher = fnv.New64()
+	}
+	if opts.TagName == "" {
+		opts.TagName = "hash"
+	}
+
+	// Reset the hash
+	opts.Hasher.Reset()
+
+	// Create our walker and walk the structure
+	w := &walker{
+		h:       opts.Hasher,
+		tag:     opts.TagName,
+		zeronil: opts.ZeroNil,
+	}
+	return w.visit(reflect.ValueOf(v), nil)
+}
+
+type walker struct {
+	h       hash.Hash64
+	tag     string
+	zeronil bool
+}
+
+type visitOpts struct {
+	// Flags are a bitmask of flags to affect behavior of this visit
+	Flags visitFlag
+
+	// Information about the struct containing this field
+	Struct      interface{}
+	StructField string
+}
+
+func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
+	t := reflect.TypeOf(0)
+
+	// Loop since these can be wrapped in multiple layers of pointers
+	// and interfaces.
+	for {
+		// If we have an interface, dereference it. We have to do this up
+		// here because it might be a nil in there and the check below must
+		// catch that.
+		if v.Kind() == reflect.Interface {
+			v = v.Elem()
+			continue
+		}
+
+		if v.Kind() == reflect.Ptr {
+			if w.zeronil {
+				t = v.Type().Elem()
+			}
+			v = reflect.Indirect(v)
+			continue
+		}
+
+		break
+	}
+
+	// If it is nil, treat it like a zero.
+	if !v.IsValid() {
+		v = reflect.Zero(t)
+	}
+
+	// Binary writing can use raw ints, we have to convert to
+	// a sized-int, we'll choose the largest...
+	switch v.Kind() {
+	case reflect.Int:
+		v = reflect.ValueOf(int64(v.Int()))
+	case reflect.Uint:
+		v = reflect.ValueOf(uint64(v.Uint()))
+	case reflect.Bool:
+		var tmp int8
+		if v.Bool() {
+			tmp = 1
+		}
+		v = reflect.ValueOf(tmp)
+	}
+
+	k := v.Kind()
+
+	// We can shortcut numeric values by directly binary writing them
+	if k >= reflect.Int && k <= reflect.Complex64 {
+		// A direct hash calculation
+		w.h.Reset()
+		err := binary.Write(w.h, binary.LittleEndian, v.Interface())
+		return w.h.Sum64(), err
+	}
+
+	switch k {
+	case reflect.Array:
+		var h uint64
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			h = hashUpdateOrdered(w.h, h, current)
+		}
+
+		return h, nil
+
+	case reflect.Map:
+		var includeMap IncludableMap
+		if opts != nil && opts.Struct != nil {
+			if v, ok := opts.Struct.(IncludableMap); ok {
+				includeMap = v
+			}
+		}
+
+		// Build the hash for the map. We do this by XOR-ing all the key
+		// and value hashes. This makes it deterministic despite ordering.
+		var h uint64
+		for _, k := range v.MapKeys() {
+			v := v.MapIndex(k)
+			if includeMap != nil {
+				incl, err := includeMap.HashIncludeMap(
+					opts.StructField, k.Interface(), v.Interface())
+				if err != nil {
+					return 0, err
+				}
+				if !incl {
+					continue
+				}
+			}
+
+			kh, err := w.visit(k, nil)
+			if err != nil {
+				return 0, err
+			}
+			vh, err := w.visit(v, nil)
+			if err != nil {
+				return 0, err
+			}
+
+			fieldHash := hashUpdateOrdered(w.h, kh, vh)
+			h = hashUpdateUnordered(h, fieldHash)
+		}
+
+		return h, nil
+
+	case reflect.Struct:
+		parent := v.Interface()
+		var include Includable
+		if impl, ok := parent.(Includable); ok {
+			include = impl
+		}
+
+		t := v.Type()
+		h, err := w.visit(reflect.ValueOf(t.Name()), nil)
+		if err != nil {
+			return 0, err
+		}
+
+		l := v.NumField()
+		for i := 0; i < l; i++ {
+			if innerV := v.Field(i); v.CanSet() || t.Field(i).Name != "_" {
+				var f visitFlag
+				fieldType := t.Field(i)
+				if fieldType.PkgPath != "" {
+					// Unexported
+					continue
+				}
+
+				tag := fieldType.Tag.Get(w.tag)
+				if tag == "ignore" || tag == "-" {
+					// Ignore this field
+					continue
+				}
+
+				// if string is set, use the string value
+				if tag == "string" {
+					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
+						innerV = reflect.ValueOf(impl.String())
+					} else {
+						return 0, &ErrNotStringer{
+							Field: v.Type().Field(i).Name,
+						}
+					}
+				}
+
+				// Check if we implement includable and check it
+				if include != nil {
+					incl, err := include.HashInclude(fieldType.Name, innerV)
+					if err != nil {
+						return 0, err
+					}
+					if !incl {
+						continue
+					}
+				}
+
+				switch tag {
+				case "set":
+					f |= visitFlagSet
+				}
+
+				kh, err := w.visit(reflect.ValueOf(fieldType.Name), nil)
+				if err != nil {
+					return 0, err
+				}
+
+				vh, err := w.visit(innerV, &visitOpts{
+					Flags:       f,
+					Struct:      parent,
+					StructField: fieldType.Name,
+				})
+				if err != nil {
+					return 0, err
+				}
+
+				fieldHash := hashUpdateOrdered(w.h, kh, vh)
+				h = hashUpdateUnordered(h, fieldHash)
+			}
+		}
+
+		return h, nil
+
+	case reflect.Slice:
+		// We have two behaviors here. If it isn't a set, then we just
+		// visit all the elements. If it is a set, then we do a deterministic
+		// hash code.
+		var h uint64
+		var set bool
+		if opts != nil {
+			set = (opts.Flags & visitFlagSet) != 0
+		}
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			if set {
+				h = hashUpdateUnordered(h, current)
+			} else {
+				h = hashUpdateOrdered(w.h, h, current)
+			}
+		}
+
+		return h, nil
+
+	case reflect.String:
+		// Directly hash
+		w.h.Reset()
+		_, err := w.h.Write([]byte(v.String()))
+		return w.h.Sum64(), err
+
+	default:
+		return 0, fmt.Errorf("unknown kind to hash: %s", k)
+	}
+
+}
+
+func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {
+	// For ordered updates, use a real hash function
+	h.Reset()
+
+	// We just panic if the binary writes fail because we are writing
+	// an int64 which should never be fail-able.
+	e1 := binary.Write(h, binary.LittleEndian, a)
+	e2 := binary.Write(h, binary.LittleEndian, b)
+	if e1 != nil {
+		panic(e1)
+	}
+	if e2 != nil {
+		panic(e2)
+	}
+
+	return h.Sum64()
+}
+
+func hashUpdateUnordered(a, b uint64) uint64 {
+	return a ^ b
+}
+
+// visitFlag is used as a bitmask for affecting visit behavior
+type visitFlag uint
+
+const (
+	visitFlagInvalid visitFlag = iota
+	visitFlagSet               = iota << 1
+)

--- a/vendor/github.com/mitchellh/hashstructure/include.go
+++ b/vendor/github.com/mitchellh/hashstructure/include.go
@@ -1,0 +1,15 @@
+package hashstructure
+
+// Includable is an interface that can optionally be implemented by
+// a struct. It will be called for each field in the struct to check whether
+// it should be included in the hash.
+type Includable interface {
+	HashInclude(field string, v interface{}) (bool, error)
+}
+
+// IncludableMap is an interface that can optionally be implemented by
+// a struct. It will be called when a map-type field is found to ask the
+// struct if the map item should be included in the hash.
+type IncludableMap interface {
+	HashIncludeMap(field string, k, v interface{}) (bool, error)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -229,6 +229,9 @@ github.com/mitchellh/go-homedir
 github.com/mitchellh/go-testing-interface
 # github.com/mitchellh/go-wordwrap v1.0.0
 github.com/mitchellh/go-wordwrap
+# github.com/mitchellh/hashstructure v1.0.0
+## explicit
+github.com/mitchellh/hashstructure
 # github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.1

--- a/website/docs/d/projects.html.markdown
+++ b/website/docs/d/projects.html.markdown
@@ -1,0 +1,270 @@
+---
+layout: "gitlab"
+page_title: "GitLab: gitlab_projects"
+sidebar_current: "docs-gitlab-data-source-projects"
+description: |-
+  List projects using specific filters.
+---
+
+# gitlab\_projects
+
+Provides details about a list of projects in the Gitlab provider. Listing all projects and group projects with [project filtering](https://docs.gitlab.com/ee/api/projects.html#list-user-projects) or [group project filtering](https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects) is supported.
+
+~> NOTE: This data source supports all available filters exposed by the `xanzy/go-gitlab` package, which might not expose all available filters exposed by the Gitlab APIs.   
+
+## Example Usage
+
+### List projects within a group tree
+
+```hcl
+data "gitlab_group" "mygroup" {
+  full_path = "mygroup"
+}
+
+data "gitlab_projects" "group_projects" {
+  group_id          = data.gitlab_group.mygroup.id
+  order_by          = "name"
+  include_subgroups = true
+  with_shared       = false
+}
+```
+
+### List projects using the search syntax
+
+```hcl
+data "gitlab_projects" "projects" {
+  search              = "postgresql"
+  visibility          = "private"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `group_id` - (Optional) The ID of the group owned by the authenticated user to look projects for within. Cannot be used with `min_access_level`, `with_programming_language` or `statistics`.
+
+* `per_page`: The maximum number of projects to return in one paginated API call, limited to `100`. Default is `20`.
+
+* `max_queryable_pages` Prevents overloading your Gitlab instance in case of a misconfiguration. Default is `10`.
+
+* `archived` - (Optional) Limit by archived status.
+
+* `visibility` - (Optional) Limit by visibility `public`, `internal`, or `private`.
+
+* `order_by` - (Optional) Return projects ordered by `id`, `name`, `path`, `created_at`, `updated_at`, or `last_activity_at` fields. Default is `created_at`.
+
+* `sort` - (Optional) Return projects sorted in `asc` or `desc` order. Default is `desc`.
+
+* `search` - (Optional) Return list of authorized projects matching the search criteria.
+
+* `simple` - (Optional) Return only the ID, URL, name, and path of each project.
+
+* `owned` - (Optional) Limit by projects owned by the current user.
+
+* `starred` - (Optional) Limit by projects starred by the current user.
+
+* `with_issues_enabled` - (Optional) Limit by projects with issues feature enabled. Default is `false`.
+
+* `with_merge_requests_enabled` - (Optional) Limit by projects with merge requests feature enabled. Default is `false`.
+
+* `with_shared` - (Optional) Include projects shared to this group. Default is `true`. Needs `group_id`.
+
+* `include_subgroups` - (Optional) Include projects in subgroups of this group. Default is `false`. Needs `group_id`.
+
+* `min_access_level` - (Optional) Limit to projects where current user has at least this access level, refer to the [official documentation](https://docs.gitlab.com/ee/api/members.html) for values. Cannot be used with `group_id`.
+
+* `with_custom_attributes` - (Optional) Include custom attributes in response _(admins only)_.
+
+* `membership` - (Optional) Limit by projects that the current user is a member of.
+
+* `statistics` - (Optional) Include project statistics. Cannot be used with `group_id`.
+
+* `with_programming_language` - (Optional) Limit by projects which use the given programming language. Cannot be used with `group_id`.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `projects` - A list containing the projects matching the supplied arguments
+
+Projects items have the following fields:
+
+* `id` - The ID of the project.
+
+* `name` - The name of the project.
+
+* `description`
+
+* `default_branch`
+
+* `public` - Whether the project is public.
+
+* `visibility` - The visibility of the project.
+
+* `ssh_url_to_repo` - The SSH clone URL of the project.
+
+* `http_url_to_repo` - The HTTP clone URL of the project.
+
+* `web_url`
+
+* `readme_url`
+
+* `tag_list` - A set of the project topics (formerly called "project tags").
+
+* `owner` - The owner of the project, due to Terraform aggregate types limitations, this field's attributes are accessed with the `owner.0` prefix. Structure is documented below.
+
+* `name_with_namespace` - In `group / subgroup / project` or `user / project` format.
+
+* `path`
+
+* `path_with_namespace` - In `group/subgroup/project` or `user/project` format.
+
+* `issues_enabled`
+
+* `open_issues_count`
+
+* `merge_requests_enabled`
+
+* `approvals_before_merge` - The numbers of approvals needed in a merge requests.
+
+* `jobs_enabled` - Whether pipelines are enabled for the project.
+
+* `wiki_enabled`
+
+* `snippets_enabled`
+
+* `resolve_outdated_diff_discussions`
+
+* `container_registry_enabled`
+
+* `created_at`
+
+* `last_activity_at`
+
+* `creator_id`
+
+* `namespace` namespace of the project, due to Terraform aggregate types limitations, this field's attributes are accessed with the `namespace.0` prefix. Structure is documented below.
+
+* `import_status`
+
+* `import_error`
+
+* `permissions` permissions for the project, due to Terraform aggregate types limitations, this field's attributes are accessed with the `permissions.0` prefix. Structure is documented below.
+
+* `archived`
+
+* `avatar_url`
+
+* `shared_runners_enabled`
+
+* `forks_count`
+
+* `star_count`
+
+* `runners_token`
+
+* `public_builds`
+
+* `only_allow_merge_if_pipeline_succeeds`
+
+* `only_allow_merge_if_all_discussions_are_resolved`
+
+* `lfs_enabled`
+
+* `request_access_enabled`
+
+* `merge_method`
+
+* `forked_from_project` If this project has been forked from another project, due to Terraform aggregate types limitations, this field's attributes are accessed with the `forked_from_project.0` prefix. Structure is documented below.
+
+* `mirror`
+
+* `mirror_user_id`
+
+* `mirror_trigger_builds`
+
+* `only_mirror_protected_branches`
+
+* `mirror_overwrites_diverged_branches`
+
+* `shared_with_groups` List of groups with which the project is shared, the structure is documented below.
+
+* `statistics`
+
+* `_links`
+
+* `ci_config_path`
+
+* `custom_attributes`
+
+The `owner` attribute exposes the following sub-attributes:
+
+~> NOTE: These sub-attributes are only populated if the Gitlab token used has an administrator scope.
+
+* `id`
+
+* `username`
+
+* `name`
+
+* `state`
+
+* `avatar_url`
+
+* `website_url`
+
+The `namespace` attribute exposes the following sub-attributes:
+
+* `id`
+
+* `name`
+
+* `path`
+
+* `kind` Whether the namespace is a `group` or a `user`.
+
+* `full_path`
+
+The `permissions` attribute exposes the following sub-attributes:
+
+* `project_access` Structure is documented below.
+
+* `group_access` Structure is documented below.
+
+The `permissions.0.project_access` attribute exposes the following sub-attributes:
+
+* `access_level`
+
+* `notification_level`
+
+The `permissions.0.group_access` attribute exposes the following sub-attributes:
+
+* `access_level`
+
+* `notification_level`
+
+The `forked_from_project` attribute exposes the following sub-attributes:
+
+* `id`
+
+* `http_url_to_repo`
+
+* `name`
+
+* `name_with_namespace`
+
+* `path`
+
+* `path_with_namespace`
+
+* `web_url`
+
+The `shared_with_groups` list objects expose the following attributes:
+
+* `group_id`
+
+* `group_access_level`
+
+* `group_name`

--- a/website/gitlab.erb
+++ b/website/gitlab.erb
@@ -19,6 +19,9 @@
                 <li<%= sidebar_current("docs-gitlab-data-source-project") %>>
                     <a href="/docs/providers/gitlab/d/project.html">gitlab_project</a>
                 </li>
+                <li<%= sidebar_current("docs-gitlab-data-source-projects") %>>
+                    <a href="/docs/providers/gitlab/d/projects.html">gitlab_projects</a>
+                </li>
                 <li<%= sidebar_current("docks-gitlab-data-source-user") %>>
                     <a href="/docs/providers/gitlab/d/user.html">gitlab_user</a>
                 </li>


### PR DESCRIPTION
Picked up the work of https://github.com/terraform-providers/terraform-provider-gitlab/pull/161, as this is a critical missing datasource.

* Made group_id optional
* Use terraform-plugin-sdk
* Method refactoring here and there

 Most credit goes to @enieuw and the original PR contributors.

**EDIT**: I ended up redoing everything after all, the datasource now supports fully all group and project listProject APIs parameters exposed by the go-gitlab package.