### PR TITLE
Fix nil pointer dereferences during error handling

### DIFF
--- a/gitlab/resource_gitlab_deploy_key.go
+++ b/gitlab/resource_gitlab_deploy_key.go
@@ -98,12 +98,8 @@ func resourceGitlabDeployKeyDelete(d *schema.ResourceData, meta interface{}) err
 	}
 	log.Printf("[DEBUG] Delete gitlab deploy key %s", d.Id())
 
-	response, err := client.DeployKeys.DeleteDeployKey(project, deployKeyID)
+	_, err = client.DeployKeys.DeleteDeployKey(project, deployKeyID)
 
-	// HTTP 204 is success with no body
-	if response.StatusCode == 204 {
-		return nil
-	}
 	return err
 }
 

--- a/gitlab/resource_gitlab_pipeline_schedule.go
+++ b/gitlab/resource_gitlab_pipeline_schedule.go
@@ -164,9 +164,9 @@ func resourceGitlabPipelineScheduleDelete(d *schema.ResourceData, meta interface
 		return fmt.Errorf("%s cannot be converted to int", d.Id())
 	}
 
-	resp, err := client.PipelineSchedules.DeletePipelineSchedule(project, pipelineScheduleID)
-	if err != nil {
-		return fmt.Errorf("%s failed to delete pipeline schedule: %s", d.Id(), resp.Status)
+	if _, err = client.PipelineSchedules.DeletePipelineSchedule(project, pipelineScheduleID); err != nil {
+		return fmt.Errorf("failed to delete pipeline schedule %q: %w", d.Id(), err)
 	}
-	return err
+
+	return nil
 }

--- a/gitlab/resource_gitlab_pipeline_schedule_variable.go
+++ b/gitlab/resource_gitlab_pipeline_schedule_variable.go
@@ -122,9 +122,9 @@ func resourceGitlabPipelineScheduleVariableDelete(d *schema.ResourceData, meta i
 	variableKey := d.Get("key").(string)
 	scheduleID := d.Get("pipeline_schedule_id").(int)
 
-	_, resp, err := client.PipelineSchedules.DeletePipelineScheduleVariable(project, scheduleID, variableKey)
-	if err != nil {
-		return fmt.Errorf("%s failed to delete pipeline schedule variable: %s", d.Id(), resp.Status)
+	if _, _, err := client.PipelineSchedules.DeletePipelineScheduleVariable(project, scheduleID, variableKey); err != nil {
+		return fmt.Errorf("failed to delete pipeline schedule variable %q: %w", d.Id(), err)
 	}
-	return err
+
+	return nil
 }


### PR DESCRIPTION
I found a few places where there was the possibility of a panic if `response` was `nil`, which can happen if GitLab cannot be reached.

Also while I was there I removed some redundant status code checking, since the GitLab client library already treats the 204 code as a success.