### PR TITLE
Bump go-gitlab to v.0.34.1

### DIFF
--- a/gitlab/resource_gitlab_label.go
+++ b/gitlab/resource_gitlab_label.go
@@ -69,7 +69,7 @@ func resourceGitlabLabelRead(d *schema.ResourceData, meta interface{}) error {
 	page := 1
 	labelsLen := 0
 	for page == 1 || labelsLen != 0 {
-		labels, _, err := client.Labels.ListLabels(project, &gitlab.ListLabelsOptions{Page: page})
+		labels, _, err := client.Labels.ListLabels(project, &gitlab.ListLabelsOptions{ListOptions: gitlab.ListOptions{Page: page}})
 		if err != nil {
 			return err
 		}

--- a/gitlab/resource_gitlab_label_test.go
+++ b/gitlab/resource_gitlab_label_test.go
@@ -103,7 +103,7 @@ func testAccCheckGitlabLabelExists(n string, label *gitlab.Label) resource.TestC
 		}
 		conn := testAccProvider.Meta().(*gitlab.Client)
 
-		labels, _, err := conn.Labels.ListLabels(repoName, &gitlab.ListLabelsOptions{PerPage: 1000})
+		labels, _, err := conn.Labels.ListLabels(repoName, &gitlab.ListLabelsOptions{ListOptions: gitlab.ListOptions{PerPage: 1000}})
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-gitlab
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.13.1
 	github.com/mitchellh/hashstructure v1.0.0
-	github.com/xanzy/go-gitlab v0.32.1
+	github.com/xanzy/go-gitlab v0.34.1
 )
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-gitlab
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.13.1
 	github.com/mitchellh/hashstructure v1.0.0
-	github.com/xanzy/go-gitlab v0.34.1
+	github.com/xanzy/go-gitlab v0.32.1
 )
 
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4A
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/xanzy/go-gitlab v0.32.1 h1:eKGfAP2FWbqStD7DtGoRBb18IYwjuCxdtEVea2rNge4=
-github.com/xanzy/go-gitlab v0.32.1/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
+github.com/xanzy/go-gitlab v0.34.1 h1:Dtqla2gWIQIevfZVS6FY4qjgrKf+5LYLzW6XBNstGSw=
+github.com/xanzy/go-gitlab v0.34.1/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.1 h1:vGMsygfmeCl4Xb6OA5U5XVAaQZ69FvoG7X2jUtQujb8=

--- a/vendor/github.com/xanzy/go-gitlab/README.md
+++ b/vendor/github.com/xanzy/go-gitlab/README.md
@@ -44,6 +44,7 @@ to add new and/or missing endpoints. Currently the following services are suppor
 - [x] Group Milestones
 - [x] Group-Level Variables
 - [x] Groups
+- [x] Instance Clusters
 - [x] Issue Boards
 - [x] Issues
 - [x] Jobs
