### PR TITLE
Add management_project_id for Group and Project Clusters

### DIFF
--- a/website/docs/r/group_cluster.html.markdown
+++ b/website/docs/r/group_cluster.html.markdown
@@ -31,6 +31,7 @@ resource gitlab_group_cluster "bar" {
   kubernetes_ca_cert            = "some-cert"
   kubernetes_authorization_type = "rbac"
   environment_scope             = "*"
+  management_cluster_id         = "123456"
 }
 ```
 
@@ -57,6 +58,8 @@ The following arguments are supported:
 * `kubernetes_authorization_type` - (Optional, string) The cluster authorization type. Valid values are `rbac`, `abac`, `unknown_authorization`. Defaults to `rbac`.
 
 * `environment_scope` - (Optional, string) The associated environment to the cluster. Defaults to `*`.
+
+* `management_cluster_id` - (Optional, string) The ID of the management project for the cluster. 
 
 ## Import
 

--- a/website/docs/r/project_cluster.html.markdown
+++ b/website/docs/r/project_cluster.html.markdown
@@ -31,6 +31,7 @@ resource gitlab_project_cluster "bar" {
   kubernetes_namespace          = "namespace"
   kubernetes_authorization_type = "rbac"
   environment_scope             = "*"
+  management_cluster_id         = "123456"
 }
 ```
 
@@ -59,6 +60,8 @@ The following arguments are supported:
 * `kubernetes_authorization_type` - (Optional, string) The cluster authorization type. Valid values are `rbac`, `abac`, `unknown_authorization`. Defaults to `rbac`.
 
 * `environment_scope` - (Optional, string) The associated environment to the cluster. Defaults to `*`.
+
+* `management_cluster_id` - (Optional, string) The ID of the management project for the cluster. 
 
 ## Import
 


### PR DESCRIPTION
Adds `management_project_id` as an option to Group and Project Clusters. 
Requires GitLab 12.10 
Option Documentation: https://docs.gitlab.com/ee/api/group_clusters.html#add-existing-cluster-to-group