### PR TITLE
Provide a way to specify client cert and key

### DIFF
--- a/gitlab/config.go
+++ b/gitlab/config.go
@@ -16,6 +16,8 @@ type Config struct {
 	BaseURL    string
 	Insecure   bool
 	CACertFile string
+	ClientCert string
+	ClientKey  string
 }
 
 // Client returns a *gitlab.Client to interact with the configured gitlab instance
@@ -38,6 +40,15 @@ func (c *Config) Client() (interface{}, error) {
 	// If configured as insecure, turn off SSL verification
 	if c.Insecure {
 		tlsConfig.InsecureSkipVerify = true
+	}
+
+	// add client cert and key to connection
+	if c.ClientCert != "" && c.ClientKey != "" {
+		clientPair, err := tls.LoadX509KeyPair(c.ClientCert, c.ClientKey)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.Certificates = []tls.Certificate{clientPair}
 	}
 
 	t := http.DefaultTransport.(*http.Transport).Clone()

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -39,6 +39,18 @@ func Provider() terraform.ResourceProvider {
 				Default:     false,
 				Description: descriptions["insecure"],
 			},
+			"client_cert": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: descriptions["client_cert"],
+			},
+			"client_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: descriptions["client_key"],
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -89,6 +101,10 @@ func init() {
 		"cacert_file": "A file containing the ca certificate to use in case ssl certificate is not from a standard chain",
 
 		"insecure": "Disable SSL verification of API calls",
+
+		"client_cert": "File path to client certificate when GitLab instance is behind company proxy. File  must contain PEM encoded data.",
+
+		"client_key": "File path to client key when GitLab instance is behind company proxy. File must contain PEM encoded data.",
 	}
 }
 
@@ -98,6 +114,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		BaseURL:    d.Get("base_url").(string),
 		CACertFile: d.Get("cacert_file").(string),
 		Insecure:   d.Get("insecure").(bool),
+		ClientCert: d.Get("client_cert").(string),
+		ClientKey:  d.Get("client_key").(string),
 	}
 
 	return config.Client()

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -78,3 +78,7 @@ The following arguments are supported in the `provider` block:
 
 * `insecure` - (Optional; boolean, defaults to false) When set to true this disables SSL verification of the connection to the
   GitLab instance.
+
+* `client_cert` - (Optional) File path to client certificate when GitLab instance is behind company proxy. File  must contain PEM encoded data.
+
+* `client_key` - (Optional) File path to client key when GitLab instance is behind company proxy. File must contain PEM encoded data. Required when `client_cert` is set.


### PR DESCRIPTION
This will allows the option to specify a client certificate and key
when your GitLab instance runs behind a proxy that requires both.