### PR TITLE
correct management_project_id argument in documentation

### DIFF
--- a/website/docs/r/group_cluster.html.markdown
+++ b/website/docs/r/group_cluster.html.markdown
@@ -31,7 +31,7 @@ resource gitlab_group_cluster "bar" {
   kubernetes_ca_cert            = "some-cert"
   kubernetes_authorization_type = "rbac"
   environment_scope             = "*"
-  management_cluster_id         = "123456"
+  management_project_id         = "123456"
 }
 ```
 
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `environment_scope` - (Optional, string) The associated environment to the cluster. Defaults to `*`.
 
-* `management_cluster_id` - (Optional, string) The ID of the management project for the cluster. 
+* `management_project_id` - (Optional, string) The ID of the management project for the cluster. 
 
 ## Import
 

--- a/website/docs/r/project_cluster.html.markdown
+++ b/website/docs/r/project_cluster.html.markdown
@@ -31,7 +31,7 @@ resource gitlab_project_cluster "bar" {
   kubernetes_namespace          = "namespace"
   kubernetes_authorization_type = "rbac"
   environment_scope             = "*"
-  management_cluster_id         = "123456"
+  management_project_id         = "123456"
 }
 ```
 
@@ -61,7 +61,7 @@ The following arguments are supported:
 
 * `environment_scope` - (Optional, string) The associated environment to the cluster. Defaults to `*`.
 
-* `management_cluster_id` - (Optional, string) The ID of the management project for the cluster. 
+* `management_project_id` - (Optional, string) The ID of the management project for the cluster. 
 
 ## Import
 


### PR DESCRIPTION
The correct argument to add a cluster management project is in fact `management_project_id` as per [the project_cluster](https://github.com/terraform-providers/terraform-provider-gitlab/blob/master/gitlab/resource_gitlab_project_cluster.go#L94) and [group_cluster](https://github.com/terraform-providers/terraform-provider-gitlab/blob/master/gitlab/resource_gitlab_group_cluster.go#L90) resource.