### PR TITLE
Fix acceptance tests

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -20,6 +20,8 @@ jobs:
         echo "::set-env name=MAKE_TARGET::testacc"
         echo "::set-env name=GO_FLAGS::-mod=vendor"
         echo "::set-env name=GO111MODULE::on"
+        echo "::set-env name=GITLAB_TOKEN::20char-testing-token"
+        echo "::set-env name=GITLAB_BASE_URL::http://127.0.0.1:8080/api/v4"
 
     - name: Start Gitlab and run acceptance tests
       run: |


### PR DESCRIPTION
I've fixed up the acceptance tests, although I'm not sure if this is the right way to fix them.

The key thing here is that the GitLab personal access token must be 20 characters in length, otherwise it will not be treated as a PAT. Here are the relevant lines of code:

https://gitlab.com/gitlab-org/gitlab/blob/3174a1f5c5c317fef7c611f0363d1b00dc85f6fc/lib/gitlab/auth/auth_finders.rb#L138-176

It first tries to see if the token is an OAuth token. If the received token matches the PAT length, it will be treated as a PAT instead.

And here's where the PAT token length is defined: https://gitlab.com/gitlab-org/gitlab/blob/911f2085d95d2f35ed95e56da762d1e218e928e4/app/models/personal_access_token.rb#L11