### PR TITLE
Add required quotes around the resource name

### DIFF
--- a/website/docs/r/group_cluster.html.markdown
+++ b/website/docs/r/group_cluster.html.markdown
@@ -21,7 +21,7 @@ resource "gitlab_group" "foo" {
   path = "foo-path"
 }
 
-resource gitlab_group_cluster "bar" {
+resource "gitlab_group_cluster" "bar" {
   group                       = "${gitlab_group.foo.id}"
   name                          = "bar-cluster"
   domain                        = "example.com"


### PR DESCRIPTION
This example was missing the quotes around the name of the resource. I added them.