### PR TITLE
Improvements to resource_gitlab_user Import (#193)

### DIFF
--- a/gitlab/resource_gitlab_user.go
+++ b/gitlab/resource_gitlab_user.go
@@ -16,7 +16,23 @@ func resourceGitlabUser() *schema.Resource {
 		Update: resourceGitlabUserUpdate,
 		Delete: resourceGitlabUserDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				client := meta.(*gitlab.Client)
+				log.Printf("[DEBUG] read gitlab user %s", d.Id())
+
+				id, _ := strconv.Atoi(d.Id())
+
+				user, _, err := client.Users.GetUser(id)
+				if err != nil {
+					return nil, err
+				}
+
+				resourceGitlabUserSetToState(d, user)
+				d.Set("email", user.Email)
+				d.Set("is_admin", user.IsAdmin)
+				d.Set("is_external", user.External)
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -26,7 +42,7 @@ func resourceGitlabUser() *schema.Resource {
 			},
 			"password": {
 				Type:      schema.TypeString,
-				Required:  true,
+				Optional:  true,
 				Sensitive: true,
 			},
 			"email": {

--- a/gitlab/resource_gitlab_user.go
+++ b/gitlab/resource_gitlab_user.go
@@ -125,7 +125,7 @@ func resourceGitlabUserCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceGitlabUserRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
-	log.Printf("[DEBUG] read gitlab user %s", d.Id())
+	log.Printf("[DEBUG] import -- read gitlab user %s", d.Id())
 
 	id, _ := strconv.Atoi(d.Id())
 

--- a/gitlab/resource_gitlab_user_test.go
+++ b/gitlab/resource_gitlab_user_test.go
@@ -74,6 +74,15 @@ func TestAccGitlabUser_basic(t *testing.T) {
 					}),
 				),
 			},
+			{
+				ResourceName:      "gitlab_user.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"skip_confirmation",
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
This change makes three improvements to the gitlab_user resource. Fixes #193.

### Change 1:
The `password` attribute for gitlab_user has been changed from required to optional. There is no mechanism in the Gitlab `user` API to `GET` the `password` attribute (see: https://docs.gitlab.com/ee/api/users.html), so it is impossible for us to ever read this attribute when we're pulling known users to set state. The field is therefore only usable when we are performing a Create or Update action on a gitlab_user (and, again, referencing the v4 API docs, `password` is **never a required attribute** for GET, POST, or PUT; it therefore makes no sense for it to be required for the Terraform provider).

Moreover: Terraform state import only requires us to do a Read action because it's describing an existing user, and because `password` is not an attribute we can `GET`, the block of Terraform code generated by `import` will not have a `password` field at all. There is therefore no choice but to make the field optional--and this **must** be done as part of the same change that corrects import behavior.

### Change 2:
The resource's State Importer originally called `ImportStatePassthrough` as the `Import` method, which essentially ensured that `terraform import` could only read the fields defined in `resourceGitlabUserRead` & `resourceGitlabUserSetToState` (in this case, `username`, `name`, `can_create_group`, and `projects_limit`). I have replaced the `ImportStatePassthrough` with an anonymous function that reuses `resourceGitlabUserSetToState`, and additionally sets `email`, `is_admin`, and `is_external`. I did not modify the fields set in `resourceGitlabUserSetToState` because that function appears to be intended to provide only a basic level of detail about a user (i.e., all the data we'd be able to pull for a user if we didn't have a token with Admin privileges).

A (presumably-unintended) consequence of the limited scope of `resourceGitlabUserSetToState` is that, before the change I'm introducing here, `email` was always set to `null` for imported users, forcing the creation of a new resource any time a user was discovered with `terraform import`. Now that `email` is included in the import function, we will be able to manage a user without destroying and replacing them.

(N.B. These fields can be easily extended in the future if need be.)

### Change 3:
The test for the gitlab_user resource has been updated to include ImportState and ImportStateVerify elements in the final stage (per the Terraform `import` implementation documentation: https://www.terraform.io/docs/extend/resources/import.html, this is mandatory for any resources which allow import). The `password` and `skip_confirmation` attributes are ignored because it is not possible to read them from the API (as I mentioned above, they are not part of the `GET` `/users` schema, which can be found here: https://docs.gitlab.com/ee/api/users.html, so there will *always* be a discrepancy between the specified value and the value we read from the API; we must therefore ignore these fields in the Import State Verification test).