### PR TITLE
Fix incorrect description of valid access levels

### DIFF
--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 * `shared_with_groups` - (Optional) Enable sharing the project with a list of groups (maps).
   * `group_id` - (Required) Group id of the group you want to share the project with.
   * `group_access_level` - (Required) Group's sharing permissions. See [group members permission][group_members_permissions] for more info.
-  Valid values are `guest`, `reporter`, `developer`, `master`.
+  Valid values are `guest`, `reporter`, `developer`, `maintainer`.
 
 * `archived` - (Optional) Whether the project is in read-only mode (archived). Repositories can be archived/unarchived by toggling this parameter.
 


### PR DESCRIPTION
This minor change corrects a mistake showing `master` as a valid level
of `group_access_level`.