### PR TITLE
Revert "Fix documentation group to use parent_id (#139)"

### DIFF
--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -24,7 +24,7 @@ resource "gitlab_group" "example" {
 resource "gitlab_project" "example" {
   name         = "example"
   description  = "An example project"
-  parent_id = "${gitlab_group.example.id}"
+  namespace_id = "${gitlab_group.example.id}"
 }
 ```
 


### PR DESCRIPTION
This reverts commit 2573a0726bffb41ed0afec2152b6f9967bff5f89.

the resource has `namespace_id` when the data source uses `parent_id`. /cc @jakubknejzlik 