### PR TITLE
Fix duplicate `isRunningEE` function

### DIFF
--- a/gitlab/provider_test.go
+++ b/gitlab/provider_test.go
@@ -1,14 +1,11 @@
 package gitlab
 
 import (
-	"errors"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/xanzy/go-gitlab"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
@@ -19,26 +16,6 @@ func init() {
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"gitlab": testAccProvider,
 	}
-}
-
-func isRunningInEE() (bool, error) {
-	if conn, ok := testAccProvider.Meta().(*gitlab.Client); ok {
-		version, _, err := conn.Version.GetVersion()
-		if err != nil {
-			return false, err
-		}
-		if strings.Contains(version.String(), "-ee") {
-			return true, nil
-		}
-	} else {
-		return false, errors.New("Provider not initialized, unable to get GitLab connection")
-	}
-	return false, nil
-}
-
-func isRunningInCE() (bool, error) {
-	isEE, err := isRunningInEE()
-	return !isEE, err
 }
 
 func TestProvider(t *testing.T) {


### PR DESCRIPTION
I missed that isRunningEE was already moved

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>