### PR TITLE
Add importer to resource_gitlab_project_push_rules

### DIFF
--- a/gitlab/resource_gitlab_project_push_rules.go
+++ b/gitlab/resource_gitlab_project_push_rules.go
@@ -110,7 +110,7 @@ func resourceGitlabProjectPushRulesCreate(d *schema.ResourceData, meta interface
 func resourceGitlabProjectPushRulesRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
-	log.Printf("[DEBUG] read gitlab project %s", project)
+	log.Printf("[DEBUG] read gitlab project %s push rules", project)
 	pushRules, _, err := client.Projects.GetProjectPushRules(project)
 	if err != nil {
 		return err
@@ -129,7 +129,7 @@ func resourceGitlabProjectPushRulesRead(d *schema.ResourceData, meta interface{}
 func resourceGitlabProjectPushRulesDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
-	log.Printf("[DEBUG] Delete gitlab project push rules %s", project)
+	log.Printf("[DEBUG] Delete gitlab project %s push rules", project)
 	log.Println(project)
 	_, err := client.Projects.DeleteProjectPushRule(project)
 	return err
@@ -142,7 +142,7 @@ func resourceGitlabProjectPushRulesImporter(d *schema.ResourceData, meta interfa
 	client := meta.(*gitlab.Client)
 	project := d.Id()
 
-	log.Printf("[DEBUG] read gitlab project %s", project)
+	log.Printf("[DEBUG] read gitlab project %s push rules", project)
 
 	pushRules, _, err := client.Projects.GetProjectPushRules(project)
 	if err != nil {

--- a/gitlab/resource_gitlab_project_push_rules.go
+++ b/gitlab/resource_gitlab_project_push_rules.go
@@ -14,6 +14,9 @@ func resourceGitlabProjectPushRules() *schema.Resource {
 		Read:   resourceGitlabProjectPushRulesRead,
 		Update: resourceGitlabProjectPushRulesUpdate,
 		Delete: resourceGitlabProjectPushRulesDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceGitlabProjectPushRulesImporter,
+		},
 		Schema: map[string]*schema.Schema{
 			"project": {
 				Type:     schema.TypeString,
@@ -130,4 +133,26 @@ func resourceGitlabProjectPushRulesDelete(d *schema.ResourceData, meta interface
 	log.Println(project)
 	_, err := client.Projects.DeleteProjectPushRule(project)
 	return err
+}
+
+func resourceGitlabProjectPushRulesImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// Push rule IDs in GitLab are internal identifiers. For ease of use, we allow importing using the project ID instead.
+	// This means we need to lookup the push rule ID during import.
+
+	client := meta.(*gitlab.Client)
+	project := d.Id()
+
+	log.Printf("[DEBUG] read gitlab project %s", project)
+
+	pushRules, _, err := client.Projects.GetProjectPushRules(project)
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(fmt.Sprintf("%d", pushRules.ID))
+
+	// Since project is used as a primary key in the Read function, we set that too.
+	d.Set("project", project)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/gitlab/resource_gitlab_project_push_rules_test.go
+++ b/gitlab/resource_gitlab_project_push_rules_test.go
@@ -78,6 +78,29 @@ func TestAccGitlabProjectPushRules_basic(t *testing.T) {
 	})
 }
 
+func TestAccGitlabProjectPushRules_import(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabProjectPushRulesDestroy,
+		Steps: []resource.TestStep{
+			{
+				SkipFunc: isRunningInCE,
+				Config:   testAccGitlabProjectPushRulesConfig(rInt),
+			},
+			{
+				SkipFunc:          isRunningInCE,
+				ResourceName:      "gitlab_project_push_rules.foo",
+				ImportStateId:     fmt.Sprintf("foo-%d", rInt),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckGitlabProjectPushRulesExists(n string, pushRules *gitlab.ProjectPushRules) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/website/docs/r/project_push_rules.html.markdown
+++ b/website/docs/r/project_push_rules.html.markdown
@@ -53,3 +53,11 @@ The following arguments are supported:
 The resource exports the following attributes:
 
 * `id` - The unique id assigned to the push rules by the GitLab server.
+
+## Import
+
+Project push rules can be imported using the ID of the project or NAMESPACE/PROJECT_NAME, e.g.
+
+```
+$ terraform import gitlab_project_push_rules.example richardc/example
+```


### PR DESCRIPTION
This PR adds an importer to the `gitlab_project_push_rules` resource.

This closes #201, closes #239, and closes #352.

Note that I am not using the push rule resource ID as the import ID. I am instead using the project ID. The reason for this is that in practice, the project ID is the primary key. It's the only value used in the resource's Read function. I didn't want to change the resource ID because that would be a breaking change.

I've tested this import functionality using a local build and can verify that it works.