### PR TITLE
Update resource gitlab_group_label to read labels from all pages

### DIFF
--- a/gitlab/resource_gitlab_group_label.go
+++ b/gitlab/resource_gitlab_group_label.go
@@ -80,9 +80,9 @@ func resourceGitlabGroupLabelRead(d *schema.ResourceData, meta interface{}) erro
 				d.Set("name", label.Name)
 				return nil
 			}
-			labelsLen = len(labels)
-			page = page + 1
 		}
+		labelsLen = len(labels)
+		page = page + 1
 	}
 
 	log.Printf("[DEBUG] failed to read gitlab label %s/%s", group, labelName)

--- a/gitlab/resource_gitlab_group_label.go
+++ b/gitlab/resource_gitlab_group_label.go
@@ -1,8 +1,6 @@
 package gitlab
 
 import (
-	"errors"
-	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -68,24 +66,27 @@ func resourceGitlabGroupLabelRead(d *schema.ResourceData, meta interface{}) erro
 	labelName := d.Id()
 	log.Printf("[DEBUG] read gitlab group label %s/%s", group, labelName)
 
-	labels, _, err := client.GroupLabels.ListGroupLabels(group, nil)
-	if err != nil {
-		return err
-	}
-	found := false
-	for _, label := range labels {
-		if label.Name == labelName {
-			d.Set("description", label.Description)
-			d.Set("color", label.Color)
-			d.Set("name", label.Name)
-			found = true
-			break
+	page := 1
+	labelsLen := 0
+	for page == 1 || labelsLen != 0 {
+		labels, _, err := client.GroupLabels.ListGroupLabels(group, &gitlab.ListGroupLabelsOptions{Page: page})
+		if err != nil {
+			return err
+		}
+		for _, label := range labels {
+			if label.Name == labelName {
+				d.Set("description", label.Description)
+				d.Set("color", label.Color)
+				d.Set("name", label.Name)
+				return nil
+			}
+			labelsLen = len(labels)
+			page = page + 1
 		}
 	}
-	if !found {
-		return errors.New(fmt.Sprintf("label %s does not exist or the user does not have permissions to see it", labelName))
-	}
 
+	log.Printf("[DEBUG] failed to read gitlab label %s/%s", group, labelName)
+	d.SetId("")
 	return nil
 }
 

--- a/gitlab/resource_gitlab_group_label_test.go
+++ b/gitlab/resource_gitlab_group_label_test.go
@@ -206,7 +206,7 @@ resource "gitlab_group" "foo" {
 }
 
 resource "gitlab_group_label" "fixme" {
-  project = "${gitlab_group.foo.id}"
+  group = "${gitlab_group.foo.id}"
   name = format("FIXME%%02d", count.index+1)
   count = 100
   color = "#ffcc00"
@@ -225,7 +225,7 @@ resource "gitlab_group" "foo" {
 }
 
 resource "gitlab_group_label" "fixme" {
-  project = "${gitlab_group.foo.id}"
+  group = "${gitlab_group.foo.id}"
   name = format("FIXME%%02d", count.index+1)
   count = 99
   color = "#ff0000"

--- a/gitlab/resource_gitlab_group_label_test.go
+++ b/gitlab/resource_gitlab_group_label_test.go
@@ -229,7 +229,7 @@ resource "gitlab_group_label" "fixme" {
   name = format("FIXME%%02d", count.index+1)
   count = 99
   color = "#ff0000"
-  description = "fix this test"
+  description = "red label"
 }
 	`, rInt, rInt)
 }


### PR DESCRIPTION
Fix #232 