### PR TITLE
Fix unhandled Jira Service error

### DIFF
--- a/gitlab/resource_gitlab_service_jira.go
+++ b/gitlab/resource_gitlab_service_jira.go
@@ -94,9 +94,8 @@ func resourceGitlabServiceJiraCreate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Create Gitlab Jira service")
 
-	_, setServiceErr := client.Services.SetJiraService(project, jiraOptions)
-	if err != nil {
-		return fmt.Errorf("[ERROR] Couldn't create Gitlab Jira service: %s", setServiceErr)
+	if _, err := client.Services.SetJiraService(project, jiraOptions); err != nil {
+		return fmt.Errorf("couldn't create Gitlab Jira service: %w", err)
 	}
 
 	d.SetId(project)


### PR DESCRIPTION
I noticed this bug while trying to investigate a [possible flaky acceptance test](https://github.com/terraform-providers/terraform-provider-gitlab/pull/356/checks?check_run_id=834966420).

The bug is that if there is an error while creating or updating the Jira Service settings, the error is ignored.