### PR TITLE
Import group labels

### DIFF
--- a/gitlab/resource_gitlab_group_label.go
+++ b/gitlab/resource_gitlab_group_label.go
@@ -1,7 +1,9 @@
 package gitlab
 
 import (
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -13,6 +15,9 @@ func resourceGitlabGroupLabel() *schema.Resource {
 		Read:   resourceGitlabGroupLabelRead,
 		Update: resourceGitlabGroupLabelUpdate,
 		Delete: resourceGitlabGroupLabelDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceGitlabGroupLabelImporter,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"group": {
@@ -122,4 +127,26 @@ func resourceGitlabGroupLabelDelete(d *schema.ResourceData, meta interface{}) er
 
 	_, err := client.GroupLabels.DeleteGroupLabel(group, options)
 	return err
+}
+
+func resourceGitlabGroupLabelImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*gitlab.Client)
+	parts := strings.SplitN(d.Id(), ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid label id (should be <group ID>.<label name>): %s", d.Id())
+	}
+
+	d.SetId(parts[1])
+	group, _, err := client.Groups.GetGroup(parts[0])
+	if err != nil {
+		return nil, err
+	}
+
+	if err := d.Set("group", group.ID); err != nil {
+		return nil, err
+	}
+
+	err = resourceGitlabGroupLabelRead(d, meta)
+
+	return []*schema.ResourceData{d}, err
 }

--- a/gitlab/resource_gitlab_group_label.go
+++ b/gitlab/resource_gitlab_group_label.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -142,7 +143,7 @@ func resourceGitlabGroupLabelImporter(d *schema.ResourceData, meta interface{}) 
 		return nil, err
 	}
 
-	if err := d.Set("group", group.ID); err != nil {
+	if err := d.Set("group", strconv.Itoa(group.ID)); err != nil {
 		return nil, err
 	}
 

--- a/gitlab/resource_gitlab_group_label_test.go
+++ b/gitlab/resource_gitlab_group_label_test.go
@@ -86,7 +86,7 @@ func TestAccGitlabGroupLabel_basic(t *testing.T) {
 
 func TestAccGitlabGroupLabel_import(t *testing.T) {
 	rInt := acctest.RandInt()
-	resourceName := "gitlab_group_label.foo"
+	resourceName := "gitlab_group_label.fixme"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/gitlab/resource_gitlab_group_label_test.go
+++ b/gitlab/resource_gitlab_group_label_test.go
@@ -84,6 +84,48 @@ func TestAccGitlabGroupLabel_basic(t *testing.T) {
 	})
 }
 
+func TestAccGitlabGroupLabel_import(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "gitlab_group_label.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabGroupLabelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabGroupLabelConfig(rInt),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: getGroupLabelImportID(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func getGroupLabelImportID(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not Found: %s", n)
+		}
+
+		labelID := rs.Primary.ID
+		if labelID == "" {
+			return "", fmt.Errorf("No deploy key ID is set")
+		}
+		groupID := rs.Primary.Attributes["group"]
+		if groupID == "" {
+			return "", fmt.Errorf("No group ID is set")
+		}
+
+		return fmt.Sprintf("%s:%s", groupID, labelID), nil
+	}
+}
+
 func testAccCheckGitlabGroupLabelExists(n string, label *gitlab.GroupLabel) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/website/docs/r/group_label.html.markdown
+++ b/website/docs/r/group_label.html.markdown
@@ -41,3 +41,11 @@ The following arguments are supported:
 The resource exports the following attributes:
 
 * `id` - The unique id assigned to the label by the GitLab server (the name of the label).
+
+## Import
+
+Gitlab group labels can be imported using an id made up of `{group_id}:{group_label_id}`, e.g.
+
+```
+$ terraform import gitlab_deploy_key_enable.example 12345:fixme
+```


### PR DESCRIPTION
This simply adds support for importing group labels, e.g.:

```sh
$ terraform import gitlab_deploy_key_enable.example 12345:fixme
```