### PR TITLE
Disable Enterprise acceptance tests for pull requests

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -32,6 +32,7 @@ jobs:
   acceptance-ee:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    if: ${{ github.event == 'push' }}
     steps:
     - name: Set up Go
       uses: actions/setup-go@v1


### PR DESCRIPTION
Using this pull request to check if the enterprise acceptance tests are disabled. The enterprise acceptance tests can't be run for pull requests because they depend on a Github Actions secret to decrypt the Gitlab Enterprise license file. This can only be done for protected branches in the repo itself.