@@ -161,7 +162,7 @@ func main() {
 	s := &gitlab.CreateProjectSnippetOptions{
 		Title:           gitlab.String("Dummy Snippet"),
 		FileName:        gitlab.String("snippet.go"),
-		Code:            gitlab.String("package main...."),
+		Content:         gitlab.String("package main...."),
 		Visibility:      gitlab.Visibility(gitlab.PublicVisibility),
 	}
 	_, _, err = git.ProjectSnippets.CreateSnippet(project.ID, s)

--- a/vendor/github.com/xanzy/go-gitlab/event_webhook_types.go
+++ b/vendor/github.com/xanzy/go-gitlab/event_webhook_types.go
@@ -85,6 +85,7 @@ type TagEvent struct {
 	UserID      int    `json:"user_id"`
 	UserName    string `json:"user_name"`
 	UserAvatar  string `json:"user_avatar"`
+	UserEmail   string `json:"user_email"`
 	ProjectID   int    `json:"project_id"`
 	Message     string `json:"message"`
 	Project     struct {
@@ -593,6 +594,10 @@ type MergeEvent struct {
 			Previous int `json:"previous"`
 			Current  int `json:"current"`
 		} `json:"source_project_id"`
+		StateID struct {
+			Previous int `json:"previous"`
+			Current  int `json:"current"`
+		} `json:"state_id"`
 		TargetBranch struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`

--- a/vendor/github.com/xanzy/go-gitlab/gitlab.go
+++ b/vendor/github.com/xanzy/go-gitlab/gitlab.go
@@ -126,8 +126,10 @@ type Client struct {
 	GroupMilestones       *GroupMilestonesService
 	GroupVariables        *GroupVariablesService
 	Groups                *GroupsService
+	InstanceCluster       *InstanceClustersService
 	IssueLinks            *IssueLinksService
 	Issues                *IssuesService
+	IssuesStatistics      *IssuesStatisticsService
 	Jobs                  *JobsService
 	Keys                  *KeysService
 	Labels                *LabelsService
@@ -147,6 +149,7 @@ type Client struct {
 	ProjectCluster        *ProjectClustersService
 	ProjectImportExport   *ProjectImportExportService
 	ProjectMembers        *ProjectMembersService
+	ProjectMirrors        *ProjectMirrorService
 	ProjectSnippets       *ProjectSnippetsService
 	ProjectVariables      *ProjectVariablesService
 	Projects              *ProjectsService
@@ -280,8 +283,10 @@ func newClient(options ...ClientOptionFunc) (*Client, error) {
 	c.GroupMilestones = &GroupMilestonesService{client: c}
 	c.GroupVariables = &GroupVariablesService{client: c}
 	c.Groups = &GroupsService{client: c}
+	c.InstanceCluster = &InstanceClustersService{client: c}
 	c.IssueLinks = &IssueLinksService{client: c}
 	c.Issues = &IssuesService{client: c, timeStats: timeStats}
+	c.IssuesStatistics = &IssuesStatisticsService{client: c}
 	c.Jobs = &JobsService{client: c}
 	c.Keys = &KeysService{client: c}
 	c.Labels = &LabelsService{client: c}
@@ -301,6 +306,7 @@ func newClient(options ...ClientOptionFunc) (*Client, error) {
 	c.ProjectCluster = &ProjectClustersService{client: c}
 	c.ProjectImportExport = &ProjectImportExportService{client: c}
 	c.ProjectMembers = &ProjectMembersService{client: c}
+	c.ProjectMirrors = &ProjectMirrorService{client: c}
 	c.ProjectSnippets = &ProjectSnippetsService{client: c}
 	c.ProjectVariables = &ProjectVariablesService{client: c}
 	c.Projects = &ProjectsService{client: c}

--- a/vendor/github.com/xanzy/go-gitlab/group_clusters.go
+++ b/vendor/github.com/xanzy/go-gitlab/group_clusters.go
@@ -93,13 +93,13 @@ func (s *GroupClustersService) GetCluster(pid interface{}, cluster int, options 
 		return nil, nil, err
 	}
 
-	pc := new(GroupCluster)
-	resp, err := s.client.Do(req, &pc)
+	gc := new(GroupCluster)
+	resp, err := s.client.Do(req, &gc)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return pc, resp, err
+	return gc, resp, err
 }
 
 // AddGroupClusterOptions represents the available AddCluster() options.
@@ -141,13 +141,13 @@ func (s *GroupClustersService) AddCluster(pid interface{}, opt *AddGroupClusterO
 		return nil, nil, err
 	}
 
-	pc := new(GroupCluster)
-	resp, err := s.client.Do(req, pc)
+	gc := new(GroupCluster)
+	resp, err := s.client.Do(req, gc)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return pc, resp, err
+	return gc, resp, err
 }
 
 // EditGroupClusterOptions represents the available EditCluster() options.
@@ -185,13 +185,13 @@ func (s *GroupClustersService) EditCluster(pid interface{}, cluster int, opt *Ed
 		return nil, nil, err
 	}
 
-	pc := new(GroupCluster)
-	resp, err := s.client.Do(req, pc)
+	gc := new(GroupCluster)
+	resp, err := s.client.Do(req, gc)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return pc, resp, err
+	return gc, resp, err
 }
 
 // DeleteCluster deletes an existing group cluster.

--- a/vendor/github.com/xanzy/go-gitlab/group_labels.go
+++ b/vendor/github.com/xanzy/go-gitlab/group_labels.go
@@ -51,6 +51,35 @@ func (s *GroupLabelsService) ListGroupLabels(gid interface{}, opt *ListGroupLabe
 	return l, resp, err
 }
 
+// GetGroupLabel get a single label for a given group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_labels.html#get-a-single-group-label
+func (s *GroupLabelsService) GetGroupLabel(gid interface{}, labelID interface{}, options ...RequestOptionFunc) (*GroupLabel, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	label, err := parseID(labelID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/labels/%s", pathEscape(group), label)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var l *GroupLabel
+	resp, err := s.client.Do(req, &l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, err
+}
+
 // CreateGroupLabelOptions represents the available CreateGroupLabel() options.
 //
 // GitLab API docs:

--- a/vendor/github.com/xanzy/go-gitlab/group_members.go
+++ b/vendor/github.com/xanzy/go-gitlab/group_members.go
@@ -176,6 +176,50 @@ func (s *GroupMembersService) AddGroupMember(gid interface{}, opt *AddGroupMembe
 	return gm, resp, err
 }
 
+// ShareWithGroup shares a group with the group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/groups.html#share-groups-with-groups
+func (s *GroupMembersService) ShareWithGroup(gid interface{}, opt *ShareWithGroupOptions, options ...RequestOptionFunc) (*Group, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/share", pathEscape(group))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	g := new(Group)
+	resp, err := s.client.Do(req, g)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return g, resp, err
+}
+
+// DeleteShareWithGroup allows to unshare a group from a group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/groups.html#delete-link-sharing-group-with-another-group
+func (s *GroupMembersService) DeleteShareWithGroup(gid interface{}, groupID int, options ...RequestOptionFunc) (*Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/share/%d", pathEscape(group), groupID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // EditGroupMemberOptions represents the available EditGroupMember()
 // options.
 //

--- a/vendor/github.com/xanzy/go-gitlab/group_milestones.go
+++ b/vendor/github.com/xanzy/go-gitlab/group_milestones.go
@@ -247,3 +247,42 @@ func (s *GroupMilestonesService) GetGroupMilestoneMergeRequests(gid interface{},
 
 	return mr, resp, err
 }
+
+type BurndownChartEvent struct {
+	CreatedAt *time.Time `json:"created_at"`
+	Weight    *int       `json:"weight"`
+	Action    *string    `json:"action"`
+}
+
+// GetGroupMilestoneBurndownChartEventsOptions represents the available
+// GetGroupMilestoneBurndownChartEventsOptions() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_milestones.html#get-all-burndown-chart-events-for-a-single-milestone-starter
+type GetGroupMilestoneBurndownChartEventsOptions ListOptions
+
+// GetGroupMilestoneBurndownChartEvents gets all merge requests assigned to a
+// single group milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_milestones.html#get-all-burndown-chart-events-for-a-single-milestone-starter
+func (s *GroupMilestonesService) GetGroupMilestoneBurndownChartEvents(gid interface{}, milestone int, opt *GetGroupMilestoneBurndownChartEventsOptions, options ...RequestOptionFunc) ([]*BurndownChartEvent, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones/%d/burndown_events", pathEscape(group), milestone)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var be []*BurndownChartEvent
+	resp, err := s.client.Do(req, &be)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return be, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/groups.go
+++ b/vendor/github.com/xanzy/go-gitlab/groups.go
@@ -33,39 +33,46 @@ type GroupsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html
 type Group struct {
-	ID                             int                        `json:"id"`
-	Name                           string                     `json:"name"`
-	Path                           string                     `json:"path"`
-	Description                    string                     `json:"description"`
-	MembershipLock                 bool                       `json:"membership_lock"`
-	Visibility                     VisibilityValue            `json:"visibility"`
-	LFSEnabled                     bool                       `json:"lfs_enabled"`
-	AvatarURL                      string                     `json:"avatar_url"`
-	WebURL                         string                     `json:"web_url"`
-	RequestAccessEnabled           bool                       `json:"request_access_enabled"`
-	FullName                       string                     `json:"full_name"`
-	FullPath                       string                     `json:"full_path"`
-	ParentID                       int                        `json:"parent_id"`
-	Projects                       []*Project                 `json:"projects"`
-	Statistics                     *StorageStatistics         `json:"statistics"`
-	CustomAttributes               []*CustomAttribute         `json:"custom_attributes"`
-	ShareWithGroupLock             bool                       `json:"share_with_group_lock"`
-	RequireTwoFactorAuth           bool                       `json:"require_two_factor_authentication"`
-	TwoFactorGracePeriod           int                        `json:"two_factor_grace_period"`
-	ProjectCreationLevel           ProjectCreationLevelValue  `json:"project_creation_level"`
-	AutoDevopsEnabled              bool                       `json:"auto_devops_enabled"`
-	SubGroupCreationLevel          SubGroupCreationLevelValue `json:"subgroup_creation_level"`
-	EmailsDisabled                 bool                       `json:"emails_disabled"`
-	MentionsDisabled               bool                       `json:"mentions_disabled"`
-	RunnersToken                   string                     `json:"runners_token"`
-	SharedProjects                 []*Project                 `json:"shared_projects"`
-	LDAPCN                         string                     `json:"ldap_cn"`
-	LDAPAccess                     AccessLevelValue           `json:"ldap_access"`
-	LDAPGroupLinks                 []*LDAPGroupLink           `json:"ldap_group_links"`
-	SharedRunnersMinutesLimit      int                        `json:"shared_runners_minutes_limit"`
-	ExtraSharedRunnersMinutesLimit int                        `json:"extra_shared_runners_minutes_limit"`
-	MarkedForDeletionOn            *ISOTime                   `json:"marked_for_deletion_on"`
-	CreatedAt                      *time.Time                 `json:"created_at"`
+	ID                    int                        `json:"id"`
+	Name                  string                     `json:"name"`
+	Path                  string                     `json:"path"`
+	Description           string                     `json:"description"`
+	MembershipLock        bool                       `json:"membership_lock"`
+	Visibility            VisibilityValue            `json:"visibility"`
+	LFSEnabled            bool                       `json:"lfs_enabled"`
+	AvatarURL             string                     `json:"avatar_url"`
+	WebURL                string                     `json:"web_url"`
+	RequestAccessEnabled  bool                       `json:"request_access_enabled"`
+	FullName              string                     `json:"full_name"`
+	FullPath              string                     `json:"full_path"`
+	ParentID              int                        `json:"parent_id"`
+	Projects              []*Project                 `json:"projects"`
+	Statistics            *StorageStatistics         `json:"statistics"`
+	CustomAttributes      []*CustomAttribute         `json:"custom_attributes"`
+	ShareWithGroupLock    bool                       `json:"share_with_group_lock"`
+	RequireTwoFactorAuth  bool                       `json:"require_two_factor_authentication"`
+	TwoFactorGracePeriod  int                        `json:"two_factor_grace_period"`
+	ProjectCreationLevel  ProjectCreationLevelValue  `json:"project_creation_level"`
+	AutoDevopsEnabled     bool                       `json:"auto_devops_enabled"`
+	SubGroupCreationLevel SubGroupCreationLevelValue `json:"subgroup_creation_level"`
+	EmailsDisabled        bool                       `json:"emails_disabled"`
+	MentionsDisabled      bool                       `json:"mentions_disabled"`
+	RunnersToken          string                     `json:"runners_token"`
+	SharedProjects        []*Project                 `json:"shared_projects"`
+	SharedWithGroups      []struct {
+		GroupID          int      `json:"group_id"`
+		GroupName        string   `json:"group_name"`
+		GroupFullPath    string   `json:"group_full_path"`
+		GroupAccessLevel int      `json:"group_access_level"`
+		ExpiresAt        *ISOTime `json:"expires_at"`
+	} `json:"shared_with_groups"`
+	LDAPCN                         string           `json:"ldap_cn"`
+	LDAPAccess                     AccessLevelValue `json:"ldap_access"`
+	LDAPGroupLinks                 []*LDAPGroupLink `json:"ldap_group_links"`
+	SharedRunnersMinutesLimit      int              `json:"shared_runners_minutes_limit"`
+	ExtraSharedRunnersMinutesLimit int              `json:"extra_shared_runners_minutes_limit"`
+	MarkedForDeletionOn            *ISOTime         `json:"marked_for_deletion_on"`
+	CreatedAt                      *time.Time       `json:"created_at"`
 }
 
 type LDAPGroupLink struct {
@@ -87,6 +94,7 @@ type ListGroupsOptions struct {
 	SkipGroups           []int             `url:"skip_groups,omitempty" json:"skip_groups,omitempty"`
 	Sort                 *string           `url:"sort,omitempty" json:"sort,omitempty"`
 	Statistics           *bool             `url:"statistics,omitempty" json:"statistics,omitempty"`
+	TopLevelOnly         *bool             `url:"top_level_only,omitempty" json:"top_level_only,omitempty"`
 	WithCustomAttributes *bool             `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
 }
 

--- a/vendor/github.com/xanzy/go-gitlab/instance_clusters.go
+++ b/vendor/github.com/xanzy/go-gitlab/instance_clusters.go
@@ -1,0 +1,151 @@
+//
+// Copyright 2020, Serena Fang
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"time"
+)
+
+// InstanceClustersService handles communication with the
+// instance clusters related methods of the GitLab API.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_clusters.html
+type InstanceClustersService struct {
+	client *Client
+}
+
+// InstanceCluster represents a GitLab Instance Cluster.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/instance_clusters.html
+type InstanceCluster struct {
+	ID                 int                 `json:"id"`
+	Name               string              `json:"name"`
+	Domain             string              `json:"domain"`
+	CreatedAt          *time.Time          `json:"created_at"`
+	ProviderType       string              `json:"provider_type"`
+	PlatformType       string              `json:"platform_type"`
+	EnvironmentScope   string              `json:"environment_scope"`
+	ClusterType        string              `json:"cluster_type"`
+	User               *User               `json:"user"`
+	PlatformKubernetes *PlatformKubernetes `json:"platform_kubernetes"`
+	ManagementProject  *ManagementProject  `json:"management_project"`
+}
+
+func (v InstanceCluster) String() string {
+	return Stringify(v)
+}
+
+// ListClusters gets a list of all instance clusters.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_clusters.html#list-instance-clusters
+func (s *InstanceClustersService) ListClusters(options ...RequestOptionFunc) ([]*InstanceCluster, *Response, error) {
+	u := fmt.Sprintf("admin/clusters")
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ics []*InstanceCluster
+	resp, err := s.client.Do(req, &ics)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ics, resp, err
+}
+
+// GetCluster gets an instance cluster.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_clusters.html#get-a-single-instance-cluster
+func (s *InstanceClustersService) GetCluster(cluster int, options ...RequestOptionFunc) (*InstanceCluster, *Response, error) {
+	u := fmt.Sprintf("admin/clusters/%d", cluster)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ic := new(InstanceCluster)
+	resp, err := s.client.Do(req, &ic)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ic, resp, err
+}
+
+// AddCluster adds an existing cluster to the instance.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_clusters.html#add-existing-instance-cluster
+func (s *InstanceClustersService) AddCluster(opt *AddClusterOptions, options ...RequestOptionFunc) (*InstanceCluster, *Response, error) {
+	u := fmt.Sprintf("admin/clusters/add")
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ic := new(InstanceCluster)
+	resp, err := s.client.Do(req, ic)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ic, resp, err
+}
+
+// EditCluster updates an existing instance cluster.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_clusters.html#edit-instance-cluster
+func (s *InstanceClustersService) EditCluster(cluster int, opt *EditClusterOptions, options ...RequestOptionFunc) (*InstanceCluster, *Response, error) {
+	u := fmt.Sprintf("admin/clusters/%d", cluster)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ic := new(InstanceCluster)
+	resp, err := s.client.Do(req, ic)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ic, resp, err
+}
+
+// DeleteCluster deletes an existing instance cluster.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_clusters.html#delete-instance-cluster
+func (s *InstanceClustersService) DeleteCluster(cluster int, options ...RequestOptionFunc) (*Response, error) {
+	u := fmt.Sprintf("admin/clusters/%d", cluster)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/xanzy/go-gitlab/issues_statistics.go
+++ b/vendor/github.com/xanzy/go-gitlab/issues_statistics.go
@@ -1,0 +1,186 @@
+//
+// Copyright 2017, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"time"
+)
+
+// IssuesStatisticsService handles communication with the issues statistics
+// related methods of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues_statistics.html
+type IssuesStatisticsService struct {
+	client *Client
+}
+
+// IssuesStatistics represents a GitLab issues statistic.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues_statistics.html
+type IssuesStatistics struct {
+	Statistics struct {
+		Counts struct {
+			All    int `json:"all"`
+			Closed int `json:"closed"`
+			Opened int `json:"opened"`
+		} `json:"counts"`
+	} `json:"statistics"`
+}
+
+func (n IssuesStatistics) String() string {
+	return Stringify(n)
+}
+
+// GetIssuesStatisticsOptions represents the available GetIssuesStatistics() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issues_statistics.html#get-issues-statistics
+type GetIssuesStatisticsOptions struct {
+	Labels           *Labels    `url:"labels,omitempty" json:"labels,omitempty"`
+	Milestone        *Milestone `url:"milestone,omitempty" json:"milestone,omitempty"`
+	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	AuthorUsername   *string    `url:"author_username,omitempty" json:"author_username,omitempty"`
+	AssigneeID       *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	AssigneeUsername []string   `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji  *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	IIDs             []int      `url:"iids,omitempty" json:"iids,omitempty"`
+	Search           *string    `url:"search,omitempty" json:"search,omitempty"`
+	In               *string    `url:"in,omitempty" json:"in,omitempty"`
+	CreatedAfter     *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore    *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter     *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore    *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Confidential     *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
+}
+
+// GetIssuesStatistics gets issues statistics on all issues the authenticated
+// user has access to.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issues_statistics.html#get-issues-statistics
+func (s *IssuesStatisticsService) GetIssuesStatistics(opt *GetIssuesStatisticsOptions, options ...RequestOptionFunc) (*IssuesStatistics, *Response, error) {
+	req, err := s.client.NewRequest("GET", "issues_statistics", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	is := new(IssuesStatistics)
+	resp, err := s.client.Do(req, is)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return is, resp, err
+}
+
+// GetGroupIssuesStatisticsOptions represents the available GetGroupIssuesStatistics()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issues_statistics.html#get-group-issues-statistics
+type GetGroupIssuesStatisticsOptions struct {
+	Labels           *Labels    `url:"labels,omitempty" json:"labels,omitempty"`
+	IIDs             []int      `url:"iids,omitempty" json:"iids,omitempty"`
+	Milestone        *Milestone `url:"milestone,omitempty" json:"milestone,omitempty"`
+	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	AuthorUsername   *string    `url:"author_username,omitempty" json:"author_username,omitempty"`
+	AssigneeID       *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	AssigneeUsername []string   `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji  *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	Search           *string    `url:"search,omitempty" json:"search,omitempty"`
+	CreatedAfter     *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore    *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter     *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore    *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Confidential     *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
+}
+
+// GetGroupIssuesStatistics gets issues count statistics for given group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issues_statistics.html#get-group-issues-statistics
+func (s *IssuesStatisticsService) GetGroupIssuesStatistics(gid interface{}, opt *GetGroupIssuesStatisticsOptions, options ...RequestOptionFunc) (*IssuesStatistics, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/issues_statistics", pathEscape(group))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	is := new(IssuesStatistics)
+	resp, err := s.client.Do(req, is)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return is, resp, err
+}
+
+// GetProjectIssuesStatisticsOptions represents the available
+// GetProjectIssuesStatistics() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issues_statistics.html#get-project-issues-statistics
+type GetProjectIssuesStatisticsOptions struct {
+	IIDs             []int      `url:"iids,omitempty" json:"iids,omitempty"`
+	Labels           *Labels    `url:"labels,omitempty" json:"labels,omitempty"`
+	Milestone        *Milestone `url:"milestone,omitempty" json:"milestone,omitempty"`
+	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	AuthorUsername   *string    `url:"author_username,omitempty" json:"author_username,omitempty"`
+	AssigneeID       *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	AssigneeUsername []string   `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji  *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	Search           *string    `url:"search,omitempty" json:"search,omitempty"`
+	CreatedAfter     *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore    *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter     *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore    *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Confidential     *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
+}
+
+// GetProjectIssuesStatistics gets issues count statistics for given project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issues_statistics.html#get-project-issues-statistics
+func (s *IssuesStatisticsService) GetProjectIssuesStatistics(pid interface{}, opt *GetProjectIssuesStatisticsOptions, options ...RequestOptionFunc) (*IssuesStatistics, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues_statistics", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	is := new(IssuesStatistics)
+	resp, err := s.client.Do(req, is)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return is, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/labels.go
+++ b/vendor/github.com/xanzy/go-gitlab/labels.go
@@ -73,7 +73,11 @@ func (l Label) String() string {
 // ListLabelsOptions represents the available ListLabels() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#list-labels
-type ListLabelsOptions ListOptions
+type ListLabelsOptions struct {
+	ListOptions
+	WithCounts            *bool `url:"with_counts,omitempty" json:"with_counts,omitempty"`
+	IncludeAncestorGroups *bool `url:"include_ancestor_groups,omitempty" json:"include_ancestor_groups,omitempty"`
+}
 
 // ListLabels gets all labels for given project.
 //
@@ -91,6 +95,34 @@ func (s *LabelsService) ListLabels(pid interface{}, opt *ListLabelsOptions, opti
 	}
 
 	var l []*Label
+	resp, err := s.client.Do(req, &l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, err
+}
+
+// GetLabel get a single label for a given project.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#get-a-single-project-label
+func (s *LabelsService) GetLabel(pid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Label, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	label, err := parseID(labelID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/labels/%s", pathEscape(project), label)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var l *Label
 	resp, err := s.client.Do(req, &l)
 	if err != nil {
 		return nil, resp, err
@@ -242,6 +274,29 @@ func (s *LabelsService) UnsubscribeFromLabel(pid interface{}, labelID interface{
 	u := fmt.Sprintf("projects/%s/labels/%s/unsubscribe", pathEscape(project), label)
 
 	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// PromoteLabel Promotes a project label to a group label.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/labels.html#promote-a-project-label-to-a-group-label
+func (s *LabelsService) PromoteLabel(pid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	label, err := parseID(labelID)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/labels/%s/promote", pathEscape(project), label)
+
+	req, err := s.client.NewRequest("PUT", u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/xanzy/go-gitlab/license.go
+++ b/vendor/github.com/xanzy/go-gitlab/license.go
@@ -48,9 +48,14 @@ type License struct {
 		Company string `json:"Company"`
 		Email   string `json:"Email"`
 	} `json:"licensee"`
+	// Add on codes that may occur in legacy licenses that don't have a plan yet.
+	// https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/app/models/license.rb
 	AddOns struct {
-		GitLabFileLocks   int `json:"GitLab_FileLocks"`
 		GitLabAuditorUser int `json:"GitLab_Auditor_User"`
+		GitLabDeployBoard int `json:"GitLab_DeployBoard"`
+		GitLabFileLocks   int `json:"GitLab_FileLocks"`
+		GitLabGeo         int `json:"GitLab_Geo"`
+		GitLabServiceDesk int `json:"GitLab_ServiceDesk"`
 	} `json:"add_ons"`
 }
 

--- a/vendor/github.com/xanzy/go-gitlab/project_mirror.go
+++ b/vendor/github.com/xanzy/go-gitlab/project_mirror.go
@@ -1,0 +1,145 @@
+//
+// Copyright 2017, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"time"
+)
+
+// ProjectMirrorService handles communication with the project mirror
+// related methods of the GitLab API.
+//
+// GitLAb API docs: https://docs.gitlab.com/ce/api/remote_mirrors.html
+type ProjectMirrorService struct {
+	client *Client
+}
+
+// ProjectMirror represents a project mirror configuration.
+//
+// GitLAb API docs: https://docs.gitlab.com/ce/api/remote_mirrors.html
+type ProjectMirror struct {
+	Enabled                bool       `json:"enabled"`
+	ID                     int        `json:"id"`
+	LastError              string     `json:"last_error"`
+	LastSuccessfulUpdateAt *time.Time `json:"last_successful_update_at"`
+	LastUpdateAt           *time.Time `json:"last_update_at"`
+	LastUpdateStartedAt    *time.Time `json:"last_update_started_at"`
+	OnlyProtectedBranches  bool       `json:"only_protected_branches"`
+	KeepDivergentRefs      bool       `json:"keep_divergent_refs"`
+	UpdateStatus           string     `json:"update_status"`
+	URL                    string     `json:"url"`
+}
+
+// ListProjectMirror gets a list of mirrors configured on the project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/remote_mirrors.html#list-a-projects-remote-mirrors
+func (s *ProjectMirrorService) ListProjectMirror(pid interface{}, options ...RequestOptionFunc) ([]*ProjectMirror, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/remote_mirrors", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var pm []*ProjectMirror
+	resp, err := s.client.Do(req, &pm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pm, resp, err
+
+}
+
+// AddProjectMirrorOptions contains the properties requires to create
+// a new project mirror.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/remote_mirrors.html#create-a-remote-mirror
+type AddProjectMirrorOptions struct {
+	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
+	Enabled               *bool   `url:"enabled,omitempty" json:"enabled,omitempty"`
+	OnlyProtectedBranches *bool   `url:"only_protected_branches,omitempty" json:"only_protected_branches,omitempty"`
+	KeepDivergentRefs     *bool   `url:"keep_divergent_refs,omitempty" json:"keep_divergent_refs,omitempty"`
+}
+
+// AddProjectMirror creates a new mirror on the project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/remote_mirrors.html#create-a-remote-mirror
+func (s *ProjectMirrorService) AddProjectMirror(pid interface{}, opt *AddProjectMirrorOptions, options ...RequestOptionFunc) (*ProjectMirror, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/remote_mirrors", pathEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pm := new(ProjectMirror)
+	resp, err := s.client.Do(req, pm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pm, resp, err
+}
+
+// EditProjectMirrorOptions contains the properties requires to edit
+// an existing project mirror.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/remote_mirrors.html#update-a-remote-mirrors-attributes
+type EditProjectMirrorOptions struct {
+	Enabled               *bool `url:"enabled,omitempty" json:"enabled,omitempty"`
+	OnlyProtectedBranches *bool `url:"only_protected_branches,omitempty" json:"only_protected_branches,omitempty"`
+	KeepDivergentRefs     *bool `url:"keep_divergent_refs,omitempty" json:"keep_divergent_refs,omitempty"`
+}
+
+// EditProjectMirror updates a project team member to a specified access level..
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/remote_mirrors.html#update-a-remote-mirrors-attributes
+func (s *ProjectMirrorService) EditProjectMirror(pid interface{}, mirror int, opt *EditProjectMirrorOptions, options ...RequestOptionFunc) (*ProjectMirror, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/remote_mirrors/%d", pathEscape(project), mirror)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pm := new(ProjectMirror)
+	resp, err := s.client.Do(req, pm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pm, resp, err
+}

--- a/vendor/github.com/xanzy/go-gitlab/project_snippets.go
+++ b/vendor/github.com/xanzy/go-gitlab/project_snippets.go
@@ -91,7 +91,7 @@ type CreateProjectSnippetOptions struct {
 	Title       *string          `url:"title,omitempty" json:"title,omitempty"`
 	FileName    *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
 	Description *string          `url:"description,omitempty" json:"description,omitempty"`
-	Code        *string          `url:"code,omitempty" json:"code,omitempty"`
+	Content     *string          `url:"content,omitempty" json:"content,omitempty"`
 	Visibility  *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
 }
 
@@ -129,7 +129,7 @@ type UpdateProjectSnippetOptions struct {
 	Title       *string          `url:"title,omitempty" json:"title,omitempty"`
 	FileName    *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
 	Description *string          `url:"description,omitempty" json:"description,omitempty"`
-	Code        *string          `url:"code,omitempty" json:"code,omitempty"`
+	Content     *string          `url:"content,omitempty" json:"content,omitempty"`
 	Visibility  *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
 }
 

--- a/vendor/github.com/xanzy/go-gitlab/projects.go
+++ b/vendor/github.com/xanzy/go-gitlab/projects.go
@@ -38,57 +38,68 @@ type ProjectsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html
 type Project struct {
-	ID                                        int               `json:"id"`
-	Description                               string            `json:"description"`
-	DefaultBranch                             string            `json:"default_branch"`
-	Public                                    bool              `json:"public"`
-	Visibility                                VisibilityValue   `json:"visibility"`
-	SSHURLToRepo                              string            `json:"ssh_url_to_repo"`
-	HTTPURLToRepo                             string            `json:"http_url_to_repo"`
-	WebURL                                    string            `json:"web_url"`
-	ReadmeURL                                 string            `json:"readme_url"`
-	TagList                                   []string          `json:"tag_list"`
-	Owner                                     *User             `json:"owner"`
-	Name                                      string            `json:"name"`
-	NameWithNamespace                         string            `json:"name_with_namespace"`
-	Path                                      string            `json:"path"`
-	PathWithNamespace                         string            `json:"path_with_namespace"`
-	IssuesEnabled                             bool              `json:"issues_enabled"`
-	OpenIssuesCount                           int               `json:"open_issues_count"`
-	MergeRequestsEnabled                      bool              `json:"merge_requests_enabled"`
-	ApprovalsBeforeMerge                      int               `json:"approvals_before_merge"`
-	JobsEnabled                               bool              `json:"jobs_enabled"`
-	WikiEnabled                               bool              `json:"wiki_enabled"`
-	SnippetsEnabled                           bool              `json:"snippets_enabled"`
-	ResolveOutdatedDiffDiscussions            bool              `json:"resolve_outdated_diff_discussions"`
-	ContainerRegistryEnabled                  bool              `json:"container_registry_enabled"`
-	CreatedAt                                 *time.Time        `json:"created_at,omitempty"`
-	LastActivityAt                            *time.Time        `json:"last_activity_at,omitempty"`
-	CreatorID                                 int               `json:"creator_id"`
-	Namespace                                 *ProjectNamespace `json:"namespace"`
-	ImportStatus                              string            `json:"import_status"`
-	ImportError                               string            `json:"import_error"`
-	Permissions                               *Permissions      `json:"permissions"`
-	MarkedForDeletionAt                       *ISOTime          `json:"marked_for_deletion_at"`
-	Archived                                  bool              `json:"archived"`
-	AvatarURL                                 string            `json:"avatar_url"`
-	SharedRunnersEnabled                      bool              `json:"shared_runners_enabled"`
-	ForksCount                                int               `json:"forks_count"`
-	StarCount                                 int               `json:"star_count"`
-	RunnersToken                              string            `json:"runners_token"`
-	PublicBuilds                              bool              `json:"public_builds"`
-	OnlyAllowMergeIfPipelineSucceeds          bool              `json:"only_allow_merge_if_pipeline_succeeds"`
-	OnlyAllowMergeIfAllDiscussionsAreResolved bool              `json:"only_allow_merge_if_all_discussions_are_resolved"`
-	RemoveSourceBranchAfterMerge              bool              `json:"remove_source_branch_after_merge"`
-	LFSEnabled                                bool              `json:"lfs_enabled"`
-	RequestAccessEnabled                      bool              `json:"request_access_enabled"`
-	MergeMethod                               MergeMethodValue  `json:"merge_method"`
-	ForkedFromProject                         *ForkParent       `json:"forked_from_project"`
-	Mirror                                    bool              `json:"mirror"`
-	MirrorUserID                              int               `json:"mirror_user_id"`
-	MirrorTriggerBuilds                       bool              `json:"mirror_trigger_builds"`
-	OnlyMirrorProtectedBranches               bool              `json:"only_mirror_protected_branches"`
-	MirrorOverwritesDivergedBranches          bool              `json:"mirror_overwrites_diverged_branches"`
+	ID                                        int                `json:"id"`
+	Description                               string             `json:"description"`
+	DefaultBranch                             string             `json:"default_branch"`
+	Public                                    bool               `json:"public"`
+	Visibility                                VisibilityValue    `json:"visibility"`
+	SSHURLToRepo                              string             `json:"ssh_url_to_repo"`
+	HTTPURLToRepo                             string             `json:"http_url_to_repo"`
+	WebURL                                    string             `json:"web_url"`
+	ReadmeURL                                 string             `json:"readme_url"`
+	TagList                                   []string           `json:"tag_list"`
+	Owner                                     *User              `json:"owner"`
+	Name                                      string             `json:"name"`
+	NameWithNamespace                         string             `json:"name_with_namespace"`
+	Path                                      string             `json:"path"`
+	PathWithNamespace                         string             `json:"path_with_namespace"`
+	IssuesEnabled                             bool               `json:"issues_enabled"`
+	OpenIssuesCount                           int                `json:"open_issues_count"`
+	MergeRequestsEnabled                      bool               `json:"merge_requests_enabled"`
+	ApprovalsBeforeMerge                      int                `json:"approvals_before_merge"`
+	JobsEnabled                               bool               `json:"jobs_enabled"`
+	WikiEnabled                               bool               `json:"wiki_enabled"`
+	SnippetsEnabled                           bool               `json:"snippets_enabled"`
+	ResolveOutdatedDiffDiscussions            bool               `json:"resolve_outdated_diff_discussions"`
+	ContainerRegistryEnabled                  bool               `json:"container_registry_enabled"`
+	CreatedAt                                 *time.Time         `json:"created_at,omitempty"`
+	LastActivityAt                            *time.Time         `json:"last_activity_at,omitempty"`
+	CreatorID                                 int                `json:"creator_id"`
+	Namespace                                 *ProjectNamespace  `json:"namespace"`
+	ImportStatus                              string             `json:"import_status"`
+	ImportError                               string             `json:"import_error"`
+	Permissions                               *Permissions       `json:"permissions"`
+	MarkedForDeletionAt                       *ISOTime           `json:"marked_for_deletion_at"`
+	Archived                                  bool               `json:"archived"`
+	AvatarURL                                 string             `json:"avatar_url"`
+	SharedRunnersEnabled                      bool               `json:"shared_runners_enabled"`
+	ForksCount                                int                `json:"forks_count"`
+	StarCount                                 int                `json:"star_count"`
+	RunnersToken                              string             `json:"runners_token"`
+	PublicBuilds                              bool               `json:"public_builds"`
+	OnlyAllowMergeIfPipelineSucceeds          bool               `json:"only_allow_merge_if_pipeline_succeeds"`
+	OnlyAllowMergeIfAllDiscussionsAreResolved bool               `json:"only_allow_merge_if_all_discussions_are_resolved"`
+	RemoveSourceBranchAfterMerge              bool               `json:"remove_source_branch_after_merge"`
+	LFSEnabled                                bool               `json:"lfs_enabled"`
+	RequestAccessEnabled                      bool               `json:"request_access_enabled"`
+	MergeMethod                               MergeMethodValue   `json:"merge_method"`
+	ForkedFromProject                         *ForkParent        `json:"forked_from_project"`
+	Mirror                                    bool               `json:"mirror"`
+	MirrorUserID                              int                `json:"mirror_user_id"`
+	MirrorTriggerBuilds                       bool               `json:"mirror_trigger_builds"`
+	OnlyMirrorProtectedBranches               bool               `json:"only_mirror_protected_branches"`
+	MirrorOverwritesDivergedBranches          bool               `json:"mirror_overwrites_diverged_branches"`
+	ServiceDeskEnabled                        bool               `json:"service_desk_enabled"`
+	ServiceDeskAddress                        string             `json:"service_desk_address"`
+	IssuesAccessLevel                         AccessControlValue `json:"issues_access_level"`
+	RepositoryAccessLevel                     AccessControlValue `json:"repository_access_level"`
+	MergeRequestsAccessLevel                  AccessControlValue `json:"merge_requests_access_level"`
+	ForkingAccessLevel                        AccessControlValue `json:"forking_access_level"`
+	WikiAccessLevel                           AccessControlValue `json:"wiki_access_level"`
+	BuildsAccessLevel                         AccessControlValue `json:"builds_access_level"`
+	SnippetsAccessLevel                       AccessControlValue `json:"snippets_access_level"`
+	PagesAccessLevel                          AccessControlValue `json:"pages_access_level"`
+	AutocloseReferencedIssues                 bool               `json:"autoclose_referenced_issues"`
 	SharedWithGroups                          []struct {
 		GroupID          int    `json:"group_id"`
 		GroupName        string `json:"group_name"`
@@ -458,7 +469,7 @@ type CreateProjectOptions struct {
 	Description                               *string             `url:"description,omitempty" json:"description,omitempty"`
 	IssuesAccessLevel                         *AccessControlValue `url:"issues_access_level,omitempty" json:"issues_access_level,omitempty"`
 	RepositoryAccessLevel                     *AccessControlValue `url:"repository_access_level,omitempty" json:"repository_access_level,omitempty"`
-	MergeRequestAccessLevel                   *AccessControlValue `url:"merge_request_access_level,omitempty" json:"merge_request_access_level,omitempty"`
+	MergeRequestsAccessLevel                  *AccessControlValue `url:"merge_requests_access_level,omitempty" json:"merge_requests_access_level,omitempty"`
 	ForkingAccessLevel                        *AccessControlValue `url:"forking_access_level,omitempty" json:"forking_access_level,omitempty"`
 	BuildsAccessLevel                         *AccessControlValue `url:"builds_access_level,omitempty" json:"builds_access_level,omitempty"`
 	WikiAccessLevel                           *AccessControlValue `url:"wiki_access_level,omitempty" json:"wiki_access_level,omitempty"`
@@ -495,6 +506,8 @@ type CreateProjectOptions struct {
 	UseCustomTemplate                         *bool               `url:"use_custom_template,omitempty" json:"use_custom_template,omitempty"`
 	GroupWithProjectTemplatesID               *int                `url:"group_with_project_templates_id,omitempty" json:"group_with_project_templates_id,omitempty"`
 	PackagesEnabled                           *bool               `url:"packages_enabled,omitempty" json:"packages_enabled,omitempty"`
+	ServiceDeskEnabled                        *bool               `url:"service_desk_enabled,omitempty" json:"service_desk_enabled,omitempty"`
+	AutocloseReferencedIssues                 *bool               `url:"autoclose_referenced_issues,omitempty" json:"autoclose_referenced_issues,omitempty"`
 
 	// Deprecated members
 	IssuesEnabled        *bool `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
@@ -561,7 +574,7 @@ type EditProjectOptions struct {
 	Description                               *string             `url:"description,omitempty" json:"description,omitempty"`
 	IssuesAccessLevel                         *AccessControlValue `url:"issues_access_level,omitempty" json:"issues_access_level,omitempty"`
 	RepositoryAccessLevel                     *AccessControlValue `url:"repository_access_level,omitempty" json:"repository_access_level,omitempty"`
-	MergeRequestAccessLevel                   *AccessControlValue `url:"merge_request_access_level,omitempty" json:"merge_request_access_level,omitempty"`
+	MergeRequestsAccessLevel                  *AccessControlValue `url:"merge_requests_access_level,omitempty" json:"merge_requests_access_level,omitempty"`
 	ForkingAccessLevel                        *AccessControlValue `url:"forking_access_level,omitempty" json:"forking_access_level,omitempty"`
 	BuildsAccessLevel                         *AccessControlValue `url:"builds_access_level,omitempty" json:"builds_access_level,omitempty"`
 	WikiAccessLevel                           *AccessControlValue `url:"wiki_access_level,omitempty" json:"wiki_access_level,omitempty"`
@@ -597,6 +610,8 @@ type EditProjectOptions struct {
 	OnlyMirrorProtectedBranches               *bool               `url:"only_mirror_protected_branches,omitempty" json:"only_mirror_protected_branches,omitempty"`
 	MirrorOverwritesDivergedBranches          *bool               `url:"mirror_overwrites_diverged_branches,omitempty" json:"mirror_overwrites_diverged_branches,omitempty"`
 	PackagesEnabled                           *bool               `url:"packages_enabled,omitempty" json:"packages_enabled,omitempty"`
+	ServiceDeskEnabled                        *bool               `url:"service_desk_enabled,omitempty" json:"service_desk_enabled,omitempty"`
+	AutocloseReferencedIssues                 *bool               `url:"autoclose_referenced_issues,omitempty" json:"autoclose_referenced_issues,omitempty"`
 
 	// Deprecated members
 	IssuesEnabled        *bool `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
@@ -857,6 +872,7 @@ type ProjectHook struct {
 	ConfidentialNoteEvents   bool       `json:"confidential_note_events"`
 	ProjectID                int        `json:"project_id"`
 	PushEvents               bool       `json:"push_events"`
+	PushEventsBranchFilter   string     `json:"push_events_branch_filter"`
 	IssuesEvents             bool       `json:"issues_events"`
 	ConfidentialIssuesEvents bool       `json:"confidential_issues_events"`
 	MergeRequestsEvents      bool       `json:"merge_requests_events"`
@@ -932,6 +948,7 @@ type AddProjectHookOptions struct {
 	URL                      *string `url:"url,omitempty" json:"url,omitempty"`
 	ConfidentialNoteEvents   *bool   `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
 	PushEvents               *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
+	PushEventsBranchFilter   *string `url:"push_events_branch_filter,omitempty" json:"push_events_branch_filter,omitempty"`
 	IssuesEvents             *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
 	ConfidentialIssuesEvents *bool   `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
 	MergeRequestsEvents      *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
@@ -977,6 +994,7 @@ type EditProjectHookOptions struct {
 	URL                      *string `url:"url,omitempty" json:"url,omitempty"`
 	ConfidentialNoteEvents   *bool   `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
 	PushEvents               *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
+	PushEventsBranchFilter   *string `url:"push_events_branch_filter,omitempty" json:"push_events_branch_filter,omitempty"`
 	IssuesEvents             *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
 	ConfidentialIssuesEvents *bool   `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
 	MergeRequestsEvents      *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`

--- a/vendor/github.com/xanzy/go-gitlab/runners.go
+++ b/vendor/github.com/xanzy/go-gitlab/runners.go
@@ -336,6 +336,44 @@ func (s *RunnersService) DisableProjectRunner(pid interface{}, runner int, optio
 	return s.client.Do(req, nil)
 }
 
+// ListGroupsRunnersOptions represents the available ListGroupsRunners() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/runners.html#list-groups-runners
+type ListGroupsRunnersOptions struct {
+	ListOptions
+	Type    *string  `url:"type,omitempty" json:"type,omitempty"`
+	Status  *string  `url:"status,omitempty" json:"status,omitempty"`
+	TagList []string `url:"tag_list,comma,omitempty" json:"tag_list,omitempty"`
+}
+
+// ListGroupsRunners lists all runners (specific and shared) available in the
+// group as well it’s ancestor groups. Shared runners are listed if at least one
+// shared runner is defined.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/runners.html#list-groups-runners
+func (s *RunnersService) ListGroupsRunners(gid interface{}, opt *ListGroupsRunnersOptions, options ...RequestOptionFunc) ([]*Runner, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/runners", pathEscape(group))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rs []*Runner
+	resp, err := s.client.Do(req, &rs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rs, resp, err
+}
+
 // RegisterNewRunnerOptions represents the available RegisterNewRunner()
 // options.
 //

--- a/vendor/github.com/xanzy/go-gitlab/services.go
+++ b/vendor/github.com/xanzy/go-gitlab/services.go
@@ -665,7 +665,17 @@ type MicrosoftTeamsService struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#microsoft-teams
 type MicrosoftTeamsServiceProperties struct {
-	WebHook string `json:"webhook"`
+	WebHook                   string    `json:"webhook"`
+	NotifyOnlyBrokenPipelines BoolValue `json:"notify_only_broken_pipelines"`
+	BranchesToBeNotified      string    `json:"branches_to_be_notified"`
+	IssuesEvents              BoolValue `json:"issues_events"`
+	ConfidentialIssuesEvents  BoolValue `json:"confidential_issues_events"`
+	MergeRequestsEvents       BoolValue `json:"merge_requests_events"`
+	TagPushEvents             BoolValue `json:"tag_push_events"`
+	NoteEvents                BoolValue `json:"note_events"`
+	ConfidentialNoteEvents    BoolValue `json:"confidential_note_events"`
+	PipelineEvents            BoolValue `json:"pipeline_events"`
+	WikiPageEvents            BoolValue `json:"wiki_page_events"`
 }
 
 // GetMicrosoftTeamsService gets MicrosoftTeams service settings for a project.
@@ -699,7 +709,18 @@ func (s *ServicesService) GetMicrosoftTeamsService(pid interface{}, options ...R
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#create-edit-microsoft-teams-service
 type SetMicrosoftTeamsServiceOptions struct {
-	WebHook *string `url:"webhook,omitempty" json:"webhook,omitempty"`
+	WebHook                   *string `url:"webhook,omitempty" json:"webhook,omitempty"`
+	NotifyOnlyBrokenPipelines *bool   `url:"notify_only_broken_pipelines" json:"notify_only_broken_pipelines"`
+	BranchesToBeNotified      *string `url:"branches_to_be_notified,omitempty" json:"branches_to_be_notified,omitempty"`
+	PushEvents                *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
+	IssuesEvents              *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
+	ConfidentialIssuesEvents  *bool   `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
+	MergeRequestsEvents       *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
+	TagPushEvents             *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
+	NoteEvents                *bool   `url:"note_events,omitempty" json:"note_events,omitempty"`
+	ConfidentialNoteEvents    *bool   `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
+	PipelineEvents            *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
+	WikiPageEvents            *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
 }
 
 // SetMicrosoftTeamsService sets Microsoft Teams service for a project
@@ -756,6 +777,7 @@ type PipelinesEmailProperties struct {
 	Recipients                string    `json:"recipients,omitempty"`
 	NotifyOnlyBrokenPipelines BoolValue `json:"notify_only_broken_pipelines,omitempty"`
 	NotifyOnlyDefaultBranch   BoolValue `json:"notify_only_default_branch,omitempty"`
+	BranchesToBeNotified      string    `json:"branches_to_be_notified,omitempty"`
 }
 
 // GetPipelinesEmailService gets Pipelines Email service settings for a project.

--- a/vendor/github.com/xanzy/go-gitlab/users.go
+++ b/vendor/github.com/xanzy/go-gitlab/users.go
@@ -112,6 +112,7 @@ type ListUsersOptions struct {
 	CreatedAfter         *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	OrderBy              *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort                 *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	External             *bool      `url:"external,omitempty" json:"external,omitempty"`
 	WithCustomAttributes *bool      `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,7 +228,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/xanzy/go-gitlab v0.32.1
+# github.com/xanzy/go-gitlab v0.34.1
 ## explicit
 github.com/xanzy/go-gitlab
 # github.com/zclconf/go-cty v1.2.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,9 +228,9 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/xanzy/go-gitlab v0.34.1
+# github.com/xanzy/go-gitlab v0.32.1
 ## explicit
-github.com/xanzy/go-gitlab v0.34.1
+github.com/xanzy/go-gitlab
 # github.com/zclconf/go-cty v1.2.1
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/convert

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,9 +228,9 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/xanzy/go-gitlab v0.32.1
+# github.com/xanzy/go-gitlab v0.34.1
 ## explicit
-github.com/xanzy/go-gitlab
+github.com/xanzy/go-gitlab v0.34.1
 # github.com/zclconf/go-cty v1.2.1
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/convert


### PR DESCRIPTION
Bump go-gitlab to v.0.34.1 

Needed to fix nested struct format in `gitlab/resource_gitlab_label.go`

Was failing with this error: 
gitlab/resource_gitlab_label.go:72:81: cannot use promoted field ListOptions.Page in struct literal of type gitlab.ListLabelsOptions
gitlab/resource_gitlab_label_test.go:106:80: cannot use promoted field ListOptions.PerPage in struct literal of type gitlab.ListLabelsOptions

because we weren't accessing the nested struct correctly.