### PR TITLE
add support for importing project push rules

### DIFF
--- a/gitlab/resource_gitlab_project_push_rules.go
+++ b/gitlab/resource_gitlab_project_push_rules.go
@@ -14,6 +14,9 @@ func resourceGitlabProjectPushRules() *schema.Resource {
 		Read:   resourceGitlabProjectPushRulesRead,
 		Update: resourceGitlabProjectPushRulesUpdate,
 		Delete: resourceGitlabProjectPushRulesDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceGitlabProjectPushRulesImport,
+		},
 		Schema: map[string]*schema.Schema{
 			"project": {
 				Type:     schema.TypeString,
@@ -130,4 +133,10 @@ func resourceGitlabProjectPushRulesDelete(d *schema.ResourceData, meta interface
 	log.Println(project)
 	_, err := client.Projects.DeleteProjectPushRule(project)
 	return err
+}
+
+func resourceGitlabProjectPushRulesImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("project", d.Id())
+	err := resourceGitlabProjectPushRulesRead(d, meta)
+	return []*schema.ResourceData{d}, err
 }

--- a/website/docs/r/project_push_rules.html.markdown
+++ b/website/docs/r/project_push_rules.html.markdown
@@ -53,3 +53,11 @@ The following arguments are supported:
 The resource exports the following attributes:
 
 * `id` - The unique id assigned to the push rules by the GitLab server.
+
+## Import
+
+GitLab push rules can be imported using the project id or name, as when importing a project, e.g.
+
+```
+$ terraform import gitlab_project_push_rules.test richardc/example
+```


### PR DESCRIPTION
Adds support for importing project push rules. Since there is a 1-to-1 relationship with the project, all that is needed is the project name or id.