### PR TITLE
Increase MaxIdleConnsPerHost in http.Transport

### DIFF
--- a/gitlab/config.go
+++ b/gitlab/config.go
@@ -40,10 +40,9 @@ func (c *Config) Client() (interface{}, error) {
 		tlsConfig.InsecureSkipVerify = true
 	}
 
-	t := &http.Transport{
-		Proxy:           http.ProxyFromEnvironment,
-		TLSClientConfig: tlsConfig,
-	}
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.TLSClientConfig = tlsConfig
+	t.MaxIdleConnsPerHost = 100
 
 	opts := []gitlab.ClientOptionFunc{
 		gitlab.WithHTTPClient(


### PR DESCRIPTION
The default behaviour of `http.Transport` does not handle the use case of "many concurrent requests against a single host" very well.

By default, it will only keep 2 persistent connections in the pool. Everything above that is burst capacity, and those connections are closed. The result is a lot of connection churn, which can lead to port exhaustion (especially on more constrained resources like a shared NAT).

We (@gitlab) recently discovered this behaviour in a slightly different context, some analysis can be found in: [gitlab-org/gitlab-pages/-/merge_requests/274](https://gitlab.com/gitlab-org/gitlab-pages/-/merge_requests/274#note_335755221).

And we had a customer report who was experiencing that same issue with the gitlab terraform provider. So this patch is intended to provide the same fix:

Increase the idle pool from 2 to 100, allowing for more connection reuse and in turn reducing connection churn.

As a bonus, this also enables http/2 -- since that is enabled by default on `http.DefaultTransport`.